### PR TITLE
Fix: validate and persist `localActual` to ensure valid store references

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { signIn } from "next-auth/react";
+import { getSession, signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import NextLink from "next/link";
 import {
   TextField,
@@ -40,6 +41,7 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     try {
@@ -101,10 +103,23 @@ export default function LoginPage() {
           setError("Credenciales inválidas. Verifica tu usuario y contraseña.");
         }
         setLoading(false);
+        return;
       }
-      // Éxito: se deja loading=true, AppContext detectará la sesión y redirigirá.
-      // Si se apagara aquí, el botón se reactivaría durante el instante
-      // en que useSession aún no refleja el nuevo estado autenticado.
+
+      // signIn no devuelve el contenido de la sesión, solo ok/error.
+      // La pedimos y validamos que venga completa antes de redirigir,
+      // en vez de asumir éxito y esperar a que AppContext la detecte sola.
+      const session = await getSession();
+
+      if (!session?.user?.rol) {
+        setError(
+          "Tu cuenta no tiene un rol asignado en este local. Contacta al administrador.",
+        );
+        setLoading(false);
+        return;
+      }
+
+      router.push("/home");
     } catch (err) {
       console.error(err);
       setError("Error de conexión. Intenta nuevamente.");
@@ -674,13 +689,13 @@ export default function LoginPage() {
               </form>
 
               {/* Footer informativo */}
-              <Box sx={{ mt: 4, textAlign: 'center' }}>
+              <Box sx={{ mt: 4, textAlign: "center" }}>
                 <Link
                   component={NextLink}
                   href="/"
                   variant="body2"
                   underline="hover"
-                  sx={{ display: 'block', mb: 1 }}
+                  sx={{ display: "block", mb: 1 }}
                 >
                   Volver a la página principal
                 </Link>

--- a/src/utils/authOptions.ts
+++ b/src/utils/authOptions.ts
@@ -142,10 +142,29 @@ export const authOptions: NextAuthOptions = {
           }
         }
 
+        // ⚠️ VALIDAR QUE localActual APUNTE A UN LOCAL REALMENTE DISPONIBLE
+        // (puede quedar huérfano si el usuario fue removido de esa tienda, la
+        // tienda se eliminó, o nunca se seteó). Si no es válido, caer al
+        // primer local disponible y persistirlo para futuros logins.
+        const localActualValido = localesDisponibles.some(
+          (local) => local.id === user.localActual?.id,
+        );
+
+        const localActualEfectivo = localActualValido
+          ? user.localActual
+          : (localesDisponibles[0] ?? null);
+
+        if (!localActualValido && localActualEfectivo) {
+          await prisma.usuario.update({
+            where: { id: user.id },
+            data: { localActualId: localActualEfectivo.id },
+          });
+        }
+
         // Obtener permisos basados en la tienda actual
         const permisos = await getPermisosUsuario(
           user.id,
-          user.localActual?.id || null,
+          localActualEfectivo?.id || null,
         );
 
         let rol = "";
@@ -153,7 +172,7 @@ export const authOptions: NextAuthOptions = {
         if (user.rol === "SUPER_ADMIN") {
           rol = "SUPER_ADMIN";
         } else {
-          rol = await getRolUsuario(user.id, user.localActual?.id || null);
+          rol = await getRolUsuario(user.id, localActualEfectivo?.id || null);
         }
 
         const negocioParaToken = {
@@ -177,7 +196,7 @@ export const authOptions: NextAuthOptions = {
           // tiendas: tiendasDisponibles,
           locales: localesDisponibles,
           // tiendaActual: user.tiendaActual
-          localActual: user.localActual,
+          localActual: localActualEfectivo,
           permisos: permisos,
         };
       },


### PR DESCRIPTION
### Summary

This pull request implements validation and persistence for the `localActual` store reference to prevent orphaned or invalid states. It ensures that:

- `localActual` corresponds to a valid store.
- An invalid `localActual` falls back to the first available store for subsequent logins.
- User roles and permissions are appropriately validated and persisted during the login flow.

### Changes

- Validated `localActual` against available stores.
- Enhanced fallback mechanism for invalid `localActual` to ensure continuity.
- Updated `authOptions.ts` to handle permissions and roles using the validated store.
- Improved login logic to validate session integrity and assign roles before redirecting users.

### Checklist

- [ ] Code changes are tested and verified.
- [ ] Documentation (if applicable) is updated to reflect the new changes.
- [