### PR TITLE
Add read-only access for business configurations

### DIFF
--- a/src/__tests__/negocioConfigAccess.test.ts
+++ b/src/__tests__/negocioConfigAccess.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { Session } from "next-auth";
-import { assertNegocioConfigAccess } from "@/lib/negocioConfigAccess";
+import {
+  assertNegocioConfigAccess,
+  assertNegocioConfigReadAccess,
+} from "@/lib/negocioConfigAccess";
 
 /**
  * Regresión de seguridad: las rutas de configuración de negocio (monedas y tasas de
@@ -77,6 +80,50 @@ describe("assertNegocioConfigAccess", () => {
 
   it("responde 403 si el usuario no tiene negocio asignado", async () => {
     const res = assertNegocioConfigAccess(sesion({}), NEGOCIO_PROPIO);
+    expect(res?.status).toBe(403);
+  });
+});
+
+/**
+ * Regresión funcional: aplicar el guard de escritura también a los GET dejaba al
+ * vendedor sin monedas ni tasas (403 silenciado en `AppContext.loadMonedas`), y con
+ * ello sin la opción de multimoneda en el POS.
+ */
+describe("assertNegocioConfigReadAccess", () => {
+  const PERMISOS_VENDEDOR =
+    "operaciones.pos-venta.acceder|operaciones.cierre.acceder";
+
+  it("deja leer al vendedor de su propio negocio, sin permiso de configuración", () => {
+    const res = assertNegocioConfigReadAccess(
+      sesion({
+        negocioId: NEGOCIO_PROPIO,
+        permisos: PERMISOS_VENDEDOR,
+        rol: "USER",
+      }),
+      NEGOCIO_PROPIO,
+    );
+    expect(res).toBeNull();
+  });
+
+  it("responde 401 si no hay sesión", () => {
+    const res = assertNegocioConfigReadAccess(null, NEGOCIO_PROPIO);
+    expect(res?.status).toBe(401);
+  });
+
+  it("responde 403 al leer la configuración de OTRO negocio", () => {
+    const res = assertNegocioConfigReadAccess(
+      sesion({
+        negocioId: NEGOCIO_PROPIO,
+        permisos: PERMISOS_VENDEDOR,
+        rol: "USER",
+      }),
+      NEGOCIO_AJENO,
+    );
+    expect(res?.status).toBe(403);
+  });
+
+  it("responde 403 si el usuario no tiene negocio asignado", () => {
+    const res = assertNegocioConfigReadAccess(sesion({}), NEGOCIO_PROPIO);
     expect(res?.status).toBe(403);
   });
 });

--- a/src/app/api/negocio/[id]/monedas/route.ts
+++ b/src/app/api/negocio/[id]/monedas/route.ts
@@ -2,7 +2,10 @@ import { prisma } from "@/lib/prisma";
 import { getSessionFromRequest } from "@/utils/authFromRequest";
 import { NextRequest, NextResponse } from "next/server";
 import { negocioMonedaCreateSchema } from "@/schemas/moneda";
-import { assertNegocioConfigAccess } from "@/lib/negocioConfigAccess";
+import {
+  assertNegocioConfigAccess,
+  assertNegocioConfigReadAccess,
+} from "@/lib/negocioConfigAccess";
 
 export async function GET(
   req: NextRequest,
@@ -12,7 +15,8 @@ export async function GET(
     const session = await getSessionFromRequest(req);
     const { id } = await params;
 
-    const accessError = assertNegocioConfigAccess(session, id);
+    // Lectura: la necesita el POS de cualquier usuario del negocio, no solo el admin.
+    const accessError = assertNegocioConfigReadAccess(session, id);
     if (accessError) return accessError;
 
     const monedas = await prisma.negocioMoneda.findMany({

--- a/src/app/api/negocio/[id]/tasas-cambio/route.ts
+++ b/src/app/api/negocio/[id]/tasas-cambio/route.ts
@@ -3,7 +3,10 @@ import { getSessionFromRequest } from "@/utils/authFromRequest";
 import { NextRequest, NextResponse } from "next/server";
 import { tasaCambioCreateSchema } from "@/schemas/tasaCambio";
 import { buildTasaSnapshot } from "@/lib/currency";
-import { assertNegocioConfigAccess } from "@/lib/negocioConfigAccess";
+import {
+  assertNegocioConfigAccess,
+  assertNegocioConfigReadAccess,
+} from "@/lib/negocioConfigAccess";
 
 export async function GET(
   req: NextRequest,
@@ -13,7 +16,8 @@ export async function GET(
     const session = await getSessionFromRequest(req);
     const { id } = await params;
 
-    const accessError = assertNegocioConfigAccess(session, id);
+    // Lectura: la necesita el POS de cualquier usuario del negocio, no solo el admin.
+    const accessError = assertNegocioConfigReadAccess(session, id);
     if (accessError) return accessError;
 
     const negocio = await prisma.negocio.findUnique({

--- a/src/lib/negocioConfigAccess.ts
+++ b/src/lib/negocioConfigAccess.ts
@@ -6,8 +6,25 @@ import { verificarPermisoUsuario } from "@/utils/permisos_back";
 export const PERMISO_CONFIGURACION_NEGOCIO = "configuracion.administrador";
 
 /**
- * Guarda para las rutas de configuración avanzada de un negocio (monedas habilitadas,
- * tasas de cambio y cambio de moneda base). Verifica, en orden:
+ * Guarda de LECTURA para la configuración multimoneda del negocio (monedas habilitadas
+ * y tasas vigentes). Solo exige sesión y pertenencia al negocio: estos datos los carga
+ * el AppContext para TODOS los usuarios, porque el POS los necesita para cobrar en
+ * moneda alternativa. Exigir aquí el permiso de configuración avanzada dejaba al
+ * vendedor sin monedas ni tasas (403 silenciado en `loadMonedas`), y con ello sin la
+ * opción de multimoneda en la pantalla de venta.
+ *
+ * Para cualquier mutación usar `assertNegocioConfigAccess`.
+ */
+export function assertNegocioConfigReadAccess(
+  session: Session | null,
+  negocioId: string,
+): NextResponse | null {
+  return assertNegocioAccess(session, negocioId);
+}
+
+/**
+ * Guarda de ESCRITURA para las rutas de configuración avanzada de un negocio (monedas
+ * habilitadas, tasas de cambio y cambio de moneda base). Verifica, en orden:
  *
  *  1. Que haya sesión.
  *  2. Que el usuario pertenezca al negocio del path. Sin esto, cualquier usuario


### PR DESCRIPTION
```markdown
### Description

This PR introduces the `assertNegocioConfigReadAccess` function to allow non-admin users, like sellers, to access business-specific multi-currency configurations. Key changes include:

- **Functionality Updates**:
  - Addition of `assertNegocioConfigReadAccess` for granting read-only access.
  - Updated API routes (`tasas-cambio`, `monedas`) to replace write access checks with read access checks where applicable.

- **Testing**:
  - Added unit tests to ensure expected behavior for various roles and session states.
  
- **POS Improvements**:
  - Ensures sellers can access currency and exchange rate configurations without requiring admin permissions.

### Checklist

- [ ] Code changes are adequately documented.
- [ ] Unit tests have been added/updated for the new functionality.
- [ ] Existing tests pass locally.
```