### PR TITLE
Improve dashboard filters and unify profit calculations

### DIFF
--- a/src/app/api/cierre/[tiendaId]/summary/route.ts
+++ b/src/app/api/cierre/[tiendaId]/summary/route.ts
@@ -40,8 +40,7 @@ export async function GET(
     });
     const monedaBase = tienda?.negocio?.monedaBase ?? "CUP";
 
-    const filtros = {
-      tiendaId: tiendaId,
+    const filtrosPeriodo = {
       ...(fechaInicio && {
         fechaInicio: { gte: new Date(fechaInicio).toISOString() },
       }),
@@ -50,16 +49,15 @@ export async function GET(
         : { fechaFin: { not: null } }),
     };
 
+    const filtros = {
+      tiendaId: tiendaId,
+      ...filtrosPeriodo,
+    };
+
     const flitrosVentas = {
       tiendaId: tiendaId,
       totaltransfer: { gt: 0 },
-      cierrePeriodo: {
-        fechaFin: { not: null },
-      },
-      createdAt: {
-        ...(fechaInicio && { gte: new Date(fechaInicio).toISOString() }),
-        ...(fechaFin && { lte: nextDayToEndDate.toISOString() }),
-      },
+      cierrePeriodo: filtrosPeriodo,
     };
 
     const cierres = await prisma.cierrePeriodo.findMany({
@@ -218,14 +216,11 @@ export async function GET(
     }
 
     // Agregados globales — bruto y descuentos en moneda base
+    // Mismo alcance que `filtros`: ventas de los cierres del rango (todas las páginas)
     const ventasParaTotales = await prisma.venta.findMany({
       where: {
         tiendaId,
-        cierrePeriodo: { fechaFin: { not: null } },
-        createdAt: {
-          ...(fechaInicio && { gte: new Date(fechaInicio).toISOString() }),
-          ...(fechaFin && { lte: nextDayToEndDate.toISOString() }),
-        },
+        cierrePeriodo: filtrosPeriodo,
       },
       select: {
         discountTotal: true,
@@ -262,21 +257,45 @@ export async function GET(
       sumTotalVentasBrutas - sumTotalDescuentos,
     );
 
-    const sumTotalGananciasPropiasNet = cierresConMontos.reduce(
-      (acc, c) => acc + Number(c.totalGananciasPropias || 0),
+    // Ganancias netas de descuento a nivel GLOBAL (todas las páginas del rango),
+    // prorrateando los descuentos por bucket Propias/Consignación — mismo
+    // criterio que el cálculo por cierre de arriba.
+    const gananciasPropiasGlobal = totales._sum.totalGananciasPropias ?? 0;
+    const gananciasConsigGlobal = totales._sum.totalGananciasConsignacion ?? 0;
+    const ventasPropiasGlobal = totales._sum.totalVentasPropias ?? 0;
+    const ventasConsigGlobal = totales._sum.totalVentasConsignacion ?? 0;
+
+    let descuentoPropiasGlobal = 0;
+    let descuentoConsigGlobal = 0;
+    if (sumTotalVentasBrutas > 0 && sumTotalDescuentos > 0) {
+      const ratioPropias = Math.max(
+        0,
+        Math.min(1, ventasPropiasGlobal / sumTotalVentasBrutas),
+      );
+      const ratioConsig = Math.max(
+        0,
+        Math.min(1, ventasConsigGlobal / sumTotalVentasBrutas),
+      );
+      descuentoPropiasGlobal = sumTotalDescuentos * ratioPropias;
+      descuentoConsigGlobal = sumTotalDescuentos * ratioConsig;
+    }
+
+    const sumTotalGananciasPropiasNet = Math.max(
       0,
+      gananciasPropiasGlobal - descuentoPropiasGlobal,
     );
-    const sumTotalGananciasConsigNet = cierresConMontos.reduce(
-      (acc, c) => acc + Number(c.totalGananciasConsignacion || 0),
+    const sumTotalGananciasConsigNet = Math.max(
       0,
+      gananciasConsigGlobal - descuentoConsigGlobal,
     );
-    const sumTotalGananciaNet = cierresConMontos.reduce(
-      (acc, c) => acc + Number(c.totalGanancia || 0),
-      0,
-    );
+    const sumTotalGananciaNet =
+      sumTotalGananciasPropiasNet + sumTotalGananciasConsigNet;
+
     // Global aggregates from DB — these cover ALL pages, not just the current one
     const sumTotalGastos = totales._sum.totalGastos ?? 0;
-    const sumTotalGananciaFinal = totales._sum.totalGananciaFinal ?? 0;
+    // Ganancia final neta de descuentos y gastos (el valor almacenado en
+    // CierrePeriodo.totalGananciaFinal no netea descuentos)
+    const sumTotalGananciaFinal = sumTotalGananciaNet - sumTotalGastos;
 
     return NextResponse.json({
       cierres: cierresConMontos as unknown as ISummaryCierre["cierres"],

--- a/src/app/api/dashboard/resumen/[tiendaId]/route.ts
+++ b/src/app/api/dashboard/resumen/[tiendaId]/route.ts
@@ -2,13 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/utils/auth";
 import { verificarPermisoUsuario } from "@/utils/permisos_back";
-import {startOfNextDay} from "@/utils/date";
+import { startOfNextDay } from "@/utils/date";
+import type { ITasaSnapshot } from "@/schemas/tasaCambio";
+import { convertToBase } from "@/lib/currency";
 
 export interface DashboardResumenMetrics {
   ventas: {
     totalPeriodo: number;
     unidadesVendidas: number;
     gananciaTotal: number;
+    totalGastos: number;
+    gananciaFinal: number;
     productosActivos: number;
   };
   topProductos: {
@@ -31,18 +35,25 @@ export interface DashboardResumenMetrics {
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: Promise<{ tiendaId: string }> }
+  { params }: { params: Promise<{ tiendaId: string }> },
 ): Promise<NextResponse<DashboardResumenMetrics | { error: string }>> {
   try {
     const session = await getSession();
     const user = session.user;
-    
-    if (!user || !verificarPermisoUsuario(user.permisos, "recuperaciones.dashboard.acceder", user.rol)) {
+
+    if (
+      !user ||
+      !verificarPermisoUsuario(
+        user.permisos,
+        "recuperaciones.dashboard.acceder",
+        user.rol,
+      )
+    ) {
       return NextResponse.json({ error: "No autorizado" }, { status: 401 });
     }
 
     const { tiendaId } = await params;
-    
+
     const { searchParams } = new URL(req.url);
     const periodo = searchParams.get("periodo") || "mes";
     const fechaInicio = searchParams.get("fechaInicio");
@@ -50,19 +61,26 @@ export async function GET(
 
     // Verificar acceso a la tienda
     const tienda = await prisma.tienda.findFirst({
-      where: user.rol === "SUPER_ADMIN" 
-        ? { id: tiendaId } // SUPER_ADMIN puede acceder a cualquier tienda
-        : {
-            id: tiendaId,
-            usuario: {
-              some: { id: user.id }
-            }
-          }
+      where:
+        user.rol === "SUPER_ADMIN"
+          ? { id: tiendaId } // SUPER_ADMIN puede acceder a cualquier tienda
+          : {
+              id: tiendaId,
+              usuario: {
+                some: { id: user.id },
+              },
+            },
+      include: { negocio: { select: { monedaBase: true } } },
     });
-    
+
     if (!tienda) {
-      return NextResponse.json({ error: "Tienda no encontrada o sin acceso" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Tienda no encontrada o sin acceso" },
+        { status: 404 },
+      );
     }
+
+    const monedaBase = tienda.negocio?.monedaBase ?? "CUP";
 
     // Calcular fechas según el filtro
     const now = new Date();
@@ -70,22 +88,29 @@ export async function GET(
     let fechaFinFiltro: Date = new Date(now);
 
     switch (periodo) {
-      case 'dia':
-        fechaInicioFiltro = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      case "dia":
+        fechaInicioFiltro = new Date(
+          now.getFullYear(),
+          now.getMonth(),
+          now.getDate(),
+        );
         break;
-      case 'semana':
+      case "semana":
         fechaInicioFiltro = new Date(now);
         fechaInicioFiltro.setDate(now.getDate() - 7);
         break;
-      case 'mes':
+      case "mes":
         fechaInicioFiltro = new Date(now.getFullYear(), now.getMonth(), 1);
         break;
-      case 'anio':
+      case "anio":
         fechaInicioFiltro = new Date(now.getFullYear(), 0, 1);
         break;
-      case 'personalizado':
+      case "personalizado":
         if (!fechaInicio) {
-          return NextResponse.json({ error: "Fecha de inicio requerida para período personalizado" }, { status: 400 });
+          return NextResponse.json(
+            { error: "Fecha de inicio requerida para período personalizado" },
+            { status: 400 },
+          );
         }
         fechaInicioFiltro = new Date(fechaInicio);
         if (fechaFin) {
@@ -96,64 +121,161 @@ export async function GET(
         fechaInicioFiltro = new Date(now.getFullYear(), now.getMonth(), 1); // Por defecto, mes actual
     }
 
-    // Obtener ventas del período
+    // Obtener ventas del período — mismo alcance que el resumen de cierres:
+    // solo períodos cerrados cuyo intervalo cae dentro del rango de fechas
+    const filtroCierres = {
+      tiendaId: tiendaId,
+      fechaInicio: { gte: fechaInicioFiltro },
+      fechaFin: { lte: fechaFinFiltro },
+    };
+
     const ventas = await prisma.venta.findMany({
       where: {
         tiendaId: tiendaId,
-        createdAt: {
-          gte: fechaInicioFiltro,
-          lte: fechaFinFiltro
-        }
+        cierrePeriodo: {
+          fechaInicio: { gte: fechaInicioFiltro },
+          fechaFin: { lte: fechaFinFiltro },
+        },
       },
       include: {
+        appliedDiscounts: true,
         productos: {
           include: {
             producto: {
               include: {
                 producto: true,
-                proveedor: true
-              }
-            }
-          }
-        }
-      }
+                proveedor: true,
+              },
+            },
+          },
+        },
+      },
     });
 
     // Calcular métricas de ventas
     let totalPeriodo = 0;
     let unidadesVendidas = 0;
     let gananciaTotal = 0;
-    
+
     // Mapas para calcular productos más vendidos y más rentables
-    const productosVendidosMap = new Map<string, { nombre: string, unidades: number }>();
-    const productosGananciaMap = new Map<string, { nombre: string, ganancia: number }>();
+    const productosVendidosMap = new Map<
+      string,
+      { nombre: string; unidades: number }
+    >();
+    const productosGananciaMap = new Map<
+      string,
+      { nombre: string; ganancia: number }
+    >();
     const productosVentasTotalesMap = new Map<string, number>();
 
     // Procesar ventas
-    ventas.forEach(venta => {
-      totalPeriodo += venta.total;
+    ventas.forEach((venta) => {
+      const tasas = (venta.tasaSnapshot ?? {}) as ITasaSnapshot;
+      const discountTotal = Number(venta.discountTotal ?? 0);
 
-      venta.productos.forEach(ventaProducto => {
+      // Pasada 1: convertir cada línea a moneda base
+      const lineas = venta.productos.map((ventaProducto) => {
+        const precioBase = convertToBase(
+          ventaProducto.precio,
+          ventaProducto.monedaPrecioCode ?? monedaBase,
+          tasas,
+          monedaBase,
+        );
+        const costoBase = convertToBase(
+          ventaProducto.costo,
+          ventaProducto.monedaCostoCode ?? monedaBase,
+          tasas,
+          monedaBase,
+        );
+        return {
+          ventaProducto,
+          bruto: precioBase * ventaProducto.cantidad,
+          gananciaBruta: (precioBase - costoBase) * ventaProducto.cantidad,
+          descuento: 0,
+        };
+      });
+
+      const ventaBruta = lineas.reduce((acc, l) => acc + l.bruto, 0);
+      totalPeriodo += Math.max(0, ventaBruta - discountTotal);
+
+      // Distribuir cada descuento aplicado solo entre sus productos afectados
+      const lineasPorPt = new Map<string, typeof lineas>();
+      lineas.forEach((linea) => {
+        const ptId = linea.ventaProducto.productoTiendaId;
+        if (!lineasPorPt.has(ptId)) lineasPorPt.set(ptId, []);
+        lineasPorPt.get(ptId)!.push(linea);
+      });
+
+      let descuentoAtribuido = 0;
+      for (const ad of venta.appliedDiscounts || []) {
+        const amount = Number(ad.amount || 0);
+        if (amount <= 0) continue;
+
+        const afectadosIds =
+          Array.isArray(ad.productsAffected) &&
+          (ad.productsAffected as unknown[]).length > 0
+            ? (ad.productsAffected as unknown[])
+                .map((x) =>
+                  String(
+                    (x as { productoTiendaId?: string }).productoTiendaId || "",
+                  ),
+                )
+                .filter(Boolean)
+            : Array.from(lineasPorPt.keys());
+
+        const lineasAfectadas = afectadosIds.flatMap(
+          (ptId) => lineasPorPt.get(ptId) || [],
+        );
+        const subtotalAfectado = lineasAfectadas.reduce(
+          (acc, l) => acc + l.bruto,
+          0,
+        );
+        if (subtotalAfectado <= 0) continue;
+
+        lineasAfectadas.forEach((linea) => {
+          linea.descuento += amount * (linea.bruto / subtotalAfectado);
+        });
+        descuentoAtribuido += amount;
+      }
+
+      // Residual: descuentos sin registro AppliedDiscount (datos antiguos) se
+      // prorratean entre todas las líneas para que el neto cuadre con discountTotal
+      const residual = discountTotal - descuentoAtribuido;
+      if (residual > 0.0001 && ventaBruta > 0) {
+        lineas.forEach((linea) => {
+          linea.descuento += residual * (linea.bruto / ventaBruta);
+        });
+      }
+
+      // Pasada 2: acumular métricas netas de descuento
+      lineas.forEach(({ ventaProducto, bruto, gananciaBruta, descuento }) => {
         unidadesVendidas += ventaProducto.cantidad;
-        const gananciaProducto = (ventaProducto.precio - ventaProducto.costo) * ventaProducto.cantidad;
+        const gananciaProducto = gananciaBruta - descuento;
+        const ventaNeta = bruto - descuento;
         gananciaTotal += gananciaProducto;
 
         // Actualizar mapas de productos
         const productoId = ventaProducto.productoTiendaId;
         const nombreProducto = ventaProducto.producto.producto.nombre;
-        const nombreProveedor = ventaProducto.producto.proveedor ? ventaProducto.producto.proveedor.nombre : undefined;
+        const nombreProveedor = ventaProducto.producto.proveedor
+          ? ventaProducto.producto.proveedor.nombre
+          : undefined;
 
         // Actualizar mapa de unidades vendidas
         if (productosVendidosMap.has(productoId)) {
           const actual = productosVendidosMap.get(productoId)!;
           productosVendidosMap.set(productoId, {
-            nombre: nombreProveedor ? `${nombreProducto} - ${nombreProveedor}` : nombreProducto,
-            unidades: actual.unidades + ventaProducto.cantidad
+            nombre: nombreProveedor
+              ? `${nombreProducto} - ${nombreProveedor}`
+              : nombreProducto,
+            unidades: actual.unidades + ventaProducto.cantidad,
           });
         } else {
           productosVendidosMap.set(productoId, {
-            nombre: nombreProveedor ? `${nombreProducto} - ${nombreProveedor}` : nombreProducto,
-            unidades: ventaProducto.cantidad
+            nombre: nombreProveedor
+              ? `${nombreProducto} - ${nombreProveedor}`
+              : nombreProducto,
+            unidades: ventaProducto.cantidad,
           });
         }
 
@@ -161,22 +283,28 @@ export async function GET(
         if (productosGananciaMap.has(productoId)) {
           const actual = productosGananciaMap.get(productoId)!;
           productosGananciaMap.set(productoId, {
-            nombre: nombreProveedor ? `${nombreProducto} - ${nombreProveedor}` : nombreProducto,
-            ganancia: actual.ganancia + gananciaProducto
+            nombre: nombreProveedor
+              ? `${nombreProducto} - ${nombreProveedor}`
+              : nombreProducto,
+            ganancia: actual.ganancia + gananciaProducto,
           });
         } else {
           productosGananciaMap.set(productoId, {
-            nombre: nombreProveedor ? `${nombreProducto} - ${nombreProveedor}` : nombreProducto,
-            ganancia: gananciaProducto
+            nombre: nombreProveedor
+              ? `${nombreProducto} - ${nombreProveedor}`
+              : nombreProducto,
+            ganancia: gananciaProducto,
           });
         }
-        
-        // Actualizar mapa de ventas totales (precio × cantidad)
-        const ventaTotal = ventaProducto.precio * ventaProducto.cantidad;
+
+        // Actualizar mapa de ventas totales netas (para rentabilidad)
         if (productosVentasTotalesMap.has(productoId)) {
-          productosVentasTotalesMap.set(productoId, productosVentasTotalesMap.get(productoId)! + ventaTotal);
+          productosVentasTotalesMap.set(
+            productoId,
+            productosVentasTotalesMap.get(productoId)! + ventaNeta,
+          );
         } else {
-          productosVentasTotalesMap.set(productoId, ventaTotal);
+          productosVentasTotalesMap.set(productoId, ventaNeta);
         }
       });
     });
@@ -186,10 +314,18 @@ export async function GET(
       where: {
         tiendaId: tiendaId,
         existencia: {
-          gt: 0
-        }
-      }
+          gt: 0,
+        },
+      },
     });
+
+    // Gastos de los cierres del rango (mismo alcance que las ventas)
+    const gastosAgregados = await prisma.cierrePeriodo.aggregate({
+      _sum: { totalGastos: true },
+      where: filtroCierres,
+    });
+    const totalGastos = gastosAgregados._sum.totalGastos ?? 0;
+    const gananciaFinal = gananciaTotal - totalGastos;
 
     // Ordenar productos por unidades vendidas y ganancia
     const topProductos = Array.from(productosVendidosMap.values())
@@ -210,11 +346,12 @@ export async function GET(
         // Obtener las ventas totales del producto (precio × cantidad)
         const ventasTotales = productosVentasTotalesMap.get(id) || 0;
         // La rentabilidad es la ganancia dividida por las ventas totales (expresada como porcentaje)
-        const rentabilidad = ventasTotales > 0 ? (ganancia / ventasTotales) * 100 : 0;
-        
+        const rentabilidad =
+          ventasTotales > 0 ? (ganancia / ventasTotales) * 100 : 0;
+
         return {
           nombre,
-          rentabilidad: parseFloat(rentabilidad.toFixed(2))
+          rentabilidad: parseFloat(rentabilidad.toFixed(2)),
         };
       })
       .sort((a, b) => a.rentabilidad - b.rentabilidad)
@@ -226,17 +363,22 @@ export async function GET(
         totalPeriodo,
         unidadesVendidas,
         gananciaTotal,
-        productosActivos
+        totalGastos,
+        gananciaFinal,
+        productosActivos,
       },
       topProductos,
       topGanancias,
       productosMenosVendidos,
-      productosMenosRentables
+      productosMenosRentables,
     };
 
     return NextResponse.json(response);
   } catch (error) {
     console.error("Error en dashboard/resumen:", error);
-    return NextResponse.json({ error: "Error al procesar la solicitud" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Error al procesar la solicitud" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/dashboard-resumen/page.tsx
+++ b/src/app/dashboard-resumen/page.tsx
@@ -20,10 +20,16 @@ import {
   TableRow,
   Typography,
   useMediaQuery,
-  useTheme
+  useTheme,
 } from "@mui/material";
-import { CalendarMonth, Refresh, Today, DateRange, ShowChart } from "@mui/icons-material";
-import { BarChart } from '@mui/x-charts/BarChart';
+import {
+  CalendarMonth,
+  Refresh,
+  Today,
+  DateRange,
+  ShowChart,
+} from "@mui/icons-material";
+import { BarChart } from "@mui/x-charts/BarChart";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import Grid from "@mui/material/Grid2";
 import { useAppContext } from "@/context/AppContext";
@@ -42,6 +48,8 @@ interface DashboardResumenMetrics {
     totalPeriodo: number;
     unidadesVendidas: number;
     gananciaTotal: number;
+    totalGastos: number;
+    gananciaFinal: number;
     productosActivos: number;
   };
   topProductos: {
@@ -63,36 +71,44 @@ interface DashboardResumenMetrics {
 }
 
 interface FilterOptions {
-  periodo: 'dia' | 'semana' | 'mes' | 'anio' | 'personalizado';
+  periodo: "dia" | "semana" | "mes" | "anio" | "personalizado";
   fechaInicio?: Dayjs | null;
   fechaFin?: Dayjs | null;
 }
 
 export default function DashboardResumenPage() {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const [metrics, setMetrics] = useState<DashboardResumenMetrics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filters, setFilters] = useState<FilterOptions>({
-    periodo: 'mes',
+    periodo: "mes",
     fechaInicio: null,
-    fechaFin: null
+    fechaFin: null,
   });
 
-  const { user, loadingContext, monedasNegocio, tasasVigentes, monedaBase } = useAppContext();
+  const { user, loadingContext, monedasNegocio, tasasVigentes, monedaBase } =
+    useAppContext();
   const { showMessage } = useMessageContext();
 
   const [displayCurrency, setDisplayCurrency] = useState<string>(monedaBase);
-  useEffect(() => { setDisplayCurrency(monedaBase); }, [monedaBase]);
+  useEffect(() => {
+    setDisplayCurrency(monedaBase);
+  }, [monedaBase]);
 
   const availableCurrencies = [
     monedaBase,
-    ...monedasNegocio.filter(m => m.activo && m.monedaCode !== monedaBase).map(m => m.monedaCode),
+    ...monedasNegocio
+      .filter((m) => m.activo && m.monedaCode !== monedaBase)
+      .map((m) => m.monedaCode),
   ];
   const hasMultipleCurrencies = availableCurrencies.length > 1;
-  const fmtS = (amt: number) => formatCurrency(convertFromBase(amt, displayCurrency, tasasVigentes, monedaBase));
+  const fmtS = (amt: number) =>
+    formatCurrency(
+      convertFromBase(amt, displayCurrency, tasasVigentes, monedaBase),
+    );
 
   // Función para obtener las métricas del dashboard
   const fetchDashboardMetrics = async () => {
@@ -104,7 +120,10 @@ export default function DashboardResumenPage() {
         throw new Error("No hay tienda seleccionada");
       }
 
-      const data = await getDashboardResumen(user.localActual.id, filters as unknown as Record<string, unknown>);
+      const data = await getDashboardResumen(
+        user.localActual.id,
+        filters as unknown as Record<string, unknown>,
+      );
       setMetrics(data);
     } catch (error) {
       console.error("Error al obtener métricas del dashboard:", error);
@@ -122,15 +141,15 @@ export default function DashboardResumenPage() {
   }, [loadingContext, user?.localActual?.id]); // Solo se dispara al cambiar de tienda o cargar inicialmente
 
   const handleFilterChange = (key: keyof FilterOptions, value: string) => {
-    setFilters(prev => {
+    setFilters((prev) => {
       const newFilters = {
         ...prev,
-        [key]: value
+        [key]: value,
       };
 
       // Si cambia a personalizado y no hay fechas, poner hoy por defecto
-      if (key === 'periodo' && value === 'personalizado' && !prev.fechaInicio) {
-        const today = new Date().toISOString().split('T')[0];
+      if (key === "periodo" && value === "personalizado" && !prev.fechaInicio) {
+        const today = new Date().toISOString().split("T")[0];
         newFilters.fechaInicio = dayjs(today);
         newFilters.fechaFin = dayjs(today);
       }
@@ -144,14 +163,8 @@ export default function DashboardResumenPage() {
   };
 
   // Componente para tarjetas de métricas
-  const MetricCard = ({
-    title,
-    value,
-  }: {
-    title: string;
-    value: string;
-  }) => (
-    <Card sx={{ height: '100%', position: 'relative', overflow: 'visible' }}>
+  const MetricCard = ({ title, value }: { title: string; value: string }) => (
+    <Card sx={{ height: "100%", position: "relative", overflow: "visible" }}>
       <CardContent sx={{ p: 2 }}>
         <Stack spacing={1.5}>
           <Typography
@@ -172,7 +185,12 @@ export default function DashboardResumenPage() {
 
   if (loadingContext) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="60vh">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="60vh"
+      >
         <CircularProgress size="3rem" />
         <Typography variant="body1" sx={{ mt: 2, ml: 2 }}>
           Cargando dashboard...
@@ -185,7 +203,10 @@ export default function DashboardResumenPage() {
     return (
       <PageContainer
         title="Resumen del Negocio"
-        breadcrumbs={[{ label: 'Inicio', href: '/home' }, { label: 'Resumen del Negocio' }]}
+        breadcrumbs={[
+          { label: "Inicio", href: "/home" },
+          { label: "Resumen del Negocio" },
+        ]}
       >
         <Alert severity="warning">
           Selecciona una tienda para ver las métricas del dashboard
@@ -195,25 +216,33 @@ export default function DashboardResumenPage() {
   }
 
   const breadcrumbs = [
-    { label: 'Inicio', href: '/home' },
-    { label: 'Resumen del Negocio' }
+    { label: "Inicio", href: "/home" },
+    { label: "Resumen del Negocio" },
   ];
 
   const headerActions = (
     <Stack
-      direction={{ xs: 'column', md: 'row' }}
+      direction={{ xs: "column", md: "row" }}
       spacing={1.5}
-      alignItems={{ xs: 'stretch', md: 'center' }}
+      alignItems={{ xs: "stretch", md: "center" }}
       sx={{
-        width: '100%',
-        justifyContent: 'flex-end',
-        mt: { xs: 1, sm: 0 }
+        width: "100%",
+        justifyContent: "flex-end",
+        mt: { xs: 1, sm: 0 },
       }}
     >
       {hasMultipleCurrencies && (
         <FormControl size="small" sx={{ minWidth: 90 }}>
-          <Select value={displayCurrency} onChange={e => setDisplayCurrency(e.target.value)} displayEmpty>
-            {availableCurrencies.map(c => <MenuItem key={c} value={c}>{c}</MenuItem>)}
+          <Select
+            value={displayCurrency}
+            onChange={(e) => setDisplayCurrency(e.target.value)}
+            displayEmpty
+          >
+            {availableCurrencies.map((c) => (
+              <MenuItem key={c} value={c}>
+                {c}
+              </MenuItem>
+            ))}
           </Select>
         </FormControl>
       )}
@@ -223,19 +252,19 @@ export default function DashboardResumenPage() {
       <ToggleButtonGroup
         value={filters.periodo}
         exclusive
-        onChange={(_, value) => value && handleFilterChange('periodo', value)}
+        onChange={(_, value) => value && handleFilterChange("periodo", value)}
         size="small"
         color="primary"
         sx={{
-          bgcolor: 'background.paper',
+          bgcolor: "background.paper",
           boxShadow: 1,
-          '& .MuiToggleButton-root': {
+          "& .MuiToggleButton-root": {
             flex: 1, // En móvil se expanden equitativamente
             px: { xs: 1, sm: 2 },
             py: 0.75,
-            fontSize: { xs: '0.7rem', sm: '0.8125rem', md: '0.875rem' },
-            whiteSpace: 'nowrap'
-          }
+            fontSize: { xs: "0.7rem", sm: "0.8125rem", md: "0.875rem" },
+            whiteSpace: "nowrap",
+          },
         }}
       >
         <ToggleButton value="dia">
@@ -261,18 +290,20 @@ export default function DashboardResumenPage() {
         </ToggleButton>
       </ToggleButtonGroup>
 
-      {filters.periodo === 'personalizado' && (
+      {filters.periodo === "personalizado" && (
         <Stack direction="row" spacing={1} alignItems="center">
           <DatePicker
             label="Desde"
             value={filters.fechaInicio}
-            onChange={(d) => setFilters(prev => ({ ...prev, fechaInicio: d }))}
+            onChange={(d) =>
+              setFilters((prev) => ({ ...prev, fechaInicio: d }))
+            }
             slotProps={{ textField: { fullWidth: true, size: "small" } }}
           />
           <DatePicker
             label="Hasta"
             value={filters.fechaFin}
-            onChange={(d) => setFilters(prev => ({ ...prev, fechaFin: d }))}
+            onChange={(d) => setFilters((prev) => ({ ...prev, fechaFin: d }))}
             slotProps={{ textField: { fullWidth: true, size: "small" } }}
           />
         </Stack>
@@ -280,24 +311,30 @@ export default function DashboardResumenPage() {
 
       <IconButton
         onClick={handleRefresh}
-        disabled={loading || (filters.periodo === 'personalizado' && !filters.fechaInicio)}
+        disabled={
+          loading ||
+          (filters.periodo === "personalizado" && !filters.fechaInicio)
+        }
         color="primary"
         sx={{
-          bgcolor: 'primary.main',
-          color: 'white',
+          bgcolor: "primary.main",
+          color: "white",
           borderRadius: 1,
-          '&:hover': { bgcolor: 'primary.dark' },
-          '&.Mui-disabled': { bgcolor: 'action.disabledBackground' },
+          "&:hover": { bgcolor: "primary.dark" },
+          "&.Mui-disabled": { bgcolor: "action.disabledBackground" },
           height: 40,
           px: { xs: 2, sm: 3 },
-          display: 'flex',
+          display: "flex",
           gap: 1,
-          width: { xs: '100%', md: 'auto' },
-          boxShadow: 2
+          width: { xs: "100%", md: "auto" },
+          boxShadow: 2,
         }}
       >
         <Refresh sx={{ fontSize: 20 }} />
-        <Typography variant="button" sx={{ fontWeight: 'bold', fontSize: '0.875rem' }}>
+        <Typography
+          variant="button"
+          sx={{ fontWeight: "bold", fontSize: "0.875rem" }}
+        >
           Aplicar
         </Typography>
       </IconButton>
@@ -307,7 +344,9 @@ export default function DashboardResumenPage() {
   return (
     <PageContainer
       title="Resumen del Negocio"
-      subtitle={!isMobile ? `Métricas clave de ${user.localActual.nombre}` : undefined}
+      subtitle={
+        !isMobile ? `Métricas clave de ${user.localActual.nombre}` : undefined
+      }
       breadcrumbs={breadcrumbs}
       headerActions={headerActions}
       maxWidth="xl"
@@ -319,7 +358,12 @@ export default function DashboardResumenPage() {
       )}
 
       {loading ? (
-        <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          minHeight="400px"
+        >
           <CircularProgress />
           <Typography variant="body2" sx={{ mt: 2, ml: 2 }}>
             Cargando métricas...
@@ -331,7 +375,13 @@ export default function DashboardResumenPage() {
           <Grid container columnSpacing={3}>
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <MetricCard
-                title={filters.periodo === 'dia' ? "Ventas de hoy" : filters.periodo === 'mes' ? "Ventas del mes" : "Ventas del período"}
+                title={
+                  filters.periodo === "dia"
+                    ? "Ventas de hoy"
+                    : filters.periodo === "mes"
+                      ? "Ventas del mes"
+                      : "Ventas del período"
+                }
                 value={fmtS(metrics.ventas.totalPeriodo)}
               />
             </Grid>
@@ -346,9 +396,20 @@ export default function DashboardResumenPage() {
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <MetricCard
                 title="Ganancia estimada"
-                value={fmtS(metrics.ventas.gananciaTotal)}
+                value={fmtS(
+                  metrics.ventas.gananciaFinal ?? metrics.ventas.gananciaTotal,
+                )}
               />
             </Grid>
+
+            {(metrics.ventas.totalGastos || 0) > 0 && (
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                <MetricCard
+                  title="Gastos"
+                  value={fmtS(metrics.ventas.totalGastos)}
+                />
+              </Grid>
+            )}
 
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <MetricCard
@@ -368,14 +429,26 @@ export default function DashboardResumenPage() {
                     Top 10 productos más vendidos
                   </Typography>
                   {metrics.topProductos.length > 0 ? (
-                    <Box sx={{ width: '100%' }}>
+                    <Box sx={{ width: "100%" }}>
                       <BarChart
                         dataset={metrics.topProductos}
                         layout="horizontal"
-                        yAxis={[{ scaleType: 'band', dataKey: 'nombre', width: 160 }]}
-                        xAxis={[{ valueFormatter: (value) => formatNumber(value) }]}
-                        series={[{ dataKey: 'unidades', label: 'Unidades vendidas', valueFormatter: (value) => formatNumber(value) }]}
-                        barLabel={(item) => item.value != null ? formatNumber(item.value) : null}
+                        yAxis={[
+                          { scaleType: "band", dataKey: "nombre", width: 160 },
+                        ]}
+                        xAxis={[
+                          { valueFormatter: (value) => formatNumber(value) },
+                        ]}
+                        series={[
+                          {
+                            dataKey: "unidades",
+                            label: "Unidades vendidas",
+                            valueFormatter: (value) => formatNumber(value),
+                          },
+                        ]}
+                        barLabel={(item) =>
+                          item.value != null ? formatNumber(item.value) : null
+                        }
                         height={350}
                         margin={{ top: 10, bottom: 20, left: 10, right: 10 }}
                       />
@@ -395,14 +468,24 @@ export default function DashboardResumenPage() {
                     Top 10 por ganancia generada
                   </Typography>
                   {metrics.topGanancias.length > 0 ? (
-                    <Box sx={{ width: '100%' }}>
+                    <Box sx={{ width: "100%" }}>
                       <BarChart
                         dataset={metrics.topGanancias}
                         layout="horizontal"
-                        yAxis={[{ scaleType: 'band', dataKey: 'nombre', width: 160 }]}
+                        yAxis={[
+                          { scaleType: "band", dataKey: "nombre", width: 160 },
+                        ]}
                         xAxis={[{ valueFormatter: (value) => fmtS(value) }]}
-                        series={[{ dataKey: 'ganancia', label: 'Ganancia', valueFormatter: (value) => fmtS(value) }]}
-                        barLabel={(item) => item.value != null ? fmtS(item.value) : null}
+                        series={[
+                          {
+                            dataKey: "ganancia",
+                            label: "Ganancia",
+                            valueFormatter: (value) => fmtS(value),
+                          },
+                        ]}
+                        barLabel={(item) =>
+                          item.value != null ? fmtS(item.value) : null
+                        }
                         height={350}
                         margin={{ top: 10, bottom: 20, left: 10, right: 10 }}
                       />
@@ -430,12 +513,16 @@ export default function DashboardResumenPage() {
                         </TableRow>
                       </TableHead>
                       <TableBody>
-                        {metrics.productosMenosVendidos.map((producto, index) => (
-                          <TableRow key={index}>
-                            <TableCell>{producto.nombre}</TableCell>
-                            <TableCell align="right">{formatNumber(producto.unidades)}</TableCell>
-                          </TableRow>
-                        ))}
+                        {metrics.productosMenosVendidos.map(
+                          (producto, index) => (
+                            <TableRow key={index}>
+                              <TableCell>{producto.nombre}</TableCell>
+                              <TableCell align="right">
+                                {formatNumber(producto.unidades)}
+                              </TableCell>
+                            </TableRow>
+                          ),
+                        )}
                       </TableBody>
                     </Table>
                   </TableContainer>
@@ -459,12 +546,16 @@ export default function DashboardResumenPage() {
                         </TableRow>
                       </TableHead>
                       <TableBody>
-                        {metrics.productosMenosRentables.map((producto, index) => (
-                          <TableRow key={index}>
-                            <TableCell>{producto.nombre}</TableCell>
-                            <TableCell align="right">{producto.rentabilidad}%</TableCell>
-                          </TableRow>
-                        ))}
+                        {metrics.productosMenosRentables.map(
+                          (producto, index) => (
+                            <TableRow key={index}>
+                              <TableCell>{producto.nombre}</TableCell>
+                              <TableCell align="right">
+                                {producto.rentabilidad}%
+                              </TableCell>
+                            </TableRow>
+                          ),
+                        )}
                       </TableBody>
                     </Table>
                   </TableContainer>
@@ -474,9 +565,7 @@ export default function DashboardResumenPage() {
           </Grid>
         </Stack>
       ) : (
-        <Alert severity="info">
-          No hay datos disponibles para mostrar
-        </Alert>
+        <Alert severity="info">No hay datos disponibles para mostrar</Alert>
       )}
     </PageContainer>
   );

--- a/src/app/dashboard-resumen/page.tsx
+++ b/src/app/dashboard-resumen/page.tsx
@@ -18,6 +18,7 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
   useMediaQuery,
   useTheme,
@@ -135,10 +136,22 @@ export default function DashboardResumenPage() {
   };
 
   useEffect(() => {
-    if (!loadingContext && user?.localActual) {
-      fetchDashboardMetrics();
+    if (loadingContext || !user?.localActual) return;
+    // En "personalizado" solo se dispara cuando ambas fechas están definidas
+    if (
+      filters.periodo === "personalizado" &&
+      (!filters.fechaInicio || !filters.fechaFin)
+    ) {
+      return;
     }
-  }, [loadingContext, user?.localActual?.id]); // Solo se dispara al cambiar de tienda o cargar inicialmente
+    fetchDashboardMetrics();
+  }, [
+    loadingContext,
+    user?.localActual?.id,
+    filters.periodo,
+    filters.fechaInicio,
+    filters.fechaFin,
+  ]); // Se dispara al cambiar de tienda o al cambiar cualquier filtro
 
   const handleFilterChange = (key: keyof FilterOptions, value: string) => {
     setFilters((prev) => {
@@ -220,127 +233,6 @@ export default function DashboardResumenPage() {
     { label: "Resumen del Negocio" },
   ];
 
-  const headerActions = (
-    <Stack
-      direction={{ xs: "column", md: "row" }}
-      spacing={1.5}
-      alignItems={{ xs: "stretch", md: "center" }}
-      sx={{
-        width: "100%",
-        justifyContent: "flex-end",
-        mt: { xs: 1, sm: 0 },
-      }}
-    >
-      {hasMultipleCurrencies && (
-        <FormControl size="small" sx={{ minWidth: 90 }}>
-          <Select
-            value={displayCurrency}
-            onChange={(e) => setDisplayCurrency(e.target.value)}
-            displayEmpty
-          >
-            {availableCurrencies.map((c) => (
-              <MenuItem key={c} value={c}>
-                {c}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      )}
-
-      <TasasBanner tasas={tasasVigentes} sx={{ mb: 2 }} />
-
-      <ToggleButtonGroup
-        value={filters.periodo}
-        exclusive
-        onChange={(_, value) => value && handleFilterChange("periodo", value)}
-        size="small"
-        color="primary"
-        sx={{
-          bgcolor: "background.paper",
-          boxShadow: 1,
-          "& .MuiToggleButton-root": {
-            flex: 1, // En móvil se expanden equitativamente
-            px: { xs: 1, sm: 2 },
-            py: 0.75,
-            fontSize: { xs: "0.7rem", sm: "0.8125rem", md: "0.875rem" },
-            whiteSpace: "nowrap",
-          },
-        }}
-      >
-        <ToggleButton value="dia">
-          <Today sx={{ mr: { xs: 0.5, sm: 1 }, fontSize: 18 }} />
-          Día
-        </ToggleButton>
-        <ToggleButton value="semana">
-          <ShowChart sx={{ mr: { xs: 0.5, sm: 1 }, fontSize: 18 }} />
-          {!isMobile && "Semana"}
-          {isMobile && "Sem."}
-        </ToggleButton>
-        <ToggleButton value="mes">
-          <CalendarMonth sx={{ mr: { xs: 0.5, sm: 1 }, fontSize: 18 }} />
-          Mes
-        </ToggleButton>
-        <ToggleButton value="anio">
-          <CalendarMonth sx={{ mr: 1, fontSize: 18 }} />
-          Año
-        </ToggleButton>
-        <ToggleButton value="personalizado">
-          <DateRange sx={{ mr: { xs: 0.5, sm: 1 }, fontSize: 18 }} />
-          {isMobile ? "Pers." : "Personalizado"}
-        </ToggleButton>
-      </ToggleButtonGroup>
-
-      {filters.periodo === "personalizado" && (
-        <Stack direction="row" spacing={1} alignItems="center">
-          <DatePicker
-            label="Desde"
-            value={filters.fechaInicio}
-            onChange={(d) =>
-              setFilters((prev) => ({ ...prev, fechaInicio: d }))
-            }
-            slotProps={{ textField: { fullWidth: true, size: "small" } }}
-          />
-          <DatePicker
-            label="Hasta"
-            value={filters.fechaFin}
-            onChange={(d) => setFilters((prev) => ({ ...prev, fechaFin: d }))}
-            slotProps={{ textField: { fullWidth: true, size: "small" } }}
-          />
-        </Stack>
-      )}
-
-      <IconButton
-        onClick={handleRefresh}
-        disabled={
-          loading ||
-          (filters.periodo === "personalizado" && !filters.fechaInicio)
-        }
-        color="primary"
-        sx={{
-          bgcolor: "primary.main",
-          color: "white",
-          borderRadius: 1,
-          "&:hover": { bgcolor: "primary.dark" },
-          "&.Mui-disabled": { bgcolor: "action.disabledBackground" },
-          height: 40,
-          px: { xs: 2, sm: 3 },
-          display: "flex",
-          gap: 1,
-          width: { xs: "100%", md: "auto" },
-          boxShadow: 2,
-        }}
-      >
-        <Refresh sx={{ fontSize: 20 }} />
-        <Typography
-          variant="button"
-          sx={{ fontWeight: "bold", fontSize: "0.875rem" }}
-        >
-          Aplicar
-        </Typography>
-      </IconButton>
-    </Stack>
-  );
-
   return (
     <PageContainer
       title="Resumen del Negocio"
@@ -348,9 +240,243 @@ export default function DashboardResumenPage() {
         !isMobile ? `Métricas clave de ${user.localActual.nombre}` : undefined
       }
       breadcrumbs={breadcrumbs}
-      headerActions={headerActions}
       maxWidth="xl"
     >
+      {isMobile ? (
+        // Mobile: layout original (columna única), sin botón "Aplicar" manual —
+        // los filtros disparan fetchDashboardMetrics solos vía el useEffect de arriba.
+        <Stack spacing={1.5} alignItems="stretch" sx={{ width: "100%", mb: 3 }}>
+          <Stack
+            direction="row"
+            spacing={1}
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            {hasMultipleCurrencies && (
+              <FormControl size="small" sx={{ minWidth: 90 }}>
+                <Select
+                  value={displayCurrency}
+                  onChange={(e) => setDisplayCurrency(e.target.value)}
+                  displayEmpty
+                >
+                  {availableCurrencies.map((c) => (
+                    <MenuItem key={c} value={c}>
+                      {c}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+
+            <Tooltip title="Actualizar datos">
+              <IconButton
+                onClick={handleRefresh}
+                disabled={
+                  loading ||
+                  (filters.periodo === "personalizado" &&
+                    (!filters.fechaInicio || !filters.fechaFin))
+                }
+                color="primary"
+                size="small"
+              >
+                <Refresh />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+
+          <TasasBanner tasas={tasasVigentes} />
+
+          <ToggleButtonGroup
+            value={filters.periodo}
+            exclusive
+            onChange={(_, value) =>
+              value && handleFilterChange("periodo", value)
+            }
+            size="small"
+            color="primary"
+            sx={{
+              bgcolor: "background.paper",
+              boxShadow: 1,
+              "& .MuiToggleButton-root": {
+                flex: 1, // En móvil se expanden equitativamente
+                px: 1,
+                py: 0.75,
+                fontSize: "0.7rem",
+                whiteSpace: "nowrap",
+              },
+            }}
+          >
+            <ToggleButton value="dia">
+              <Today sx={{ mr: 0.5, fontSize: 18 }} />
+              Día
+            </ToggleButton>
+            <ToggleButton value="semana">
+              <ShowChart sx={{ mr: 0.5, fontSize: 18 }} />
+              Sem.
+            </ToggleButton>
+            <ToggleButton value="mes">
+              <CalendarMonth sx={{ mr: 0.5, fontSize: 18 }} />
+              Mes
+            </ToggleButton>
+            <ToggleButton value="anio">
+              <CalendarMonth sx={{ mr: 0.5, fontSize: 18 }} />
+              Año
+            </ToggleButton>
+            <ToggleButton value="personalizado">
+              <DateRange sx={{ mr: 0.5, fontSize: 18 }} />
+              Pers.
+            </ToggleButton>
+          </ToggleButtonGroup>
+
+          {filters.periodo === "personalizado" && (
+            <Stack direction="row" spacing={1} alignItems="center">
+              <DatePicker
+                label="Desde"
+                value={filters.fechaInicio}
+                onChange={(d) =>
+                  setFilters((prev) => ({ ...prev, fechaInicio: d }))
+                }
+                slotProps={{ textField: { fullWidth: true, size: "small" } }}
+              />
+              <DatePicker
+                label="Hasta"
+                value={filters.fechaFin}
+                onChange={(d) =>
+                  setFilters((prev) => ({ ...prev, fechaFin: d }))
+                }
+                slotProps={{ textField: { fullWidth: true, size: "small" } }}
+              />
+            </Stack>
+          )}
+        </Stack>
+      ) : (
+        // Desktop: título en su fila (arriba), filtros repartidos en filas propias.
+        <Stack spacing={1.5} alignItems="flex-start" sx={{ mb: 3 }}>
+          <Stack
+            direction="row"
+            flexWrap="wrap"
+            useFlexGap
+            spacing={1}
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ width: "100%" }}
+          >
+            <TasasBanner tasas={tasasVigentes} />
+
+            <Stack direction="row" spacing={1} alignItems="center">
+              {hasMultipleCurrencies && (
+                <FormControl size="small" sx={{ minWidth: 90 }}>
+                  <Select
+                    value={displayCurrency}
+                    onChange={(e) => setDisplayCurrency(e.target.value)}
+                    displayEmpty
+                  >
+                    {availableCurrencies.map((c) => (
+                      <MenuItem key={c} value={c}>
+                        {c}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+
+              <Tooltip title="Actualizar datos">
+                <IconButton
+                  onClick={handleRefresh}
+                  disabled={
+                    loading ||
+                    (filters.periodo === "personalizado" &&
+                      (!filters.fechaInicio || !filters.fechaFin))
+                  }
+                  color="primary"
+                >
+                  <Refresh />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+          </Stack>
+
+          <Stack
+            direction="row"
+            flexWrap="wrap"
+            useFlexGap
+            spacing={1}
+            alignItems="center"
+          >
+            <ToggleButtonGroup
+              value={filters.periodo}
+              exclusive
+              onChange={(_, value) =>
+                value && handleFilterChange("periodo", value)
+              }
+              size="small"
+              color="primary"
+              sx={{
+                bgcolor: "background.paper",
+                boxShadow: 1,
+                "& .MuiToggleButton-root": {
+                  px: 2,
+                  py: 0.75,
+                  fontSize: "0.875rem",
+                  whiteSpace: "nowrap",
+                },
+              }}
+            >
+              <ToggleButton value="dia">
+                <Today sx={{ mr: 1, fontSize: 18 }} />
+                Día
+              </ToggleButton>
+              <ToggleButton value="semana">
+                <ShowChart sx={{ mr: 1, fontSize: 18 }} />
+                Semana
+              </ToggleButton>
+              <ToggleButton value="mes">
+                <CalendarMonth sx={{ mr: 1, fontSize: 18 }} />
+                Mes
+              </ToggleButton>
+              <ToggleButton value="anio">
+                <CalendarMonth sx={{ mr: 1, fontSize: 18 }} />
+                Año
+              </ToggleButton>
+              <ToggleButton value="personalizado">
+                <DateRange sx={{ mr: 1, fontSize: 18 }} />
+                Personalizado
+              </ToggleButton>
+            </ToggleButtonGroup>
+
+            {filters.periodo === "personalizado" && (
+              <Stack
+                direction="row"
+                flexWrap="wrap"
+                spacing={1}
+                alignItems="center"
+              >
+                <DatePicker
+                  label="Desde"
+                  value={filters.fechaInicio}
+                  onChange={(d) =>
+                    setFilters((prev) => ({ ...prev, fechaInicio: d }))
+                  }
+                  slotProps={{
+                    textField: { size: "small", sx: { width: 160 } },
+                  }}
+                />
+                <DatePicker
+                  label="Hasta"
+                  value={filters.fechaFin}
+                  onChange={(d) =>
+                    setFilters((prev) => ({ ...prev, fechaFin: d }))
+                  }
+                  slotProps={{
+                    textField: { size: "small", sx: { width: 160 } },
+                  }}
+                />
+              </Stack>
+            )}
+          </Stack>
+        </Stack>
+      )}
+
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
           {error}
@@ -388,13 +514,6 @@ export default function DashboardResumenPage() {
 
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <MetricCard
-                title="Unidades vendidas"
-                value={formatNumber(metrics.ventas.unidadesVendidas)}
-              />
-            </Grid>
-
-            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-              <MetricCard
                 title="Ganancia estimada"
                 value={fmtS(
                   metrics.ventas.gananciaFinal ?? metrics.ventas.gananciaTotal,
@@ -413,8 +532,8 @@ export default function DashboardResumenPage() {
 
             <Grid size={{ xs: 12, sm: 6, md: 3 }}>
               <MetricCard
-                title="Productos c/ stock"
-                value={formatNumber(metrics.ventas.productosActivos)}
+                title="Unidades vendidas"
+                value={formatNumber(metrics.ventas.unidadesVendidas)}
               />
             </Grid>
           </Grid>


### PR DESCRIPTION
---

### Description of changes

This pull request introduces various enhancements to the dashboard functionality and resolves inconsistencies in profit calculations across different components. Key changes include:

- **Dashboard Filters & UI Improvements**:
  - Refined logic for "personalizado" date filters to validate correctness and ensure accurate data fetching.
  - Optimized UI for responsive behavior on both mobile and desktop layouts, with improved filter positioning.
  - Added a tooltip for data refresh and enhanced overall button accessibility.
  - Reorganized metric cards for clarity, swapping the positions of "Unidades vendidas" and "Productos c/ stock".

- **Profit Calculation Fix**:
  - Unified profit calculations between the dashboard and the cierre summaries.
  - Corrected discrepancies by ensuring consistent currency conversion to the base currency, proper handling of discounts, expenses, and sales within closed periods only.
  - Introduced a "Ganancia estimada" (final net profit) display and a new "Gastos" card on the dashboard resumen page.
  - Aligned global totals across dashboard and cierre summaries for reconciliation over all relevant periods.