### PR TITLE
Refactor payment modal and enhance currency handling

### DIFF
--- a/src/app/pos/components/PaymentModal.tsx
+++ b/src/app/pos/components/PaymentModal.tsx
@@ -17,7 +17,6 @@ import {
   Chip,
   Menu,
   IconButton,
-  Link,
 } from "@mui/material";
 import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
@@ -655,6 +654,24 @@ const PaymentModal: FC<IProps> = ({
                           <AttachMoneyIcon />
                         </InputAdornment>
                       }
+                      endAdornment={
+                        admiteTransfer ? (
+                          <InputAdornment position="end">
+                            <IconButton
+                              edge="end"
+                              size="small"
+                              onClick={() => toggleTransfer(moneda)}
+                              title={
+                                (showTransfer[moneda] ?? false)
+                                  ? "Ocultar transferencia"
+                                  : "Mostrar transferencia"
+                              }
+                            >
+                              <CreditCardIcon fontSize="small" />
+                            </IconButton>
+                          </InputAdornment>
+                        ) : undefined
+                      }
                       label="Efectivo"
                       value={pago.cash || ""}
                       type="number"
@@ -794,120 +811,90 @@ const PaymentModal: FC<IProps> = ({
                 </>
               )}
 
-              {/* Transferencia (Toggle) */}
+              {/* Transferencia (Collapse bajo Efectivo) */}
               {admiteTransfer && (
-                <>
-                  <Link
-                    component="button"
-                    type="button"
-                    variant="body2"
-                    onClick={() => toggleTransfer(moneda)}
-                    sx={{
-                      mt: admiteEfectivo ? 1.5 : 0.5,
-                      mb: 1,
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 0.5,
-                      textTransform: "none",
-                      color: "text.secondary",
-                      "&:hover": {
-                        color: "primary.main",
-                      },
-                    }}
-                  >
-                    <CreditCardIcon sx={{ fontSize: "1.1rem" }} />
-                    Transferencia
-                    {(showTransfer[moneda] ?? false) ? (
-                      <ExpandLessIcon sx={{ fontSize: "1.1rem" }} />
-                    ) : (
-                      <ExpandMoreIcon sx={{ fontSize: "1.1rem" }} />
-                    )}
-                  </Link>
-
-                  <Collapse in={showTransfer[moneda] ?? false}>
-                    <Box sx={{ pl: 1 }}>
-                      <FormControl fullWidth sx={{ mt: 1 }}>
-                        <InputLabel>Transferencia</InputLabel>
-                        <OutlinedInput
-                          startAdornment={
-                            <InputAdornment position="start">
-                              <CreditCardIcon />
-                            </InputAdornment>
-                          }
-                          label="Transferencia"
-                          value={pago.transfer || ""}
-                          type={"number"}
-                          onMouseDown={(e) => {
-                            if (e.button !== 0) return;
-                            const inp = (
-                              e.currentTarget as HTMLElement
-                            ).querySelector("input");
-                            if (inp) setTimeout(() => inp.select(), 0);
-                          }}
-                          onChange={(e) => {
-                            if (isBase) {
-                              const v = e.target.value;
-                              if (moneyRegex.test(v)) {
-                                const newTransfer = Number(v);
-                                const newCash = parseFloat(
-                                  Math.max(
-                                    0,
-                                    pago.cash + pago.transfer - newTransfer,
-                                  ).toFixed(2),
-                                );
-                                updatePago(moneda, {
-                                  transfer: newTransfer,
-                                  cash: newCash,
-                                });
-                              } else if (v === "") {
-                                const total = parseFloat(
-                                  (pago.cash + pago.transfer).toFixed(2),
-                                );
-                                updatePago(moneda, {
-                                  transfer: 0,
-                                  cash: total,
-                                });
-                              }
-                            } else {
-                              const newTransfer =
-                                parseFloat(e.target.value) || 0;
-                              const newCash = Math.max(
-                                0,
-                                pago.cash + pago.transfer - newTransfer,
+                <Collapse in={showTransfer[moneda] ?? false}>
+                  <Box sx={{ mt: 1 }}>
+                    <FormControl fullWidth>
+                      <InputLabel>Transferencia</InputLabel>
+                      <OutlinedInput
+                        startAdornment={
+                          <InputAdornment position="start">
+                            <CreditCardIcon />
+                          </InputAdornment>
+                        }
+                        label="Transferencia"
+                        value={pago.transfer || ""}
+                        type={"number"}
+                        onMouseDown={(e) => {
+                          if (e.button !== 0) return;
+                          const inp = (
+                            e.currentTarget as HTMLElement
+                          ).querySelector("input");
+                          if (inp) setTimeout(() => inp.select(), 0);
+                        }}
+                        onChange={(e) => {
+                          if (isBase) {
+                            const v = e.target.value;
+                            if (moneyRegex.test(v)) {
+                              const newTransfer = Number(v);
+                              const newCash = parseFloat(
+                                Math.max(
+                                  0,
+                                  pago.cash + pago.transfer - newTransfer,
+                                ).toFixed(2),
                               );
                               updatePago(moneda, {
                                 transfer: newTransfer,
                                 cash: newCash,
                               });
-                            }
-                          }}
-                          inputProps={{ inputMode: "decimal" }}
-                        />
-                      </FormControl>
-
-                      {/* Transfer destination */}
-                      {pago.transfer > 0 && transferDestinations.length > 0 && (
-                        <FormControl fullWidth margin="normal">
-                          <InputLabel>Destino</InputLabel>
-                          <Select
-                            value={pago.transferDestId}
-                            onChange={(e) =>
+                            } else if (v === "") {
+                              const total = parseFloat(
+                                (pago.cash + pago.transfer).toFixed(2),
+                              );
                               updatePago(moneda, {
-                                transferDestId: e.target.value,
-                              })
+                                transfer: 0,
+                                cash: total,
+                              });
                             }
-                          >
-                            {transferDestinations.map((d) => (
-                              <MenuItem key={d.id} value={d.id}>
-                                {d.nombre}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      )}
-                    </Box>
-                  </Collapse>
-                </>
+                          } else {
+                            const newTransfer = parseFloat(e.target.value) || 0;
+                            const newCash = Math.max(
+                              0,
+                              pago.cash + pago.transfer - newTransfer,
+                            );
+                            updatePago(moneda, {
+                              transfer: newTransfer,
+                              cash: newCash,
+                            });
+                          }
+                        }}
+                        inputProps={{ inputMode: "decimal" }}
+                      />
+                    </FormControl>
+
+                    {/* Transfer destination */}
+                    {pago.transfer > 0 && transferDestinations.length > 0 && (
+                      <FormControl fullWidth margin="normal">
+                        <InputLabel>Destino</InputLabel>
+                        <Select
+                          value={pago.transferDestId}
+                          onChange={(e) =>
+                            updatePago(moneda, {
+                              transferDestId: e.target.value,
+                            })
+                          }
+                        >
+                          {transferDestinations.map((d) => (
+                            <MenuItem key={d.id} value={d.id}>
+                              {d.nombre}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    )}
+                  </Box>
+                </Collapse>
               )}
 
               {/* Equivalente en base */}

--- a/src/app/pos/components/PaymentModal.tsx
+++ b/src/app/pos/components/PaymentModal.tsx
@@ -17,6 +17,7 @@ import {
   Chip,
   Menu,
   IconButton,
+  Link,
 } from "@mui/material";
 import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
 import CreditCardIcon from "@mui/icons-material/CreditCard";
@@ -120,6 +121,7 @@ const PaymentModal: FC<IProps> = ({
   const [payBreakdownKeys, setPayBreakdownKeys] = useState<
     Record<string, number>
   >({});
+  const [showTransfer, setShowTransfer] = useState<Record<string, boolean>>({});
   const [addPayAnchor, setAddPayAnchor] = useState<null | HTMLElement>(null);
 
   const monedas = Object.keys(pagosMap);
@@ -412,6 +414,10 @@ const PaymentModal: FC<IProps> = ({
     });
   };
 
+  const toggleTransfer = (moneda: string) => {
+    setShowTransfer((prev) => ({ ...prev, [moneda]: !prev[moneda] }));
+  };
+
   const handleToggleBreakdown = () => {
     if (!showBreakdown) {
       setBreakdownResetKey((k) => k + 1);
@@ -461,6 +467,7 @@ const PaymentModal: FC<IProps> = ({
     setBreakdownResetKey((k) => k + 1);
     setShowPayBreakdown({});
     setPayBreakdownKeys({});
+    setShowTransfer({});
     onClose();
   };
 
@@ -787,81 +794,120 @@ const PaymentModal: FC<IProps> = ({
                 </>
               )}
 
-              {/* Transferencia */}
+              {/* Transferencia (Toggle) */}
               {admiteTransfer && (
-                <FormControl fullWidth sx={{ mt: admiteEfectivo ? 2 : 0 }}>
-                  <InputLabel>Transferencia</InputLabel>
-                  <OutlinedInput
-                    startAdornment={
-                      <InputAdornment position="start">
-                        <CreditCardIcon />
-                      </InputAdornment>
-                    }
-                    label="Transferencia"
-                    value={pago.transfer || ""}
-                    type={"number"}
-                    onMouseDown={(e) => {
-                      if (e.button !== 0) return;
-                      const inp = (
-                        e.currentTarget as HTMLElement
-                      ).querySelector("input");
-                      if (inp) setTimeout(() => inp.select(), 0);
+                <>
+                  <Link
+                    component="button"
+                    type="button"
+                    variant="body2"
+                    onClick={() => toggleTransfer(moneda)}
+                    sx={{
+                      mt: admiteEfectivo ? 1.5 : 0.5,
+                      mb: 1,
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 0.5,
+                      textTransform: "none",
+                      color: "text.secondary",
+                      "&:hover": {
+                        color: "primary.main",
+                      },
                     }}
-                    onChange={(e) => {
-                      if (isBase) {
-                        const v = e.target.value;
-                        if (moneyRegex.test(v)) {
-                          const newTransfer = Number(v);
-                          const newCash = parseFloat(
-                            Math.max(
-                              0,
-                              pago.cash + pago.transfer - newTransfer,
-                            ).toFixed(2),
-                          );
-                          updatePago(moneda, {
-                            transfer: newTransfer,
-                            cash: newCash,
-                          });
-                        } else if (v === "") {
-                          const total = parseFloat(
-                            (pago.cash + pago.transfer).toFixed(2),
-                          );
-                          updatePago(moneda, { transfer: 0, cash: total });
-                        }
-                      } else {
-                        const newTransfer = parseFloat(e.target.value) || 0;
-                        const newCash = Math.max(
-                          0,
-                          pago.cash + pago.transfer - newTransfer,
-                        );
-                        updatePago(moneda, {
-                          transfer: newTransfer,
-                          cash: newCash,
-                        });
-                      }
-                    }}
-                    inputProps={{ inputMode: "decimal" }}
-                  />
-                </FormControl>
-              )}
-
-              {/* Transfer destination */}
-              {pago.transfer > 0 && transferDestinations.length > 0 && (
-                <FormControl fullWidth margin="normal">
-                  <InputLabel>Destino</InputLabel>
-                  <Select
-                    value={pago.transferDestId}
-                    onChange={(e) =>
-                      updatePago(moneda, { transferDestId: e.target.value })
-                    }
                   >
-                    {transferDestinations.map((d) => (
-                      <MenuItem key={d.id} value={d.id}>
-                        {d.nombre}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
+                    <CreditCardIcon sx={{ fontSize: "1.1rem" }} />
+                    Transferencia
+                    {(showTransfer[moneda] ?? false) ? (
+                      <ExpandLessIcon sx={{ fontSize: "1.1rem" }} />
+                    ) : (
+                      <ExpandMoreIcon sx={{ fontSize: "1.1rem" }} />
+                    )}
+                  </Link>
+
+                  <Collapse in={showTransfer[moneda] ?? false}>
+                    <Box sx={{ pl: 1 }}>
+                      <FormControl fullWidth sx={{ mt: 1 }}>
+                        <InputLabel>Transferencia</InputLabel>
+                        <OutlinedInput
+                          startAdornment={
+                            <InputAdornment position="start">
+                              <CreditCardIcon />
+                            </InputAdornment>
+                          }
+                          label="Transferencia"
+                          value={pago.transfer || ""}
+                          type={"number"}
+                          onMouseDown={(e) => {
+                            if (e.button !== 0) return;
+                            const inp = (
+                              e.currentTarget as HTMLElement
+                            ).querySelector("input");
+                            if (inp) setTimeout(() => inp.select(), 0);
+                          }}
+                          onChange={(e) => {
+                            if (isBase) {
+                              const v = e.target.value;
+                              if (moneyRegex.test(v)) {
+                                const newTransfer = Number(v);
+                                const newCash = parseFloat(
+                                  Math.max(
+                                    0,
+                                    pago.cash + pago.transfer - newTransfer,
+                                  ).toFixed(2),
+                                );
+                                updatePago(moneda, {
+                                  transfer: newTransfer,
+                                  cash: newCash,
+                                });
+                              } else if (v === "") {
+                                const total = parseFloat(
+                                  (pago.cash + pago.transfer).toFixed(2),
+                                );
+                                updatePago(moneda, {
+                                  transfer: 0,
+                                  cash: total,
+                                });
+                              }
+                            } else {
+                              const newTransfer =
+                                parseFloat(e.target.value) || 0;
+                              const newCash = Math.max(
+                                0,
+                                pago.cash + pago.transfer - newTransfer,
+                              );
+                              updatePago(moneda, {
+                                transfer: newTransfer,
+                                cash: newCash,
+                              });
+                            }
+                          }}
+                          inputProps={{ inputMode: "decimal" }}
+                        />
+                      </FormControl>
+
+                      {/* Transfer destination */}
+                      {pago.transfer > 0 && transferDestinations.length > 0 && (
+                        <FormControl fullWidth margin="normal">
+                          <InputLabel>Destino</InputLabel>
+                          <Select
+                            value={pago.transferDestId}
+                            onChange={(e) =>
+                              updatePago(moneda, {
+                                transferDestId: e.target.value,
+                              })
+                            }
+                          >
+                            {transferDestinations.map((d) => (
+                              <MenuItem key={d.id} value={d.id}>
+                                {d.nombre}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                      )}
+                    </Box>
+                  </Collapse>
+                </>
               )}
 
               {/* Equivalente en base */}


### PR DESCRIPTION
### Description
This pull request refactors the `PaymentModal` and introduces improvements:

- Replaced the "Transferencia" link with an `endAdornment` toggle for transfer fields, reducing UI clutter.
- Transfer fields are now collapsed by default with a toggleable state per currency, improving clarity.
- Added multi-currency (`multimoneda`) support to the `ventas` API and offline sync.
- Fixed floating-point noise in `calcularVuelto` to avoid phantom change due to accumulated precision errors.
- Removed unnecessary console.log debugging from `PaymentModal`.

### Checklist
- [ ] Tests added or updated.
- [ ] Documentation updated if necessary.
- [ ] Review from at least one team member.
- [ ] Changes tested in relevant environments.