### PR TITLE
fix(cierre | ventas): fix de duplicacion de periodos

### DIFF
--- a/src/app/ventas/page.tsx
+++ b/src/app/ventas/page.tsx
@@ -62,11 +62,16 @@ const Ventas = () => {
   const [noPeriodFound, setNoPeriodFound] = useState(false);
   const [noLocalActual, setNoLocalActual] = useState(false);
   const [statsExpanded, setStatsExpanded] = useState(false);
+  const [isProcessingPeriod, setIsProcessingPeriod] = useState(false);
   const { ConfirmDialogComponent, confirmDialog } = useConfirmDialog();
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
   const [selectedVenta, setSelectedVenta] = useState<IVenta | null>(null);
 
   const handleCreateFirstPeriod = async () => {
+    // Evitar múltiples clics mientras se procesa
+    if (isProcessingPeriod) return;
+    
+    setIsProcessingPeriod(true);
     try {
       setIsDataLoading(true);
       const tiendaId = user.localActual.id;
@@ -76,6 +81,8 @@ const Ventas = () => {
     } catch (error) {
       console.log(error);
       showMessage("Error al crear el primer período", "error");
+    } finally {
+      setIsProcessingPeriod(false);
     }
   };
 
@@ -241,9 +248,9 @@ const Ventas = () => {
           color="primary"
           size="large"
           onClick={handleCreateFirstPeriod}
-          disabled={isDataLoading}
+          disabled={isDataLoading || isProcessingPeriod}
         >
-          Crear Primer Período
+          {isProcessingPeriod ? "Creando período..." : "Crear Primer Período"}
         </Button>
       </PageContainer>
     );

--- a/src/components/tablaProductosCierre/intex.tsx
+++ b/src/components/tablaProductosCierre/intex.tsx
@@ -79,6 +79,7 @@ interface IProps {
   handleCerrarCaja?: () => Promise<void>;
   hideTotales?: boolean;
   showOnlyCants?: boolean;
+  isProcessing?: boolean;
 }
 
 export const TablaProductosCierre: FC<IProps> = ({
@@ -87,6 +88,7 @@ export const TablaProductosCierre: FC<IProps> = ({
   handleCerrarCaja,
   hideTotales,
   showOnlyCants,
+  isProcessing = false,
 }) => {
   const { user } = useAppContext();
   const { showMessage } = useMessageContext();
@@ -482,14 +484,14 @@ export const TablaProductosCierre: FC<IProps> = ({
               <Button
                 variant="contained"
                 onClick={handleCierre}
-                disabled={disableCierreBtn}
+                disabled={disableCierreBtn || isProcessing}
                 size="large"
                 sx={{
                   minWidth: '140px',
                   height: '48px'
                 }}
               >
-                Cerrar caja
+                {isProcessing ? "Procesando..." : "Cerrar caja"}
               </Button>
             </Box>
           )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Cambia la creación de períodos a una transacción con locking y SQL raw, lo que puede afectar concurrencia/comportamiento en BD si el dialecto o aislamiento no coinciden. El resto son cambios de UX para evitar doble envío, de bajo impacto.
> 
> **Overview**
> Evita la **duplicación de períodos** al abrir un cierre: el endpoint `PUT /api/cierre/[tiendaId]/open` ahora crea el período dentro de una `transaction` y bloquea la lectura del último registro con `SELECT ... FOR UPDATE`, devolviendo `400` cuando ya hay un período abierto.
> 
> En la UI de `cierre` y `ventas` se agrega estado de *processing* para impedir múltiples clics al crear/abrir períodos o cerrar caja, deshabilitando botones y mostrando textos de progreso; `TablaProductosCierre` recibe `isProcessing` para deshabilitar el botón de cierre mientras corre la operación.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d1cf4a8034d9b3dde6f186d39bcda372f7f9eb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->