### PR TITLE
feat: permitir catálogo demo opcional en activación landing

### DIFF
--- a/docs/REFERIDOS_N8N_CONTRATOS.md
+++ b/docs/REFERIDOS_N8N_CONTRATOS.md
@@ -123,6 +123,7 @@ Objeto `payload` de negocio más campos extra:
 | `numeroLocales` | number | 1–19. |
 | `mensaje` | string | Mensaje opcional. |
 | `referido` | string | Código `PRM-XXXX` o vacío. |
+| `incluirProductosPrueba` | boolean | Si el usuario pidió catálogo demo en la tienda Principal. |
 | `timestamp` | string | ISO 8601. |
 | `source` | string | `landing-page`. |
 | `token` | string \| null | JWT de activación de negocio (48 h; ver `src/constants/onboarding.ts`). |

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcrypt';
+import { seedDemoCatalogForTienda } from '../src/lib/onboarding/seedDemoCatalogForTienda';
 
 const prisma = new PrismaClient();
 
@@ -339,71 +340,9 @@ async function main() {
       console.log('  - Usuario vendedor ya existe');
     }
 
-    // ── 5. Categorías ─────────────────────────────────────────────────
-    const categoriasData = [
-      { nombre: 'Bebidas', color: '#2196F3' },
-      { nombre: 'Snacks', color: '#FF9800' },
-      { nombre: 'Lácteos', color: '#4CAF50' },
-      { nombre: 'Aseo Personal', color: '#9C27B0' },
-    ];
-    const categoriasMap: Record<string, string> = {};
-    let categoriasCreadas = 0;
-    for (const cat of categoriasData) {
-      let categoria = await prisma.categoria.findFirst({ where: { nombre: cat.nombre, negocioId } });
-      if (!categoria) {
-        categoria = await prisma.categoria.create({ data: { ...cat, negocioId } });
-        categoriasCreadas++;
-      }
-      categoriasMap[cat.nombre] = categoria.id;
-    }
-    console.log(`  ✓ Categorías (${categoriasCreadas} creadas, ${categoriasData.length - categoriasCreadas} existentes)`);
-
-    // ── 6. Productos y stock ──────────────────────────────────────────
-    const productosData = [
-      { nombre: 'Agua Mineral 500ml', descripcion: 'Agua mineral natural', categoria: 'Bebidas', costo: 0.50, precio: 1.00, existencia: 50 },
-      { nombre: 'Refresco Cola 355ml', descripcion: 'Refresco sabor cola en lata', categoria: 'Bebidas', costo: 0.80, precio: 1.50, existencia: 30 },
-      { nombre: 'Jugo de Naranja 1L', descripcion: 'Jugo 100% natural de naranja', categoria: 'Bebidas', costo: 1.20, precio: 2.50, existencia: 20 },
-      { nombre: 'Papas Fritas', descripcion: 'Papas fritas en bolsa 50g', categoria: 'Snacks', costo: 0.60, precio: 1.25, existencia: 40 },
-      { nombre: 'Galletas Oreo', descripcion: 'Galletas Oreo pack 154g', categoria: 'Snacks', costo: 1.00, precio: 2.00, existencia: 25 },
-      { nombre: 'Chocolate Barra', descripcion: 'Chocolate con leche 100g', categoria: 'Snacks', costo: 0.90, precio: 1.75, existencia: 18 },
-      { nombre: 'Leche Entera 1L', descripcion: 'Leche entera pasteurizada', categoria: 'Lácteos', costo: 1.20, precio: 2.50, existencia: 20 },
-      { nombre: 'Yogur Natural 200g', descripcion: 'Yogur natural sin azúcar', categoria: 'Lácteos', costo: 0.90, precio: 1.75, existencia: 15 },
-      { nombre: 'Queso Fresco 250g', descripcion: 'Queso fresco artesanal', categoria: 'Lácteos', costo: 2.00, precio: 4.00, existencia: 12 },
-      { nombre: 'Jabón de Baño', descripcion: 'Jabón de baño barra 90g', categoria: 'Aseo Personal', costo: 0.70, precio: 1.50, existencia: 35 },
-      { nombre: 'Shampoo 400ml', descripcion: 'Shampoo para todo tipo de cabello', categoria: 'Aseo Personal', costo: 2.50, precio: 5.00, existencia: 10 },
-      { nombre: 'Pasta Dental 75ml', descripcion: 'Pasta dental con flúor', categoria: 'Aseo Personal', costo: 1.00, precio: 2.00, existencia: 22 },
-    ];
-
-    let productosCreados = 0;
-    for (const p of productosData) {
-      let producto = await prisma.producto.findFirst({ where: { nombre: p.nombre, negocioId } });
-      if (!producto) {
-        producto = await prisma.producto.create({
-          data: {
-            nombre: p.nombre,
-            descripcion: p.descripcion,
-            categoriaId: categoriasMap[p.categoria],
-            negocioId,
-          },
-        });
-        productosCreados++;
-      }
-      const existeEnTienda = await prisma.productoTienda.findFirst({
-        where: { productoId: producto.id, tiendaId: tienda.id },
-      });
-      if (!existeEnTienda) {
-        await prisma.productoTienda.create({
-          data: {
-            productoId: producto.id,
-            tiendaId: tienda.id,
-            costo: p.costo,
-            precio: p.precio,
-            existencia: p.existencia,
-          },
-        });
-      }
-    }
-    console.log(`  ✓ Productos (${productosCreados} creados, ${productosData.length - productosCreados} existentes)`);
+    // ── 5–6. Categorías y productos demo ───────────────────────────────
+    await seedDemoCatalogForTienda(prisma, negocioId, tienda.id);
+    console.log('  ✓ Catálogo demo (categorías y productos)');
 
     // ── 7. Destinos de transferencia ──────────────────────────────────
     const transferDestsData = [

--- a/src/app/activar/page.tsx
+++ b/src/app/activar/page.tsx
@@ -40,6 +40,7 @@ interface Credentials {
   usuario: string;
   passwordTemporal: string;
   negocio: string;
+  incluirProductosPrueba?: boolean;
 }
 
 const TEAL = '#4ECDC4';
@@ -231,6 +232,9 @@ function ActivarContent() {
               'Período de prueba gratuita de 7 días',
               'Acceso completo a todas las funcionalidades',
               'Una tienda preconfigurada lista para usar',
+              ...(credentials.incluirProductosPrueba
+                ? ['Inventario de ejemplo precargado en tu tienda Principal']
+                : []),
               'Soporte directo con el equipo de desarrollo',
               'Pasados los 7 días podrás contratar el plan que mejor se adapte a tu negocio',
             ].map((item) => (

--- a/src/app/api/activar-cuenta/route.ts
+++ b/src/app/api/activar-cuenta/route.ts
@@ -49,7 +49,8 @@ export async function POST(request: NextRequest) {
     }
 
     const parsedPayload = activationTokenPayloadSchema.parse(payload);
-    const { nombre, nombreNegocio, correo, telefono, referido } = parsedPayload;
+    const { nombre, nombreNegocio, correo, telefono, referido, incluirProductosPrueba } =
+      parsedPayload;
 
     if (!nombre?.trim() || !correo?.trim() || !nombreNegocio?.trim()) {
       return NextResponse.json({ error: 'El enlace de activación no contiene información válida.' }, { status: 400 });
@@ -64,6 +65,7 @@ export async function POST(request: NextRequest) {
       telefono: typeof telefono === 'string' ? telefono : '',
       numeroLocales,
       referido,
+      incluirProductosPrueba,
     });
 
     return NextResponse.json(resultado, { status: 201 });

--- a/src/app/api/contact-form/route.ts
+++ b/src/app/api/contact-form/route.ts
@@ -36,6 +36,7 @@ export async function POST(request: NextRequest) {
       numeroLocales: 1,
       mensaje: body.mensaje ?? '',
       referido: referidoNormalizado,
+      incluirProductosPrueba: body.incluirProductosPrueba,
       timestamp: new Date().toISOString(),
       source: 'landing-page',
     };
@@ -54,6 +55,7 @@ export async function POST(request: NextRequest) {
           telefono: payload.telefono,
           numeroLocales: payload.numeroLocales,
           referido: payload.referido,
+          incluirProductosPrueba: payload.incluirProductosPrueba,
         },
         activationSecret,
         { expiresIn: LANDING_ACTIVATION_JWT_EXPIRES_IN }

--- a/src/app/landing-components/ContactSection.tsx
+++ b/src/app/landing-components/ContactSection.tsx
@@ -14,6 +14,11 @@ import {
   CircularProgress,
   Alert,
   Stack,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
 } from '@mui/material';
 import {
   Phone,
@@ -88,6 +93,7 @@ export default function ContactSection() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [errorMessage, setErrorMessage] = useState('');
+  const [incluirProductosPrueba, setIncluirProductosPrueba] = useState<boolean | null>(null);
 
   const handleInputChange = (field: keyof FormData) => (
     event: React.ChangeEvent<HTMLInputElement | { value: unknown }>
@@ -108,6 +114,8 @@ export default function ContactSection() {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(formData.correo)) return false;
 
+    if (incluirProductosPrueba === null) return false;
+
     return true;
   };
 
@@ -116,7 +124,11 @@ export default function ContactSection() {
     
     if (!validateForm()) {
       setSubmitStatus('error');
-      setErrorMessage('Por favor, completa nombre, nombre del negocio y un correo válido.');
+      setErrorMessage(
+        incluirProductosPrueba === null
+          ? 'Indica si deseas incluir productos de ejemplo en tu tienda Principal.'
+          : 'Por favor, completa nombre, nombre del negocio y un correo válido.'
+      );
       return;
     }
 
@@ -132,6 +144,7 @@ export default function ContactSection() {
       telefono: telefonoTrim ? normalizePhone(telefonoTrim) : '',
       numeroLocales: 1,
       referido: formData.referido.trim().toUpperCase(),
+      incluirProductosPrueba: incluirProductosPrueba as boolean,
     };
 
     try {
@@ -148,6 +161,7 @@ export default function ContactSection() {
       if (response.ok) {
         setSubmitStatus('success');
         setFormData(initialFormData);
+        setIncluirProductosPrueba(null);
       } else {
         setSubmitStatus('error');
         setErrorMessage(
@@ -333,12 +347,52 @@ export default function ContactSection() {
                   </Grid>
 
                   <Grid item xs={12}>
+                    <FormControl
+                      component="fieldset"
+                      required
+                      sx={{
+                        width: '100%',
+                        '& .MuiFormLabel-root': { color: 'rgba(255,255,255,0.7)' },
+                        '& .MuiFormLabel-root.Mui-focused': { color: TEAL },
+                        '& .MuiFormControlLabel-label': { color: 'rgba(255,255,255,0.9)' },
+                      }}
+                    >
+                      <FormLabel component="legend">
+                        ¿Incluir productos de ejemplo en tu tienda Principal?
+                      </FormLabel>
+                      <RadioGroup
+                        value={
+                          incluirProductosPrueba === null
+                            ? ''
+                            : incluirProductosPrueba
+                              ? 'yes'
+                              : 'no'
+                        }
+                        onChange={(event) =>
+                          setIncluirProductosPrueba(event.target.value === 'yes')
+                        }
+                      >
+                        <FormControlLabel
+                          value="yes"
+                          control={<Radio sx={{ color: TEAL, '&.Mui-checked': { color: TEAL } }} />}
+                          label="Sí, incluir 12 productos de ejemplo con stock y precios"
+                        />
+                        <FormControlLabel
+                          value="no"
+                          control={<Radio sx={{ color: TEAL, '&.Mui-checked': { color: TEAL } }} />}
+                          label="No, empezar con inventario vacío"
+                        />
+                      </RadioGroup>
+                    </FormControl>
+                  </Grid>
+
+                  <Grid item xs={12}>
                     <Button
                       type="submit"
                       variant="contained"
                       size="large"
                       fullWidth
-                      disabled={isSubmitting}
+                      disabled={isSubmitting || incluirProductosPrueba === null}
                       startIcon={isSubmitting ? <CircularProgress size={20} color="inherit" /> : <Send />}
                       sx={{
                         py: 1.5,

--- a/src/constants/demoCatalog.ts
+++ b/src/constants/demoCatalog.ts
@@ -1,0 +1,35 @@
+export interface IDemoCategoria {
+  nombre: string;
+  color: string;
+}
+
+export interface IDemoProducto {
+  nombre: string;
+  descripcion: string;
+  categoria: string;
+  costo: number;
+  precio: number;
+  existencia: number;
+}
+
+export const DEMO_CATEGORIAS: IDemoCategoria[] = [
+  { nombre: 'Bebidas', color: '#2196F3' },
+  { nombre: 'Snacks', color: '#FF9800' },
+  { nombre: 'Lácteos', color: '#4CAF50' },
+  { nombre: 'Aseo Personal', color: '#9C27B0' },
+];
+
+export const DEMO_PRODUCTOS: IDemoProducto[] = [
+  { nombre: 'Agua Mineral 500ml', descripcion: 'Agua mineral natural', categoria: 'Bebidas', costo: 0.5, precio: 1.0, existencia: 50 },
+  { nombre: 'Refresco Cola 355ml', descripcion: 'Refresco sabor cola en lata', categoria: 'Bebidas', costo: 0.8, precio: 1.5, existencia: 30 },
+  { nombre: 'Jugo de Naranja 1L', descripcion: 'Jugo 100% natural de naranja', categoria: 'Bebidas', costo: 1.2, precio: 2.5, existencia: 20 },
+  { nombre: 'Papas Fritas', descripcion: 'Papas fritas en bolsa 50g', categoria: 'Snacks', costo: 0.6, precio: 1.25, existencia: 40 },
+  { nombre: 'Galletas Oreo', descripcion: 'Galletas Oreo pack 154g', categoria: 'Snacks', costo: 1.0, precio: 2.0, existencia: 25 },
+  { nombre: 'Chocolate Barra', descripcion: 'Chocolate con leche 100g', categoria: 'Snacks', costo: 0.9, precio: 1.75, existencia: 18 },
+  { nombre: 'Leche Entera 1L', descripcion: 'Leche entera pasteurizada', categoria: 'Lácteos', costo: 1.2, precio: 2.5, existencia: 20 },
+  { nombre: 'Yogur Natural 200g', descripcion: 'Yogur natural sin azúcar', categoria: 'Lácteos', costo: 0.9, precio: 1.75, existencia: 15 },
+  { nombre: 'Queso Fresco 250g', descripcion: 'Queso fresco artesanal', categoria: 'Lácteos', costo: 2.0, precio: 4.0, existencia: 12 },
+  { nombre: 'Jabón de Baño', descripcion: 'Jabón de baño barra 90g', categoria: 'Aseo Personal', costo: 0.7, precio: 1.5, existencia: 35 },
+  { nombre: 'Shampoo 400ml', descripcion: 'Shampoo para todo tipo de cabello', categoria: 'Aseo Personal', costo: 2.5, precio: 5.0, existencia: 10 },
+  { nombre: 'Pasta Dental 75ml', descripcion: 'Pasta dental con flúor', categoria: 'Aseo Personal', costo: 1.0, precio: 2.0, existencia: 22 },
+];

--- a/src/lib/onboarding/initializeNegocio.ts
+++ b/src/lib/onboarding/initializeNegocio.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import bcrypt from 'bcrypt';
 import { captureReferralForNewBusiness } from '@/lib/referrals/captureReferral';
+import { seedDemoCatalogForTienda } from '@/lib/onboarding/seedDemoCatalogForTienda';
 import {
   getLandingRegistrationConflict,
   LandingRegistrationConflictError,
@@ -16,12 +17,14 @@ export interface IOnboardingInput {
   /** Cantidad de tiendas a crear (1–19). */
   numeroLocales: number;
   referido?: string;
+  incluirProductosPrueba: boolean;
 }
 
 export interface IOnboardingResult {
   usuario: string;
   passwordTemporal: string;
   negocio: string;
+  incluirProductosPrueba: boolean;
 }
 
 function generarPasswordTemporal(): string {
@@ -107,11 +110,16 @@ export async function initializeNegocio(input: IOnboardingInput): Promise<IOnboa
       promoterCode: input.referido,
       creatorEmail: correo,
     });
+
+    if (input.incluirProductosPrueba) {
+      await seedDemoCatalogForTienda(tx, negocio.id, tiendas[0].id);
+    }
   });
 
   return {
     usuario: correo,
     passwordTemporal,
     negocio: nombreNegocio,
+    incluirProductosPrueba: input.incluirProductosPrueba,
   };
 }

--- a/src/lib/onboarding/seedDemoCatalogForTienda.ts
+++ b/src/lib/onboarding/seedDemoCatalogForTienda.ts
@@ -1,0 +1,55 @@
+import type { Prisma, PrismaClient } from '@prisma/client';
+import { DEMO_CATEGORIAS, DEMO_PRODUCTOS } from '@/constants/demoCatalog';
+
+type DemoCatalogClient = PrismaClient | Prisma.TransactionClient;
+
+export async function seedDemoCatalogForTienda(
+  client: DemoCatalogClient,
+  negocioId: string,
+  tiendaId: string,
+): Promise<void> {
+  const categoriasMap: Record<string, string> = {};
+
+  for (const cat of DEMO_CATEGORIAS) {
+    let categoria = await client.categoria.findFirst({
+      where: { nombre: cat.nombre, negocioId },
+    });
+    if (!categoria) {
+      categoria = await client.categoria.create({
+        data: { ...cat, negocioId },
+      });
+    }
+    categoriasMap[cat.nombre] = categoria.id;
+  }
+
+  for (const p of DEMO_PRODUCTOS) {
+    let producto = await client.producto.findFirst({
+      where: { nombre: p.nombre, negocioId },
+    });
+    if (!producto) {
+      producto = await client.producto.create({
+        data: {
+          nombre: p.nombre,
+          descripcion: p.descripcion,
+          categoriaId: categoriasMap[p.categoria],
+          negocioId,
+        },
+      });
+    }
+
+    const existeEnTienda = await client.productoTienda.findFirst({
+      where: { productoId: producto.id, tiendaId },
+    });
+    if (!existeEnTienda) {
+      await client.productoTienda.create({
+        data: {
+          productoId: producto.id,
+          tiendaId,
+          costo: p.costo,
+          precio: p.precio,
+          existencia: p.existencia,
+        },
+      });
+    }
+  }
+}

--- a/src/schemas/referral.ts
+++ b/src/schemas/referral.ts
@@ -22,6 +22,7 @@ export const landingContactFormSchema = z.object({
     .refine((val) => !val || REFERRAL_PROMO_CODE_REGEX.test(val), {
       message: 'El código de referido no tiene un formato válido.',
     }),
+  incluirProductosPrueba: z.boolean(),
 });
 
 export const activationTokenPayloadSchema = z.object({
@@ -39,6 +40,7 @@ export const activationTokenPayloadSchema = z.object({
     .refine((val) => !val || REFERRAL_PROMO_CODE_REGEX.test(val), {
       message: 'El código de referido no tiene un formato válido.',
     }),
+  incluirProductosPrueba: z.boolean().optional().default(false),
 });
 
 export const promoterActivationTokenSchema = z.object({


### PR DESCRIPTION
El formulario exige elegir si se precargan productos de ejemplo; la preferencia viaja en el JWT hasta initializeNegocio, que crea el catálogo solo en la tienda Principal usando lógica compartida con el seed de desarrollo.