### PR TITLE
fix: mejorar desglose de billetes en móvil del POS

### DIFF
--- a/src/app/pos/components/PaymentModal.tsx
+++ b/src/app/pos/components/PaymentModal.tsx
@@ -704,7 +704,7 @@ const PaymentModal: FC<IProps> = ({
                               border: "1px solid",
                               borderColor: "divider",
                               borderRadius: 1,
-                              px: 1.5,
+                              px: { xs: 0.5, sm: 1.5 },
                               pb: 1,
                             }}
                           >
@@ -752,7 +752,7 @@ const PaymentModal: FC<IProps> = ({
                                 border: "1px solid",
                                 borderColor: "divider",
                                 borderRadius: 1,
-                                px: 1.5,
+                                px: { xs: 0.5, sm: 1.5 },
                                 pb: 1,
                               }}
                             >

--- a/src/components/BillBreakdown/BillBreakdownDynamic.tsx
+++ b/src/components/BillBreakdown/BillBreakdownDynamic.tsx
@@ -50,7 +50,14 @@ const BillBreakdownDynamic: FC<Props> = ({
   const diff = targetAmount !== undefined ? total - targetAmount : null;
 
   return (
-    <Box sx={{ py: 1, maxWidth: 500, mx: "auto" }}>
+    <Box
+      sx={{
+        py: { xs: 0.5, sm: 1 },
+        width: "100%",
+        maxWidth: { xs: "100%", sm: 500 },
+        mx: "auto",
+      }}
+    >
       {denominations.map((d) => (
         <DenominationRow
           key={d}
@@ -67,7 +74,11 @@ const BillBreakdownDynamic: FC<Props> = ({
         mt={0.5}
         sx={{ borderTop: "1px solid", borderColor: "divider" }}
       >
-        <Typography variant="h5" fontWeight={600}>
+        <Typography
+          variant="h5"
+          fontWeight={600}
+          sx={{ fontSize: { xs: "1.1rem", sm: "1.5rem" } }}
+        >
           Total: {total.toFixed(2)}
         </Typography>
         {diff !== null && total > 0 && (
@@ -75,6 +86,7 @@ const BillBreakdownDynamic: FC<Props> = ({
             variant="body2"
             color={diff >= 0 ? "success.main" : "error.main"}
             fontWeight={500}
+            sx={{ fontSize: { xs: "0.75rem", sm: "0.875rem" } }}
           >
             {diff === 0
               ? "Exacto ✓"

--- a/src/components/BillBreakdown/BillBreakdownInput.tsx
+++ b/src/components/BillBreakdown/BillBreakdownInput.tsx
@@ -50,7 +50,14 @@ const BillBreakdownInput: FC<Props> = ({
   const total = denominations.reduce((acc, d) => acc + d * (counts[d] ?? 0), 0);
 
   return (
-    <Box sx={{ py: 1, maxWidth: 500, mx: "auto" }}>
+    <Box
+      sx={{
+        py: { xs: 0.5, sm: 1 },
+        width: "100%",
+        maxWidth: { xs: "100%", sm: 500 },
+        mx: "auto",
+      }}
+    >
       {denominations.map((d) => (
         <DenominationRow
           key={d}

--- a/src/components/BillBreakdown/BillBreakdownSummary.tsx
+++ b/src/components/BillBreakdown/BillBreakdownSummary.tsx
@@ -36,7 +36,11 @@ const BillBreakdownSummary: FC<Props> = ({ total, targetAmount, overLabel = 'Cam
         borderColor: 'divider',
       }}
     >
-      <Typography variant="h5" fontWeight={600}>
+      <Typography
+        variant="h5"
+        fontWeight={600}
+        sx={{ fontSize: { xs: '1.1rem', sm: '1.5rem' } }}
+      >
         Total: {formatCurrency(total)}
       </Typography>
       {status && (
@@ -47,7 +51,10 @@ const BillBreakdownSummary: FC<Props> = ({ total, targetAmount, overLabel = 'Cam
           sx={{
             color: status.color,
             borderColor: status.color,
+            fontSize: { xs: '0.7rem', sm: '0.8125rem' },
+            maxWidth: { xs: '50%', sm: 'none' },
             '& .MuiChip-icon': { color: status.color },
+            '& .MuiChip-label': { px: { xs: 0.75, sm: 1.5 } },
           }}
           variant="outlined"
         />

--- a/src/components/BillBreakdown/DenominationRow.tsx
+++ b/src/components/BillBreakdown/DenominationRow.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { Box, Typography } from "@mui/material";
+import { alpha, Box, Typography } from "@mui/material";
 import NumberSpinner from "@/components/NumberSpinner";
 
 interface Props {
@@ -8,27 +8,53 @@ interface Props {
   onChange: (count: number) => void;
 }
 
+const numericSx = {
+  fontVariantNumeric: "tabular-nums",
+  fontSize: { xs: "0.75rem", sm: "0.875rem" },
+} as const;
+
 const DenominationRow: FC<Props> = ({ denomination, count, onChange }) => {
   const subtotal = denomination * count;
+  const hasCount = count > 0;
 
   return (
     <Box
       sx={{
         display: "grid",
-        gridTemplateColumns: "56px 20px 1fr 20px 72px",
         alignItems: "center",
-        gap: 0.5,
-        py: 0.25,
+        gap: { xs: 0.25, sm: 0.5 },
+        py: { xs: 0.125, sm: 0.25 },
+        px: { xs: 0.5, sm: 0.75 },
+        borderRadius: 1,
+        transition: "background-color 0.15s ease",
+        gridTemplateColumns: {
+          xs: "40px 1fr minmax(52px, auto)",
+          sm: "48px 16px 1fr 16px 64px",
+        },
+        ...(hasCount && {
+          bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+        }),
       }}
     >
-      <Typography variant="body2" fontWeight={500} textAlign="right">
+      <Typography
+        variant="body2"
+        fontWeight={500}
+        textAlign="right"
+        sx={numericSx}
+      >
         {denomination}
       </Typography>
-      <Typography variant="body2" color="text.secondary" textAlign="center">
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        textAlign="center"
+        sx={{ display: { xs: "none", sm: "block" } }}
+      >
         ×
       </Typography>
       <Box sx={{ "& .MuiFormControl-root": { width: "100%" } }}>
         <NumberSpinner
+          compact
           size="small"
           value={count}
           min={0}
@@ -36,13 +62,22 @@ const DenominationRow: FC<Props> = ({ denomination, count, onChange }) => {
           onValueChange={(val) => onChange(val ?? 0)}
         />
       </Box>
-      <Typography variant="body2" color="text.secondary" textAlign="center">
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        textAlign="center"
+        sx={{ display: { xs: "none", sm: "block" } }}
+      >
         =
       </Typography>
       <Typography
         variant="body2"
-        color={subtotal > 0 ? "text.primary" : "text.disabled"}
-        fontWeight={subtotal > 0 ? 500 : 400}
+        color={hasCount ? "text.primary" : "text.disabled"}
+        fontWeight={hasCount ? 500 : 400}
+        textAlign="right"
+        noWrap
+        title={String(subtotal)}
+        sx={numericSx}
       >
         {subtotal}
       </Typography>

--- a/src/components/NumberSpinner.tsx
+++ b/src/components/NumberSpinner.tsx
@@ -14,11 +14,13 @@ export default function NumberSpinner({
   label,
   error,
   size = "medium",
+  compact = false,
   ...other
 }: BaseNumberField.Root.Props & {
   label?: React.ReactNode;
   size?: "small" | "medium";
   error?: boolean;
+  compact?: boolean;
 }) {
   let id = React.useId();
   if (idProp) {
@@ -38,7 +40,8 @@ export default function NumberSpinner({
           sx={{
             "& .MuiButton-root": {
               borderColor: "divider",
-              minWidth: 0,
+              minWidth: compact ? 28 : 0,
+              px: compact ? 0.5 : undefined,
               bgcolor: "action.hover",
               "&:not(.Mui-disabled)": {
                 color: "text.primary",
@@ -119,17 +122,23 @@ export default function NumberSpinner({
               slotProps={{
                 input: {
                   ...props,
-                  size:
-                    Math.max(
-                      (other.min?.toString() || "").length,
-                      state.inputValue.length || 1,
-                    ) + 1,
+                  size: Math.max(
+                    compact ? 4 : 1,
+                    (other.min?.toString() || "").length,
+                    state.inputValue.length || 1,
+                  ) + (compact ? 0 : 1),
                   sx: {
                     textAlign: "center",
+                    fontVariantNumeric: "tabular-nums",
+                    ...(compact && {
+                      minWidth: "4ch",
+                      fontSize: "0.8125rem",
+                      px: 0.5,
+                    }),
                   },
                 },
               }}
-              sx={{ pr: 0, borderRadius: 0, flex: 1 }}
+              sx={{ pr: 0, borderRadius: 0, flex: 1, minWidth: 0 }}
             />
           )}
         />


### PR DESCRIPTION
Adapta el layout del desglose por denominaciones para pantallas estrechas, con spinner compacto, resaltado azul en filas activas y menos padding.