### PR TITLE
Enhance currency handling with read-only support for transfers

### DIFF
--- a/src/components/GestionInventario/movimientos/MovimientosView.tsx
+++ b/src/components/GestionInventario/movimientos/MovimientosView.tsx
@@ -253,6 +253,13 @@ export default function MovimientosView() {
             productoId: item.productoId,
             costoUnitario: item.costo,
             costoTotal: item.costoTotal,
+            // Moneda tal cual venía de la tienda origen — nunca reinterpretar
+            // el costo en la moneda base del destino (bug: CUP leído como USD).
+            monedaCompra: item.monedaCostoCode,
+            // Precio de venta origen — usado solo si el producto no existía
+            // aún en la tienda destino (ver CreateMoviento).
+            precio: item.precio,
+            monedaPrecio: item.monedaPrecioCode,
             ...(item.proveedor && { proveedorId: item.proveedor.id }),
             movimientoOrigenId: item.movimientoOrigenId,
           };
@@ -283,7 +290,9 @@ export default function MovimientosView() {
         categoria: item.productoTienda?.producto?.categoria,
         productoTiendaId: item.productoTiendaId,
         precio: item.productoTienda?.precio,
+        monedaPrecioCode: item.productoTienda?.monedaPrecioCode,
         costo: item.productoTienda?.costo,
+        monedaCostoCode: item.productoTienda?.monedaCostoCode,
         existencia: item.productoTienda?.existencia,
         proveedorId: item.productoTienda?.proveedorId,
         proveedor: item.productoTienda?.proveedor,

--- a/src/components/ProductcSelectionModal/ProductCard.tsx
+++ b/src/components/ProductcSelectionModal/ProductCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import {
   Box,
   Card,
@@ -10,11 +10,11 @@ import {
   Stack,
   Typography,
   CardContent,
-  styled
+  styled,
 } from "@mui/material";
 import { ExpandMore, ExpandLess } from "@mui/icons-material";
-import {formatCurrency} from "@/utils/formatters";
-import StockBadge from './StockBadge';
+import { formatCurrency, formatMontoEnMoneda } from "@/utils/formatters";
+import StockBadge from "./StockBadge";
 
 interface ProductCardProps {
   name: string;
@@ -23,19 +23,32 @@ interface ProductCardProps {
   stock: number;
   actions?: React.ReactNode;
   onClick?: () => void;
+  // Moneda del costo/precio — mostrarla solo cuando el movimiento la usa (ver
+  // ProductSelectionModal.mostrarMoneda)
+  monedaCosto?: string;
+  monedaPrecio?: string;
 }
 
 const StyledCard = styled(Card)(() => ({
-  display: 'flex',
-  flexDirection: 'column',
+  display: "flex",
+  flexDirection: "column",
 }));
 
-function ProductCard({name, cost, precio, stock, onClick, actions}: ProductCardProps ) {
+function ProductCard({
+  name,
+  cost,
+  precio,
+  stock,
+  onClick,
+  actions,
+  monedaCosto,
+  monedaPrecio,
+}: ProductCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   return (
     <StyledCard variant="outlined">
-      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ display: "flex", alignItems: "center" }}>
         <CardActionArea onClick={onClick} sx={{ flex: 1, minWidth: 0 }}>
           <Box sx={{ px: 1.5, py: 1 }}>
             <Stack direction="row" spacing={1} alignItems="center">
@@ -44,7 +57,7 @@ function ProductCard({name, cost, precio, stock, onClick, actions}: ProductCardP
                 component="div"
                 sx={{
                   fontWeight: 700,
-                  color: 'text.primary',
+                  color: "text.primary",
                   lineHeight: 1.3,
                   flex: 1,
                 }}
@@ -57,28 +70,50 @@ function ProductCard({name, cost, precio, stock, onClick, actions}: ProductCardP
         </CardActionArea>
         <IconButton
           size="small"
-          onClick={() => setExpanded(v => !v)}
+          onClick={() => setExpanded((v) => !v)}
           sx={{ p: 0.5, mx: 0.5, flexShrink: 0 }}
         >
-          {expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+          {expanded ? (
+            <ExpandLess fontSize="small" />
+          ) : (
+            <ExpandMore fontSize="small" />
+          )}
         </IconButton>
       </Box>
 
       <Collapse in={expanded} unmountOnExit>
         <Divider />
-        <CardContent sx={{ py: 1, px: 1.5, '&:last-child': { pb: 1 } }}>
+        <CardContent sx={{ py: 1, px: 1.5, "&:last-child": { pb: 1 } }}>
           <Stack spacing={0.5}>
             <Stack direction="row" justifyContent="space-between">
-              <Typography variant="caption" color="text.secondary">Precio:</Typography>
-              <Typography variant="caption" fontWeight={600}>{formatCurrency(precio)}</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Precio:
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                {monedaPrecio
+                  ? formatMontoEnMoneda(precio, monedaPrecio)
+                  : formatCurrency(precio)}
+              </Typography>
             </Stack>
             <Stack direction="row" justifyContent="space-between">
-              <Typography variant="caption" color="text.secondary">Costo:</Typography>
-              <Typography variant="caption" fontWeight={600}>{formatCurrency(cost)}</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Costo:
+              </Typography>
+              <Typography variant="caption" fontWeight={600}>
+                {monedaCosto
+                  ? formatMontoEnMoneda(cost, monedaCosto)
+                  : formatCurrency(cost)}
+              </Typography>
             </Stack>
             <Stack direction="row" justifyContent="space-between">
-              <Typography variant="caption" color="text.secondary">Costo total:</Typography>
-              <Typography variant="caption" fontWeight={700} color="primary">{formatCurrency(cost * stock)}</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Costo total:
+              </Typography>
+              <Typography variant="caption" fontWeight={700} color="primary">
+                {monedaCosto
+                  ? formatMontoEnMoneda(cost * stock, monedaCosto)
+                  : formatCurrency(cost * stock)}
+              </Typography>
             </Stack>
           </Stack>
         </CardContent>
@@ -87,7 +122,7 @@ function ProductCard({name, cost, precio, stock, onClick, actions}: ProductCardP
       {actions && (
         <>
           <Divider />
-          <CardActions sx={{ justifyContent: 'flex-end', p: 1 }}>
+          <CardActions sx={{ justifyContent: "flex-end", p: 1 }}>
             {actions}
           </CardActions>
         </>

--- a/src/components/ProductcSelectionModal/ProductSelectedCard.tsx
+++ b/src/components/ProductcSelectionModal/ProductSelectedCard.tsx
@@ -36,6 +36,9 @@ interface ProductSelectedCardProps {
   moneda?: string;
   monedasDisponibles?: string[];
   onActualizarMoneda?: (nuevaMoneda: string) => void;
+  // TRASPASO_ENTRADA: moneda fija de la tienda origen, no editable — se
+  // muestra como texto en vez del selector.
+  monedaSoloLectura?: boolean;
 }
 
 const StyledCard = styled(Card)(({ theme }) => ({
@@ -62,6 +65,7 @@ const ProductSelectedCard: React.FC<ProductSelectedCardProps> = ({
   moneda,
   monedasDisponibles,
   onActualizarMoneda,
+  monedaSoloLectura,
 }) => {
   return (
     <StyledCard variant="outlined">
@@ -119,23 +123,34 @@ const ProductSelectedCard: React.FC<ProductSelectedCardProps> = ({
               step={0.01}
             />
 
-            {monedasDisponibles && monedasDisponibles.length > 1 && (
+            {monedaSoloLectura && moneda && (
               <TextField
-                select
                 size="small"
                 label="Moneda"
                 value={moneda}
-                disabled={disabledCosto}
-                onChange={(e) => onActualizarMoneda?.(e.target.value)}
+                disabled
                 sx={{ width: 90 }}
-              >
-                {monedasDisponibles.map((code) => (
-                  <MenuItem key={code} value={code}>
-                    {code}
-                  </MenuItem>
-                ))}
-              </TextField>
+              />
             )}
+            {!monedaSoloLectura &&
+              monedasDisponibles &&
+              monedasDisponibles.length > 1 && (
+                <TextField
+                  select
+                  size="small"
+                  label="Moneda"
+                  value={moneda}
+                  disabled={disabledCosto}
+                  onChange={(e) => onActualizarMoneda?.(e.target.value)}
+                  sx={{ width: 90 }}
+                >
+                  {monedasDisponibles.map((code) => (
+                    <MenuItem key={code} value={code}>
+                      {code}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
           </Stack>
           <Box
             display="flex"
@@ -147,7 +162,9 @@ const ProductSelectedCard: React.FC<ProductSelectedCardProps> = ({
             </Typography>
             <Box display="flex" alignItems="center" gap={2}>
               <Typography variant="h6" fontWeight="bold">
-                {monedasDisponibles && monedasDisponibles.length > 1 && moneda
+                {moneda &&
+                (monedaSoloLectura ||
+                  (monedasDisponibles && monedasDisponibles.length > 1))
                   ? formatMontoEnMoneda(costoTotal, moneda)
                   : formatCurrency(costoTotal)}
               </Typography>

--- a/src/components/ProductcSelectionModal/ProductSelectionModal.tsx
+++ b/src/components/ProductcSelectionModal/ProductSelectionModal.tsx
@@ -46,6 +46,9 @@ export interface IProductoDisponible {
 
   productoTiendaId?: string;
   precio?: number;
+  // Moneda en la que está expresado `precio` — mismo motivo que
+  // monedaCostoCode: reinterpretarlo sin convertir es un bug de dinero.
+  monedaPrecioCode?: string | null;
   costo?: number;
   // Moneda en la que está expresado `costo` — SIEMPRE debe acompañar al
   // número: reinterpretarlo en otra moneda sin convertir es un bug de dinero.
@@ -108,6 +111,10 @@ export const ProductSelectionModal: React.FC<ProductSelectionModalProps> = ({
     iTipoMovimiento === "COMPRA" &&
     operacion === "ENTRADA" &&
     monedasNegocio.filter((m) => m.activo).length > 1;
+  // En TRASPASO_ENTRADA la moneda no es editable (viene fija de la tienda
+  // origen) pero igual debe mostrarse en ambas pestañas del modal.
+  const mostrarMoneda =
+    permiteMonedaPorProducto || iTipoMovimiento === "TRASPASO_ENTRADA";
   const monedasDisponibles = useMemo(
     () => [
       monedaBase,
@@ -451,6 +458,9 @@ export const ProductSelectionModal: React.FC<ProductSelectionModalProps> = ({
         categoriaId: producto.categoriaId,
         categoria: producto.categoria,
         precio: producto.precio,
+        // El precio del producto está guardado en su propia moneda — mismo
+        // criterio que monedaCostoCode.
+        monedaPrecioCode: producto.monedaPrecioCode ?? monedaBase,
         costo: producto.costo,
         // El costo del producto está guardado en su propia moneda — arrancar
         // ahí (nunca en monedaBase a secas) evita interpretar mal el número.
@@ -587,6 +597,7 @@ export const ProductSelectionModal: React.FC<ProductSelectionModalProps> = ({
       isFiltering,
       currentPage,
       onReject: onReject ? handleRejectClick : undefined,
+      mostrarMoneda,
     }),
     [
       operacion,
@@ -605,6 +616,7 @@ export const ProductSelectionModal: React.FC<ProductSelectionModalProps> = ({
       currentPage,
       onReject,
       handleRejectClick,
+      mostrarMoneda,
     ],
   );
 

--- a/src/components/ProductcSelectionModal/tables/TableProductosDisponibles.tsx
+++ b/src/components/ProductcSelectionModal/tables/TableProductosDisponibles.tsx
@@ -1,5 +1,11 @@
-import {formatCurrency, formatNumber, normalizeSearch} from "@/utils/formatters";
-import {Search, DoDisturbOn} from "@mui/icons-material";
+import {
+  formatCurrency,
+  formatMontoEnMoneda,
+  formatNumber,
+  normalizeSearch,
+} from "@/utils/formatters";
+import { useAppContext } from "@/context/AppContext";
+import { Search, DoDisturbOn } from "@mui/icons-material";
 import {
   Alert,
   Box,
@@ -17,16 +23,19 @@ import {
   FormControl,
   InputLabel,
   Select,
-  MenuItem, Tooltip, IconButton, Button
+  MenuItem,
+  Tooltip,
+  IconButton,
+  Button,
 } from "@mui/material";
-import React, {useCallback, useEffect, useRef, useState} from "react";
-import {IProductoDisponible, OperacionTipo} from "../ProductSelectionModal";
-import {ICategory} from "@/schemas/categoria";
-import {fetchCategories} from "@/services/categoryService";
-import {useVirtualizer} from '@tanstack/react-virtual';
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { IProductoDisponible, OperacionTipo } from "../ProductSelectionModal";
+import { ICategory } from "@/schemas/categoria";
+import { fetchCategories } from "@/services/categoryService";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import ProductCard from "@/components/ProductcSelectionModal/ProductCard";
 import ProductProcessorData from "@/components/ProductProcessorData/ProductProcessorData";
-import {IProcessedData} from "@/schemas/processedData";
+import { IProcessedData } from "@/schemas/processedData";
 
 interface IProps {
   operacion: OperacionTipo;
@@ -36,61 +45,64 @@ interface IProps {
   isMobile: boolean;
   isLoadingMore: boolean;
   hasMore: boolean;
-  loadMoreProductos: () => Promise<void>
-  agregarProducto: (producto: IProductoDisponible) => void
-  onFilterChange?: (filters: { text?: string, categoriaId?: string }) => void
+  loadMoreProductos: () => Promise<void>;
+  agregarProducto: (producto: IProductoDisponible) => void;
+  onFilterChange?: (filters: { text?: string; categoriaId?: string }) => void;
   onSearchChange?: (isActive: boolean) => void;
   onProductScan?: (data: IProcessedData) => void;
   show: boolean;
   isFiltering: boolean;
   currentPage: number;
   onReject?: (producto: IProductoDisponible) => void;
+  mostrarMoneda?: boolean;
 }
 
 const TableProductosDisponibles: React.FC<IProps> = ({
-                                                       operacion,
-                                                       loading,
-                                                       productos,
-                                                       productosDisponibles,
-                                                       isMobile,
-                                                       isLoadingMore,
-                                                       hasMore,
-                                                       loadMoreProductos,
-                                                       agregarProducto,
-                                                       onFilterChange,
-                                                       onSearchChange,
-                                                       onProductScan,
-                                                       show,
-                                                       isFiltering,
-                                                       currentPage,
-                                                       onReject
-                                                     }) => {
-
+  operacion,
+  loading,
+  productos,
+  productosDisponibles,
+  isMobile,
+  isLoadingMore,
+  hasMore,
+  loadMoreProductos,
+  agregarProducto,
+  onFilterChange,
+  onSearchChange,
+  onProductScan,
+  show,
+  isFiltering,
+  currentPage,
+  onReject,
+  mostrarMoneda,
+}) => {
+  const { monedaBase } = useAppContext();
   const [categorias, setCategorias] = useState<ICategory[]>([]);
-  const [filterText, setFilterText] = useState('');
-  const [filterCategoryId, setFilterCategoryId] = useState('');
+  const [filterText, setFilterText] = useState("");
+  const [filterCategoryId, setFilterCategoryId] = useState("");
 
   // Refs para los inputs no controlados
   const tableContainerRef = useRef<HTMLDivElement>(null);
 
-
   // Clear category filter when switching to mobile
   useEffect(() => {
     if (isMobile && filterCategoryId) {
-      setFilterCategoryId('');
+      setFilterCategoryId("");
     }
   }, [isMobile]); // Intencional: solo ejecutar cuando cambia isMobile
 
   // Notify parent when search/filter is active
   useEffect(() => {
-    onSearchChange?.(filterText.trim().length > 0 || filterCategoryId.length > 0);
+    onSearchChange?.(
+      filterText.trim().length > 0 || filterCategoryId.length > 0,
+    );
   }, [filterText, filterCategoryId, onSearchChange]);
 
   // Virtualización de filas
   const rowVirtualizer = useVirtualizer({
     count: productosDisponibles.length,
     getScrollElement: () => tableContainerRef.current,
-    estimateSize: () => isMobile ? 52 : 56, // Compact collapsed card height on mobile
+    estimateSize: () => (isMobile ? 52 : 56), // Compact collapsed card height on mobile
     overscan: 10,
   });
 
@@ -115,15 +127,15 @@ const TableProductosDisponibles: React.FC<IProps> = ({
     // 7. El componente está visible
     // 8. No estamos en la carga inicial
     if (
-        productosDisponibles.length > 0 &&
-        !loading &&
-        !isFiltering &&
-        productos.length > 0 &&
-        hasMore &&
-        !loadingRef.current &&
-        !isLoadingMore &&
-        show &&
-        currentPage > 1 // Evitar ejecutar en la carga inicial
+      productosDisponibles.length > 0 &&
+      !loading &&
+      !isFiltering &&
+      productos.length > 0 &&
+      hasMore &&
+      !loadingRef.current &&
+      !isLoadingMore &&
+      show &&
+      currentPage > 1 // Evitar ejecutar en la carga inicial
     ) {
       // Usar timeout para evitar ejecuciones inmediatas
       timeoutRef.current = setTimeout(() => {
@@ -157,7 +169,7 @@ const TableProductosDisponibles: React.FC<IProps> = ({
     loadMoreProductos,
     isLoadingMore,
     show,
-    currentPage
+    currentPage,
   ]);
 
   // Resetear el ref cuando se cambian los filtros
@@ -194,7 +206,7 @@ const TableProductosDisponibles: React.FC<IProps> = ({
       const normalizedText = normalizeSearch(filterText);
       onFilterChange({
         text: normalizedText || undefined,
-        categoriaId: filterCategoryId || undefined
+        categoriaId: filterCategoryId || undefined,
       });
     }
   }, [onFilterChange, filterText, filterCategoryId]);
@@ -209,318 +221,395 @@ const TableProductosDisponibles: React.FC<IProps> = ({
   }, [filterText, filterCategoryId, handleApplyFilters]);
 
   return (
-      <div style={{display: show ? 'block' : 'none'}}>
-        <Box sx={{ mb: 1.5 }}>
-          <Grid container spacing={1} alignItems="center">
-            <Grid size={{xs: 12, sm: 4}}>
-              <Box display="flex" alignItems="center" gap={1}>
-                <TextField
-                    fullWidth
-                    type="search"
-                    size="small"
-                    placeholder="Buscar por nombre o proveedor..."
-                    value={filterText}
-                    onChange={(e) => setFilterText(e.target.value)}
-                    slotProps={{
-                      input: {
-                        startAdornment: (
-                            <InputAdornment position="start">
-                              <Search/>
-                            </InputAdornment>
-                        )
-                      }
-                    }}
-                />
-                {onProductScan && (
-                  <ProductProcessorData
-                    onProcessedData={(data: IProcessedData) => { if (data?.code) onProductScan(data); }}
-                    onHardwareScan={(data: IProcessedData) => { if (data?.code) onProductScan(data); }}
-                    keepFocus={false}
-                    showInput={false}
-                  />
-                )}
-              </Box>
-            </Grid>
-
-            {!isMobile && (
-              <Grid size={{xs: 12, sm: 4}}>
-                  <FormControl fullWidth size="small">
-                      <InputLabel>Categoría</InputLabel>
-                      <Select
-                          label="Categoría"
-                          value={filterCategoryId}
-                          onChange={(e) => setFilterCategoryId(e.target.value as string)}
-                      >
-                          <MenuItem value="">Todas las categorías</MenuItem>
-                        {categorias.map(categoria => (
-                            <MenuItem key={categoria.id} value={categoria.id}>
-                              {categoria.nombre}
-                            </MenuItem>
-                        ))}
-                      </Select>
-                  </FormControl>
-              </Grid>
-            )}
-
-          </Grid>
-        </Box>
-        {(loading && productos.length === 0 && show) && (
-            <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', py: 8}}>
-              <CircularProgress size={40} thickness={4} sx={{color: '#1976d2'}}/>
-              <Typography variant="body2" color="primary" sx={{mt: 2, fontWeight: 'medium'}}>
-                Cargando productos...
-              </Typography>
-            </Box>
-        )
-        }
-
-        {productos.length > 0 && (
-            <Box
-                ref={tableContainerRef}
-                sx={{
-                  height: isMobile ? 500 : 500,
-                  overflow: 'auto',
-                  border: isMobile ? 'none' : '1px solid',
-                  borderColor: 'divider',
-                  borderRadius: 1,
-                  bgcolor: isMobile ? 'transparent' : 'background.paper'
+    <div style={{ display: show ? "block" : "none" }}>
+      <Box sx={{ mb: 1.5 }}>
+        <Grid container spacing={1} alignItems="center">
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <Box display="flex" alignItems="center" gap={1}>
+              <TextField
+                fullWidth
+                type="search"
+                size="small"
+                placeholder="Buscar por nombre o proveedor..."
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <Search />
+                      </InputAdornment>
+                    ),
+                  },
                 }}
-            >
-                {!isMobile ? (
-                  <Table
-                      style={{
-                        tableLayout: 'fixed',
-                      }}
-                  >
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>
-                          Producto
-                        </TableCell>
-                        <TableCell>
-                          Existencia
-                        </TableCell>
-                        <TableCell>
-                          Costo
-                        </TableCell>
-                        <TableCell>
-                          Precio
-                        </TableCell>
-                        {onReject && (
-                          <TableCell>
-                            Acciones
-                          </TableCell>
-                        )}
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {productosDisponibles.length > 0 ? (
-                          <>
-                            {(() => {
-                              const virtualItems = rowVirtualizer.getVirtualItems();
-                              const totalSize = rowVirtualizer.getTotalSize();
-                              const paddingTop = virtualItems.length > 0 ? virtualItems?.[0]?.start || 0 : 0;
-                              const paddingBottom = virtualItems.length > 0 ? totalSize - (virtualItems?.[virtualItems.length - 1]?.end || 0) : 0;
+              />
+              {onProductScan && (
+                <ProductProcessorData
+                  onProcessedData={(data: IProcessedData) => {
+                    if (data?.code) onProductScan(data);
+                  }}
+                  onHardwareScan={(data: IProcessedData) => {
+                    if (data?.code) onProductScan(data);
+                  }}
+                  keepFocus={false}
+                  showInput={false}
+                />
+              )}
+            </Box>
+          </Grid>
 
-                              return (
-                                  <>
-                                    {paddingTop > 0 && (
-                                        <TableRow>
-                                              <TableCell
-                                                  colSpan={onReject ? 5 : 4}
-                                                  style={{height: `${paddingTop}px`, padding: 0, border: 0}}
-                                              />
-                                        </TableRow>
+          {!isMobile && (
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Categoría</InputLabel>
+                <Select
+                  label="Categoría"
+                  value={filterCategoryId}
+                  onChange={(e) =>
+                    setFilterCategoryId(e.target.value as string)
+                  }
+                >
+                  <MenuItem value="">Todas las categorías</MenuItem>
+                  {categorias.map((categoria) => (
+                    <MenuItem key={categoria.id} value={categoria.id}>
+                      {categoria.nombre}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+          )}
+        </Grid>
+      </Box>
+      {loading && productos.length === 0 && show && (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            py: 8,
+          }}
+        >
+          <CircularProgress size={40} thickness={4} sx={{ color: "#1976d2" }} />
+          <Typography
+            variant="body2"
+            color="primary"
+            sx={{ mt: 2, fontWeight: "medium" }}
+          >
+            Cargando productos...
+          </Typography>
+        </Box>
+      )}
+
+      {productos.length > 0 && (
+        <Box
+          ref={tableContainerRef}
+          sx={{
+            height: isMobile ? 500 : 500,
+            overflow: "auto",
+            border: isMobile ? "none" : "1px solid",
+            borderColor: "divider",
+            borderRadius: 1,
+            bgcolor: isMobile ? "transparent" : "background.paper",
+          }}
+        >
+          {!isMobile ? (
+            <Table
+              style={{
+                tableLayout: "fixed",
+              }}
+            >
+              <TableHead>
+                <TableRow>
+                  <TableCell>Producto</TableCell>
+                  <TableCell>Existencia</TableCell>
+                  <TableCell>Costo</TableCell>
+                  <TableCell>Precio</TableCell>
+                  {onReject && <TableCell>Acciones</TableCell>}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {productosDisponibles.length > 0 ? (
+                  <>
+                    {(() => {
+                      const virtualItems = rowVirtualizer.getVirtualItems();
+                      const totalSize = rowVirtualizer.getTotalSize();
+                      const paddingTop =
+                        virtualItems.length > 0
+                          ? virtualItems?.[0]?.start || 0
+                          : 0;
+                      const paddingBottom =
+                        virtualItems.length > 0
+                          ? totalSize -
+                            (virtualItems?.[virtualItems.length - 1]?.end || 0)
+                          : 0;
+
+                      return (
+                        <>
+                          {paddingTop > 0 && (
+                            <TableRow>
+                              <TableCell
+                                colSpan={onReject ? 5 : 4}
+                                style={{
+                                  height: `${paddingTop}px`,
+                                  padding: 0,
+                                  border: 0,
+                                }}
+                              />
+                            </TableRow>
+                          )}
+                          {virtualItems.map((virtualRow) => {
+                            const producto =
+                              productosDisponibles[virtualRow.index];
+                            const isDisabled =
+                              operacion === "SALIDA" &&
+                              producto.existencia <= 0;
+                            return (
+                              <TableRow
+                                key={virtualRow.key}
+                                data-index={virtualRow.index}
+                                ref={rowVirtualizer.measureElement}
+                                hover={!isDisabled}
+                                onClick={() =>
+                                  !isDisabled && agregarProducto(producto)
+                                }
+                                sx={{
+                                  cursor: isDisabled
+                                    ? "not-allowed"
+                                    : "pointer",
+                                  opacity: isDisabled ? 0.5 : 1,
+                                }}
+                              >
+                                <TableCell>
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight="medium"
+                                    sx={{
+                                      overflow: "hidden",
+                                      textOverflow: "ellipsis",
+                                      whiteSpace: "nowrap",
+                                      display: "block",
+                                    }}
+                                  >
+                                    {producto.proveedor
+                                      ? `${producto.nombre} - ${producto.proveedor.nombre}`
+                                      : producto.nombre}
+                                  </Typography>
+                                  {producto.proveedor && (
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                      sx={{
+                                        overflow: "hidden",
+                                        textOverflow: "ellipsis",
+                                        whiteSpace: "nowrap",
+                                        display: "block",
+                                      }}
+                                    >
+                                      {producto.proveedor.nombre}
+                                    </Typography>
+                                  )}
+                                </TableCell>
+                                <TableCell>
+                                  <Chip
+                                    label={formatNumber(
+                                      producto.existencia || 0,
                                     )}
-                                    {virtualItems.map(virtualRow => {
-                                      const producto = productosDisponibles[virtualRow.index];
-                                      const isDisabled = operacion === 'SALIDA' && producto.existencia <= 0;
-                                      return (
-                                          <TableRow
-                                              key={virtualRow.key}
-                                              data-index={virtualRow.index}
-                                              ref={rowVirtualizer.measureElement}
-                                              hover={!isDisabled}
-                                              onClick={() => !isDisabled && agregarProducto(producto)}
-                                              sx={{
-                                                cursor: isDisabled ? 'not-allowed' : 'pointer',
-                                                opacity: isDisabled ? 0.5 : 1
-                                              }}
-                                          >
-                                            <TableCell>
-                                              <Typography
-                                                  variant="body2"
-                                                  fontWeight="medium"
-                                                  sx={{
-                                                    overflow: 'hidden',
-                                                    textOverflow: 'ellipsis',
-                                                    whiteSpace: 'nowrap',
-                                                    display: 'block'
-                                                  }}
-                                              >
-                                                {producto.proveedor ? `${producto.nombre} - ${producto.proveedor.nombre}` : producto.nombre}
-                                              </Typography>
-                                              {producto.proveedor && (
-                                                  <Typography
-                                                      variant="caption"
-                                                      color="text.secondary"
-                                                      sx={{
-                                                        overflow: 'hidden',
-                                                        textOverflow: 'ellipsis',
-                                                        whiteSpace: 'nowrap',
-                                                        display: 'block'
-                                                      }}
-                                                  >
-                                                    {producto.proveedor.nombre}
-                                                  </Typography>
-                                              )}
-                                            </TableCell>
-                                            <TableCell>
-                                              <Chip
-                                                  label={formatNumber(producto.existencia || 0)}
-                                                  size="medium"
-                                                  color={producto.existencia <= 0 ? 'error' : producto.existencia <= 5 ? 'warning' : 'success'}
-                                                  sx={{fontSize: '0.75rem'}}
-                                              />
-                                            </TableCell>
-                                            <TableCell>
-                                              <Typography
-                                                  variant="body2"
-                                                  fontWeight="medium"
-                                                  sx={{
-                                                    overflow: 'hidden',
-                                                    textOverflow: 'ellipsis',
-                                                    whiteSpace: 'nowrap'
-                                                  }}
-                                              >
-                                                {formatCurrency(producto.costo)}
-                                              </Typography>
-                                            </TableCell>
-                                            <TableCell>
-                                              <Typography
-                                                  variant="body2"
-                                                  fontWeight="medium"
-                                                  sx={{
-                                                    overflow: 'hidden',
-                                                    textOverflow: 'ellipsis',
-                                                    whiteSpace: 'nowrap'
-                                                  }}
-                                              >
-                                                {formatCurrency(producto.precio)}
-                                              </Typography>
-                                            </TableCell>
-                                            {onReject && (
-                                              <TableCell onClick={(e) => e.stopPropagation()}>
-                                                {producto.movimientoOrigenId && (
-                                                  <Tooltip title="Rechazar Entrada">
-                                                    <IconButton
-                                                      size="small"
-                                                      color="error"
-                                                      onClick={() => onReject(producto)}
-                                                    >
-                                                      <DoDisturbOn />
-                                                    </IconButton>
-                                                  </Tooltip>
-                                                )}
-                                              </TableCell>
-                                            )}
-                                          </TableRow>
-                                      );
-                                    })}
-                                    {paddingBottom > 0 && (
-                                        <TableRow>
-                                          <TableCell
-                                              colSpan={onReject ? 5 : 4}
-                                              style={{height: `${paddingBottom}px`, padding: 0, border: 0}}
-                                          />
-                                        </TableRow>
+                                    size="medium"
+                                    color={
+                                      producto.existencia <= 0
+                                        ? "error"
+                                        : producto.existencia <= 5
+                                          ? "warning"
+                                          : "success"
+                                    }
+                                    sx={{ fontSize: "0.75rem" }}
+                                  />
+                                </TableCell>
+                                <TableCell>
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight="medium"
+                                    sx={{
+                                      overflow: "hidden",
+                                      textOverflow: "ellipsis",
+                                      whiteSpace: "nowrap",
+                                    }}
+                                  >
+                                    {mostrarMoneda
+                                      ? formatMontoEnMoneda(
+                                          producto.costo,
+                                          producto.monedaCostoCode ??
+                                            monedaBase,
+                                        )
+                                      : formatCurrency(producto.costo)}
+                                  </Typography>
+                                </TableCell>
+                                <TableCell>
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight="medium"
+                                    sx={{
+                                      overflow: "hidden",
+                                      textOverflow: "ellipsis",
+                                      whiteSpace: "nowrap",
+                                    }}
+                                  >
+                                    {mostrarMoneda
+                                      ? formatMontoEnMoneda(
+                                          producto.precio,
+                                          producto.monedaPrecioCode ??
+                                            monedaBase,
+                                        )
+                                      : formatCurrency(producto.precio)}
+                                  </Typography>
+                                </TableCell>
+                                {onReject && (
+                                  <TableCell
+                                    onClick={(e) => e.stopPropagation()}
+                                  >
+                                    {producto.movimientoOrigenId && (
+                                      <Tooltip title="Rechazar Entrada">
+                                        <IconButton
+                                          size="small"
+                                          color="error"
+                                          onClick={() => onReject(producto)}
+                                        >
+                                          <DoDisturbOn />
+                                        </IconButton>
+                                      </Tooltip>
                                     )}
-                                  </>
-                              );
-                            })()}
-                          </>
-                      ) : (
-                          <TableRow>
-                            <TableCell colSpan={onReject ? 5 : 4} align="center" sx={{py: 4}}>
-                              <Typography variant="body2" color="text.secondary">
-                                {loading ? 'Cargando productos...' : 'No se encontraron productos con los filtros aplicados'}
-                              </Typography>
-                            </TableCell>
-                          </TableRow>
-                      )}
-                    </TableBody>
-                  </Table>
+                                  </TableCell>
+                                )}
+                              </TableRow>
+                            );
+                          })}
+                          {paddingBottom > 0 && (
+                            <TableRow>
+                              <TableCell
+                                colSpan={onReject ? 5 : 4}
+                                style={{
+                                  height: `${paddingBottom}px`,
+                                  padding: 0,
+                                  border: 0,
+                                }}
+                              />
+                            </TableRow>
+                          )}
+                        </>
+                      );
+                    })()}
+                  </>
                 ) : (
-                    <Box sx={{ position: 'relative', height: `${rowVirtualizer.getTotalSize()}px`, width: '100%' }}>
-                      {rowVirtualizer.getVirtualItems().map(virtualRow => {
-                        const producto = productosDisponibles[virtualRow.index];
-                        const isDisabled = operacion === 'SALIDA' && producto.existencia <= 0;
-                        return (
-                          <Box
-                            key={virtualRow.key}
-                            data-index={virtualRow.index}
-                            ref={rowVirtualizer.measureElement}
-                            sx={{
-                              position: 'absolute',
-                              top: 0,
-                              left: 0,
-                              width: '100%',
-                              transform: `translateY(${virtualRow.start}px)`,
-                              p: 1
+                  <TableRow>
+                    <TableCell
+                      colSpan={onReject ? 5 : 4}
+                      align="center"
+                      sx={{ py: 4 }}
+                    >
+                      <Typography variant="body2" color="text.secondary">
+                        {loading
+                          ? "Cargando productos..."
+                          : "No se encontraron productos con los filtros aplicados"}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          ) : (
+            <Box
+              sx={{
+                position: "relative",
+                height: `${rowVirtualizer.getTotalSize()}px`,
+                width: "100%",
+              }}
+            >
+              {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                const producto = productosDisponibles[virtualRow.index];
+                const isDisabled =
+                  operacion === "SALIDA" && producto.existencia <= 0;
+                return (
+                  <Box
+                    key={virtualRow.key}
+                    data-index={virtualRow.index}
+                    ref={rowVirtualizer.measureElement}
+                    sx={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      transform: `translateY(${virtualRow.start}px)`,
+                      p: 1,
+                    }}
+                  >
+                    <ProductCard
+                      key={producto.productoId}
+                      name={
+                        producto.proveedor
+                          ? `${producto.nombre} - ${producto.proveedor.nombre}`
+                          : producto.nombre
+                      }
+                      cost={producto.costo}
+                      precio={producto.precio}
+                      stock={producto.existencia}
+                      monedaCosto={
+                        mostrarMoneda
+                          ? (producto.monedaCostoCode ?? monedaBase)
+                          : undefined
+                      }
+                      monedaPrecio={
+                        mostrarMoneda
+                          ? (producto.monedaPrecioCode ?? monedaBase)
+                          : undefined
+                      }
+                      onClick={() => !isDisabled && agregarProducto(producto)}
+                      actions={
+                        producto.movimientoOrigenId && (
+                          <Button
+                            variant="contained"
+                            color="error"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onReject(producto);
                             }}
                           >
-                            <ProductCard
-                                key={producto.productoId}
-                                name={producto.proveedor ? `${producto.nombre} - ${producto.proveedor.nombre}` : producto.nombre}
-                                cost={producto.costo}
-                                precio = {producto.precio}
-                                stock={producto.existencia}
-                                onClick={() => !isDisabled && agregarProducto(producto)}
-                                actions={
-                                    producto.movimientoOrigenId && (<Button
-                                        variant="contained"
-                                        color="error"
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          onReject(producto);
-                                        }}
-                                    >
-                                      Rechazar
-                                    </Button>)
-                                }
-                            />
-                          </Box>
-                        );
-                      })}
-                    </Box>
-                )}
+                            Rechazar
+                          </Button>
+                        )
+                      }
+                    />
+                  </Box>
+                );
+              })}
             </Box>
+          )}
+        </Box>
+      )}
+
+      {!hasMore && productosDisponibles.length > 0 && (
+        <Box textAlign="center" p={2}>
+          <Typography variant="body2" color="text.secondary">
+            No hay más productos para cargar
+          </Typography>
+        </Box>
+      )}
+
+      {!isLoadingMore &&
+        !loading &&
+        productosDisponibles.length === 0 &&
+        productos.length === 0 && (
+          <Box textAlign="center" p={4}>
+            <Alert severity="info" sx={{ maxWidth: 400, mx: "auto" }}>
+              <Typography variant="body2">
+                No se encontraron productos con los filtros aplicados
+              </Typography>
+            </Alert>
+          </Box>
         )}
-
-        {
-            !hasMore && productosDisponibles.length > 0 && (
-                <Box textAlign="center" p={2}>
-                  <Typography variant="body2" color="text.secondary">
-                    No hay más productos para cargar
-                  </Typography>
-                </Box>
-            )
-        }
-
-        {
-            !isLoadingMore && !loading && productosDisponibles.length === 0 && productos.length === 0 && (
-                <Box textAlign="center" p={4}>
-                  <Alert severity="info" sx={{maxWidth: 400, mx: 'auto'}}>
-                    <Typography variant="body2">
-                      No se encontraron productos con los filtros aplicados
-                    </Typography>
-                  </Alert>
-                </Box>
-            )
-        }
-      </div>
-  )
-
+    </div>
+  );
 };
 
 export default React.memo(TableProductosDisponibles);

--- a/src/components/ProductcSelectionModal/tables/TableProductosSeleccionados.tsx
+++ b/src/components/ProductcSelectionModal/tables/TableProductosSeleccionados.tsx
@@ -66,13 +66,17 @@ const TableProductosSeleccionados: React.FC<IProps> = ({
     (sum, p) => sum + p.cantidad,
     0,
   );
-  // Cada producto puede estar en una moneda distinta (ver
-  // permiteMonedaPorProducto) — sumarlos todos en un solo número mezclaría
-  // monedas. Se agrupa por moneda y se muestra el desglose.
+  // En TRASPASO_ENTRADA la moneda no es editable (viene fija de la tienda
+  // origen) pero igual debe mostrarse, no solo cuando permiteMonedaPorProducto.
+  const mostrarMoneda =
+    permiteMonedaPorProducto || tipoMovimiento === "TRASPASO_ENTRADA";
+  // Cada producto puede estar en una moneda distinta (ver mostrarMoneda) —
+  // sumarlos todos en un solo número mezclaría monedas. Se agrupa por moneda
+  // y se muestra el desglose.
   const totalCostoPorMoneda = productosSeleccionados.reduce<
     Record<string, number>
   >((acc, p) => {
-    const moneda = permiteMonedaPorProducto
+    const moneda = mostrarMoneda
       ? (p.monedaCostoCode ?? monedaBase)
       : monedaBase;
     acc[moneda] = (acc[moneda] ?? 0) + p.costoTotal;
@@ -156,9 +160,7 @@ const TableProductosSeleccionados: React.FC<IProps> = ({
                     color="warning.main"
                     fontWeight="bold"
                   >
-                    {permiteMonedaPorProducto &&
-                    monedasConCosto[0] &&
-                    monedasConCosto[0] !== monedaBase
+                    {mostrarMoneda && monedasConCosto[0]
                       ? formatMontoEnMoneda(
                           totalCostoPorMoneda[monedasConCosto[0]] ?? 0,
                           monedasConCosto[0],
@@ -201,9 +203,7 @@ const TableProductosSeleccionados: React.FC<IProps> = ({
                 <TableCell>Producto</TableCell>
                 <TableCell align="center">Cantidad</TableCell>
                 <TableCell align="center">Costo Unit.</TableCell>
-                {permiteMonedaPorProducto && (
-                  <TableCell align="center">Moneda</TableCell>
-                )}
+                {mostrarMoneda && <TableCell align="center">Moneda</TableCell>}
                 <TableCell align="right">Costo Total</TableCell>
               </TableRow>
             </TableHead>
@@ -289,39 +289,41 @@ const TableProductosSeleccionados: React.FC<IProps> = ({
                         sx={{ width: 100 }}
                       />
                     </TableCell>
-                    {permiteMonedaPorProducto && (
+                    {mostrarMoneda && (
                       <TableCell align="center">
-                        <TextField
-                          select
-                          size="small"
-                          value={producto.monedaCostoCode ?? monedaBase}
-                          onChange={(e) =>
-                            actualizarMoneda(
-                              producto.productoId,
-                              e.target.value,
-                            )
-                          }
-                          disabled={
-                            esSalida || tipoMovimiento === "TRASPASO_ENTRADA"
-                          }
-                          sx={{ width: 90 }}
-                        >
-                          {monedasDisponibles.map((code) => (
-                            <MenuItem key={code} value={code}>
-                              {code}
-                            </MenuItem>
-                          ))}
-                        </TextField>
+                        {tipoMovimiento === "TRASPASO_ENTRADA" ? (
+                          <Typography variant="body2" fontWeight="medium">
+                            {producto.monedaCostoCode ?? monedaBase}
+                          </Typography>
+                        ) : (
+                          <TextField
+                            select
+                            size="small"
+                            value={producto.monedaCostoCode ?? monedaBase}
+                            onChange={(e) =>
+                              actualizarMoneda(
+                                producto.productoId,
+                                e.target.value,
+                              )
+                            }
+                            disabled={esSalida}
+                            sx={{ width: 90 }}
+                          >
+                            {monedasDisponibles.map((code) => (
+                              <MenuItem key={code} value={code}>
+                                {code}
+                              </MenuItem>
+                            ))}
+                          </TextField>
+                        )}
                       </TableCell>
                     )}
                     <TableCell align="right">
                       <Typography variant="body2" fontWeight="medium">
-                        {permiteMonedaPorProducto &&
-                        producto.monedaCostoCode &&
-                        producto.monedaCostoCode !== monedaBase
+                        {mostrarMoneda
                           ? formatMontoEnMoneda(
                               producto.costoTotal,
-                              producto.monedaCostoCode,
+                              producto.monedaCostoCode ?? monedaBase,
                             )
                           : formatCurrency(producto.costoTotal)}
                       </Typography>
@@ -371,12 +373,17 @@ const TableProductosSeleccionados: React.FC<IProps> = ({
                   actualizarCosto(producto.productoId, nuevoCosto)
                 }
                 onEliminar={() => eliminarProducto(producto.productoId)}
-                {...(permiteMonedaPorProducto && {
-                  moneda: producto.monedaCostoCode ?? monedaBase,
-                  monedasDisponibles,
-                  onActualizarMoneda: (nuevaMoneda: string) =>
-                    actualizarMoneda(producto.productoId, nuevaMoneda),
-                })}
+                {...(tipoMovimiento === "TRASPASO_ENTRADA"
+                  ? {
+                      moneda: producto.monedaCostoCode ?? monedaBase,
+                      monedaSoloLectura: true,
+                    }
+                  : permiteMonedaPorProducto && {
+                      moneda: producto.monedaCostoCode ?? monedaBase,
+                      monedasDisponibles,
+                      onActualizarMoneda: (nuevaMoneda: string) =>
+                        actualizarMoneda(producto.productoId, nuevaMoneda),
+                    })}
               />
             );
           })}

--- a/src/lib/movimiento/index.ts
+++ b/src/lib/movimiento/index.ts
@@ -91,6 +91,8 @@ export const CreateMoviento = async (
           proveedorId: itemProveedorId,
           movimientoOrigenId,
           fechaVencimiento,
+          precio,
+          monedaPrecio,
           monedaOriginal,
           montoOriginal,
           tasaUsada: tasaUsadaItem,
@@ -224,7 +226,13 @@ export const CreateMoviento = async (
               tiendaId,
               productoId,
               costo: costoUnitario || 0,
-              precio: 0,
+              // TRASPASO_ENTRADA trae el precio de venta de la tienda origen;
+              // el resto de movimientos no lo envía y arranca en 0 como antes.
+              precio: precio ?? 0,
+              // Moneda del precio traído de la tienda origen — igual que
+              // monedaCostoCode, null significa monedaBase (mismo negocio en
+              // ambas tiendas, por lo que null es seguro de conservar tal cual).
+              monedaPrecioCode: precio ? (monedaPrecio ?? null) : null,
               existencia: cantidad,
               monedaCostoCode: costoUnitario ? monedaEfectiva : null,
               proveedorId: itemProveedorId || proveedorId || null,

--- a/src/schemas/movimiento.ts
+++ b/src/schemas/movimiento.ts
@@ -97,6 +97,12 @@ export const movimientoCreateSchema = z.object({
   costoUnitario: z.number().nonnegative().finite().optional(),
   costoTotal: z.number().nonnegative().finite().optional(),
   monedaCompra: z.string().optional(),
+  // Solo TRASPASO_ENTRADA: precio de venta de la tienda origen, usado al
+  // crear el ProductoTienda en el destino cuando el producto no existía ahí.
+  precio: z.number().nonnegative().finite().optional(),
+  // Moneda del precio anterior — mismo motivo que monedaCompra (evita
+  // interpretar el precio en la moneda base del destino).
+  monedaPrecio: z.string().optional(),
   proveedorId: z.string().uuid().optional(),
   movimientoOrigenId: z.string().uuid().optional(),
   fechaVencimiento: z.coerce.date().optional(),


### PR DESCRIPTION
```
### Description
- Introduced a `monedaSoloLectura` property to support fixed, read-only currency display in transferred products (`TRASPASO_ENTRADA`).
- Updated UI components to handle editable and non-editable currency fields based on context.
- Improved multi-currency formatting across modals and product tables using `formatMontoEnMoneda`.
- Enhanced validation and schema robustness for `precio` and `monedaPrecio` fields in transfers.
- Fixed edge cases involving mixed-currency stock and cost calculations.

### Checklist
- [ ] Tests have been added or updated where necessary.
- [ ] Documentation has been updated to reflect changes.
- [ ] Code has been reviewed for potential optimizations or issues.
```