### PR TITLE
feat(pos): escáner de pistola global con carrito y paneles abiertos

### DIFF
--- a/src/app/pos/components/ResumenDiaModal.tsx
+++ b/src/app/pos/components/ResumenDiaModal.tsx
@@ -262,6 +262,10 @@ const ResumenDiaModal: FC<IProps> = ({ open, onClose, tiendaId, cierreId }) => {
     <Dialog
       open={open}
       onClose={onClose}
+      disableEnforceFocus
+      disableAutoFocus
+      disableRestoreFocus
+      sx={{ zIndex: (theme) => theme.zIndex.drawer - 1 }}
       fullScreen={isMobile}
       maxWidth="lg"
       fullWidth

--- a/src/app/pos/components/SalesDrawer.tsx
+++ b/src/app/pos/components/SalesDrawer.tsx
@@ -379,7 +379,14 @@ export const SalesDrawer: FC<IProps> = ({
 
   return (
     <>
-      <Drawer anchor="bottom" open={showSales} onClose={handleClose}>
+      <Drawer
+        anchor="bottom"
+        open={showSales}
+        onClose={handleClose}
+        disableEnforceFocus
+        disableAutoFocus
+        disableRestoreFocus
+      >
         <Box
           sx={{
             width: "100vw",

--- a/src/app/pos/page.tsx
+++ b/src/app/pos/page.tsx
@@ -74,6 +74,8 @@ import ResumenDiaModal from "@/app/pos/components/ResumenDiaModal";
 import FlagIcon from "@mui/icons-material/Flag";
 import { AsociarCodigoDialog } from "@/app/pos/components/AsociarCodigoDialog";
 import { usePermisos } from "@/utils/permisos_front";
+import { useHardwareScanner } from "@/hooks/useHardwareScanner";
+import { processClientDataFromQR } from "@/utils/scanner";
 
 export default function POSInterface() {
   const [categories, setCategories] = useState<ICategory[]>([]);
@@ -174,6 +176,7 @@ export default function POSInterface() {
 
   // Referencia al scanner para poder reabrirlo
   const scannerRef = useRef<ProductProcessorDataRef>(null);
+  const hardwareScanHandlerRef = useRef<(data: IProcessedData) => void>(() => {});
 
   // Estado para prevenir múltiples sincronizaciones simultáneas (no para pagos)
   const [syncingIdentifiers, setSyncingIdentifiers] = useState<Set<string>>(
@@ -190,6 +193,22 @@ export default function POSInterface() {
 
   const [isCartPinned, setIsCartPinned] = useState(false);
 
+  useEffect(() => {
+    if (openCart && !isCartPinned) {
+      searchInputRef.current?.blur();
+      setIntentToSearch(false);
+      setShowSearchResults(false);
+    }
+  }, [openCart, isCartPinned]);
+
+  useEffect(() => {
+    if (showSyncView || resumenDiaOpen) {
+      searchInputRef.current?.blur();
+      setIntentToSearch(false);
+      setShowSearchResults(false);
+    }
+  }, [showSyncView, resumenDiaOpen]);
+
   const { verificarPermiso } = usePermisos();
   const puedeAsociarCodigo = verificarPermiso(
     "operaciones.pos-venta.asociar_codigo",
@@ -197,6 +216,7 @@ export default function POSInterface() {
 
   const [asociarCodigoOpen, setAsociarCodigoOpen] = useState(false);
   const [codigoNoEncontrado, setCodigoNoEncontrado] = useState<string>("");
+  const [cameraScannerOpen, setCameraScannerOpen] = useState(false);
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
@@ -215,6 +235,20 @@ export default function POSInterface() {
     if (isTablet) return "calc(100% - 40vw)";
     return "calc(100% - 35vw)";
   };
+
+  const scannerEnabled =
+    !editingCartId &&
+    !intentToSearch &&
+    !paymentDialog &&
+    !asociarCodigoOpen &&
+    !selectedProduct &&
+    !cameraScannerOpen;
+
+  useHardwareScanner({
+    enabled: scannerEnabled,
+    onScan: (raw) =>
+      hardwareScanHandlerRef.current(processClientDataFromQR(raw)),
+  });
 
   // Función para reabrir el scanner solo si el producto vino de escaneo de cámara
   const reopenScannerIfNeeded = () => {
@@ -286,6 +320,7 @@ export default function POSInterface() {
       }
     }
   };
+  hardwareScanHandlerRef.current = handleHardwareScan;
 
   // Crear un Map/índice al cargar productos una sola vez
   const productCodeMap = useMemo(() => {
@@ -1602,18 +1637,8 @@ export default function POSInterface() {
                 onProcessedData={(data: IProcessedData) => {
                   if (data?.code) handleProductScan(data.code);
                 }}
-                onHardwareScan={handleHardwareScan}
-                keepFocus={
-                  editingCartId
-                    ? false
-                    : !(
-                        intentToSearch ||
-                        paymentDialog ||
-                        showSyncView ||
-                        openSpeedDial ||
-                        resumenDiaOpen
-                      )
-                }
+                enableHardwareScanner={false}
+                onCameraOpenChange={setCameraScannerOpen}
               />
               {scannerError && (
                 <Alert
@@ -1723,14 +1748,17 @@ export default function POSInterface() {
       {isCartPinned && (
         <Box
           sx={{
+            position: "fixed",
+            right: 0,
+            top: { xs: 56, sm: 64 },
             width: getCartWidth(),
             maxWidth: getCartWidth(),
             minWidth: "360px",
-            height: "100%", // Use parent height
+            height: { xs: "calc(100vh - 56px)", sm: "calc(100vh - 64px)" },
             overflow: "hidden",
             borderLeft: "1px solid rgba(0,0,0,0.1)",
             backgroundColor: "background.paper",
-            zIndex: 1201,
+            zIndex: (theme) => theme.zIndex.drawer + 1,
           }}
         >
           <CartContent

--- a/src/app/pos/page.tsx
+++ b/src/app/pos/page.tsx
@@ -143,7 +143,6 @@ export default function POSInterface() {
     ITransferDestination[]
   >([]);
   const [intentToSearch, setIntentToSearch] = useState(false);
-  const [openSpeedDial, setOpenSpeedDial] = useState(false);
   const [resumenDiaOpen, setResumenDiaOpen] = useState(false);
   // Edición de nombre de carrito (píldora)
   const [editingCartId, setEditingCartId] = useState<string | null>(null);
@@ -851,12 +850,10 @@ export default function POSInterface() {
 
   const handleShowUserSales = () => {
     setShowUserSales(true);
-    setOpenSpeedDial(false);
   };
 
   const handleCloseSyncView = () => {
     setShowSyncView(false);
-    setOpenSpeedDial(false);
   };
   const handleSearch = (query: string) => {
     setSearchQuery(query);

--- a/src/components/ProductProcessorData/MobileQrScanner.tsx
+++ b/src/components/ProductProcessorData/MobileQrScanner.tsx
@@ -24,6 +24,7 @@ type MobileQrScannerProps = {
   qrCodeSuccessCallback: QrcodeSuccessCallback;
   qrCodeErrorCallback?: QrcodeErrorCallback;
   buttonLabel?: string;
+  onOpenChange?: (open: boolean) => void;
 };
 
 export interface MobileQrScannerRef {
@@ -31,7 +32,7 @@ export interface MobileQrScannerRef {
 }
 
 const MobileQrScanner = forwardRef<MobileQrScannerRef, MobileQrScannerProps>(
-  ({ qrCodeSuccessCallback, qrCodeErrorCallback, buttonLabel }, ref) => {
+  ({ qrCodeSuccessCallback, qrCodeErrorCallback, buttonLabel, onOpenChange }, ref) => {
     const [isOpen, setIsOpen] = useState(false);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(false);
@@ -52,6 +53,10 @@ const MobileQrScanner = forwardRef<MobileQrScannerRef, MobileQrScannerProps>(
         audioService.resumeAudioContext();
       }
     }, [isOpen]);
+
+    useEffect(() => {
+      onOpenChange?.(isOpen);
+    }, [isOpen, onOpenChange]);
 
     useImperativeHandle(ref, () => ({
       openScanner: () => {

--- a/src/components/ProductProcessorData/ProductProcessorData.tsx
+++ b/src/components/ProductProcessorData/ProductProcessorData.tsx
@@ -9,6 +9,8 @@ type ClientProcessorDataProps = {
   onHardwareScan?: (processedData: IProcessedData) => void;
   keepFocus?: boolean;
   showInput?: boolean;
+  enableHardwareScanner?: boolean;
+  onCameraOpenChange?: (open: boolean) => void;
 };
 
 export interface ProductProcessorDataRef {
@@ -16,7 +18,17 @@ export interface ProductProcessorDataRef {
 }
 
 const ProductProcessorData = forwardRef<ProductProcessorDataRef, ClientProcessorDataProps>(
-  ({ onProcessedData, onHardwareScan, keepFocus = true, showInput = false }, ref) => {
+  (
+    {
+      onProcessedData,
+      onHardwareScan,
+      keepFocus = true,
+      showInput = false,
+      enableHardwareScanner = true,
+      onCameraOpenChange,
+    },
+    ref,
+  ) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const qrModuleRef = React.useRef<any>(null);
 
@@ -48,6 +60,8 @@ const ProductProcessorData = forwardRef<ProductProcessorDataRef, ClientProcessor
           onHardwareScan={handleHardwareScan}
           keepFocus={keepFocus}
           showInput={showInput}
+          enableHardwareScanner={enableHardwareScanner}
+          onCameraOpenChange={onCameraOpenChange}
         />
       </Box>
     );

--- a/src/components/ProductProcessorData/QrModuleScanner.tsx
+++ b/src/components/ProductProcessorData/QrModuleScanner.tsx
@@ -8,6 +8,8 @@ type QrModuleScannerProps = {
   onHardwareScan?: (qrText: string) => void;
   keepFocus?: boolean;
   showInput?: boolean;
+  enableHardwareScanner?: boolean;
+  onCameraOpenChange?: (open: boolean) => void;
 };
 
 export interface QrModuleScannerRef {
@@ -15,7 +17,17 @@ export interface QrModuleScannerRef {
 }
 
 const QrModuleScanner = forwardRef<QrModuleScannerRef, QrModuleScannerProps>(
-  ({ onScan, onHardwareScan, keepFocus = true, showInput = false }, ref) => {
+  (
+    {
+      onScan,
+      onHardwareScan,
+      keepFocus = true,
+      showInput = false,
+      enableHardwareScanner = true,
+      onCameraOpenChange,
+    },
+    ref,
+  ) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mobileScannerRef = React.useRef<any>(null);
 
@@ -34,12 +46,18 @@ const QrModuleScanner = forwardRef<QrModuleScannerRef, QrModuleScannerProps>(
         gap={1} 
         width="100%" 
       >
-        <MobileQrScanner ref={mobileScannerRef} qrCodeSuccessCallback={onScan} />
-        <HardwareQrScanner
-          qrCodeSuccessCallback={onHardwareScan ? onHardwareScan : () => {}}
-          keepFocus={keepFocus}
-          showInput={showInput}
+        <MobileQrScanner
+          ref={mobileScannerRef}
+          qrCodeSuccessCallback={onScan}
+          onOpenChange={onCameraOpenChange}
         />
+        {enableHardwareScanner && (
+          <HardwareQrScanner
+            qrCodeSuccessCallback={onHardwareScan ? onHardwareScan : () => {}}
+            keepFocus={keepFocus}
+            showInput={showInput}
+          />
+        )}
       </Box>
     );
   }

--- a/src/components/cartDrawer/CartDrawer.tsx
+++ b/src/components/cartDrawer/CartDrawer.tsx
@@ -42,6 +42,10 @@ const CartDrawer: FC<IProps> = ({
         anchor="right"
         open={open}
         onClose={onClose}
+        disableEnforceFocus
+        disableAutoFocus
+        disableRestoreFocus
+        sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
         PaperProps={{
           sx: {
             height: '100dvh',

--- a/src/hooks/useHardwareScanner.ts
+++ b/src/hooks/useHardwareScanner.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from "react";
+import {
+  HARDWARE_SCAN_IDLE_MS,
+  isEditableTarget,
+  shouldAcceptScanKey,
+} from "@/utils/hardwareScanner";
+
+type UseHardwareScannerOptions = {
+  enabled: boolean;
+  onScan: (rawCode: string) => void;
+  idleMs?: number;
+};
+
+export function useHardwareScanner({
+  enabled,
+  onScan,
+  idleMs = HARDWARE_SCAN_IDLE_MS,
+}: UseHardwareScannerOptions) {
+  const bufferRef = useRef("");
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onScanRef = useRef(onScan);
+
+  onScanRef.current = onScan;
+
+  useEffect(() => {
+    const clearBuffer = () => {
+      bufferRef.current = "";
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+
+    const flushBuffer = () => {
+      const code = bufferRef.current.trim();
+      clearBuffer();
+      if (code.length > 0) {
+        onScanRef.current(code);
+      }
+    };
+
+    const scheduleFlush = () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(flushBuffer, idleMs);
+    };
+
+    if (!enabled) {
+      clearBuffer();
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target)) {
+        clearBuffer();
+        return;
+      }
+
+      if (event.key === "Enter") {
+        if (bufferRef.current.length > 0) {
+          event.preventDefault();
+          flushBuffer();
+        }
+        return;
+      }
+
+      if (!shouldAcceptScanKey(event.key)) return;
+
+      bufferRef.current += event.key;
+      scheduleFlush();
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+      clearBuffer();
+    };
+  }, [enabled, idleMs]);
+}

--- a/src/utils/hardwareScanner.ts
+++ b/src/utils/hardwareScanner.ts
@@ -1,0 +1,23 @@
+export const HARDWARE_SCAN_IDLE_MS = 100;
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+  const el =
+    target instanceof HTMLElement
+      ? target.closest('input, textarea, select, [contenteditable="true"]')
+      : null;
+
+  if (!el) return false;
+
+  // Input con foco residual detrás de un modal/drawer (aria-hidden) no debe bloquear la pistola
+  if (el.closest('[aria-hidden="true"]')) return false;
+
+  if (el instanceof HTMLInputElement && (el.readOnly || el.disabled)) return false;
+  if (el instanceof HTMLTextAreaElement && (el.readOnly || el.disabled)) return false;
+  if (el instanceof HTMLSelectElement && el.disabled) return false;
+
+  return true;
+}
+
+export function shouldAcceptScanKey(key: string): boolean {
+  return key.length === 1;
+}


### PR DESCRIPTION
Reemplaza el input invisible por un listener global en el POS para que el escaneo funcione con carrito, resumen del día y ventas abiertas, sin romper búsqueda ni cámara. Ajusta z-index y focus trap para que el carrito quede por encima del resumen.