### PR TITLE
Refine TRMI handling and enhance elTOQUE integration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -864,7 +864,7 @@ model TasaReferenciaExterna {
   id        String   @id @default(uuid())
   fuente    String   @default("ELTOQUE")
   tasas     Json // { "USD": 440, "EUR": 500, "MLC": 210 } — códigos ISO, CUP por unidad
-  fechaDato DateTime // Momento del dato según la fuente (no cuándo lo trajimos)
+  fechaDato DateTime // Reloj de la fuente al responder (la TRMI no publica fecha propia)
   fetchedAt DateTime @default(now())
 
   @@index([fuente, fetchedAt])

--- a/src/__tests__/eltoque.test.ts
+++ b/src/__tests__/eltoque.test.ts
@@ -48,20 +48,37 @@ describe("normalizarRespuestaEltoque", () => {
     expect(res?.tasas).toEqual({ USD: 440 });
   });
 
-  it("compone fechaDato con la fecha y hora reportadas por la fuente", () => {
+  it("descarta valores no numéricos sin tumbar el resto de la respuesta", () => {
+    // Basta que elTOQUE devuelva null en una moneda que ni usamos para que un parseo
+    // estricto dejara la integración caída.
     const res = normalizarRespuestaEltoque({
+      tasas: { USD: 440, USDT_TRC20: null, MLC: "210" },
+    });
+    expect(res?.tasas).toEqual({ USD: 440 });
+  });
+
+  it("interpreta la hora reportada como hora de Cuba, no del servidor", () => {
+    // En verano Cuba es UTC−4: 09:05:03 en La Habana ⇒ 13:05:03Z. Se compara el instante
+    // en UTC para que el test no dependa de la zona de la máquina que lo corre (en Vercel
+    // es UTC y ahí estaba el bug: el dato quedaba corrido 4 h).
+    const verano = normalizarRespuestaEltoque({
       tasas: { USD: 440 },
       date: "2026-07-27",
       hour: 9,
       minutes: 5,
       seconds: 3,
     });
+    expect(verano?.fechaDato.toISOString()).toBe("2026-07-27T13:05:03.000Z");
 
-    expect(res?.fechaDato.getFullYear()).toBe(2026);
-    expect(res?.fechaDato.getMonth()).toBe(6); // julio
-    expect(res?.fechaDato.getDate()).toBe(27);
-    expect(res?.fechaDato.getHours()).toBe(9);
-    expect(res?.fechaDato.getMinutes()).toBe(5);
+    // En invierno es UTC−5.
+    const invierno = normalizarRespuestaEltoque({
+      tasas: { USD: 440 },
+      date: "2026-01-15",
+      hour: 9,
+      minutes: 0,
+      seconds: 0,
+    });
+    expect(invierno?.fechaDato.toISOString()).toBe("2026-01-15T14:00:00.000Z");
   });
 
   it("cae a la fecha actual si la fuente no reporta fecha", () => {
@@ -83,6 +100,7 @@ describe("normalizarRespuestaEltoque", () => {
   it("devuelve null si la respuesta no tiene la forma esperada", () => {
     expect(normalizarRespuestaEltoque({ rates: { USD: 440 } })).toBeNull();
     expect(normalizarRespuestaEltoque(null)).toBeNull();
+    // Forma válida pero sin un solo valor usable ⇒ tampoco hay nada que cachear.
     expect(normalizarRespuestaEltoque({ tasas: { USD: "440" } })).toBeNull();
   });
 

--- a/src/app/api/tasas-referencia/route.ts
+++ b/src/app/api/tasas-referencia/route.ts
@@ -21,7 +21,11 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "Sin permiso" }, { status: 403 });
     }
 
-    return NextResponse.json(await getTasasReferencia());
+    // ?force=1 → viene del botón "Actualizar". No salta la caché, solo reduce el TTL
+    // exigido (ver ELTOQUE_FORCE_MIN_MINUTES): la cuota del token sigue protegida.
+    const force = req.nextUrl.searchParams.get("force") === "1";
+
+    return NextResponse.json(await getTasasReferencia({ force }));
   } catch (error) {
     console.error(error);
     return NextResponse.json(

--- a/src/components/TasasReferenciaCard.tsx
+++ b/src/components/TasasReferenciaCard.tsx
@@ -43,6 +43,20 @@ const fmtActualizado = (iso: string) =>
     minute: "2-digit",
   });
 
+// La TRMI se mueve en minutos, así que lo que importa no es la hora exacta de la consulta
+// sino cuánto hace que se hizo. La hora exacta queda en el tooltip.
+const fmtEdad = (iso: string) => {
+  const minutos = Math.max(
+    0,
+    Math.round((Date.now() - new Date(iso).getTime()) / 60000),
+  );
+  if (minutos < 1) return "hace instantes";
+  if (minutos < 60) return `hace ${minutos} min`;
+  const horas = Math.floor(minutos / 60);
+  if (horas < 24) return `hace ${horas} h`;
+  return `hace ${Math.floor(horas / 24)} d`;
+};
+
 export function TasasReferenciaCard({
   vigentes,
   monedasHabilitadas,
@@ -56,16 +70,23 @@ export function TasasReferenciaCard({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [aplicando, setAplicando] = useState<string | null>(null);
+  const [refrescando, setRefrescando] = useState(false);
 
-  const load = useCallback(async () => {
-    setLoading(true);
+  /**
+   * @param force refresco pedido por el usuario: pide un dato más nuevo que el TTL normal
+   *   y mantiene el panel visible (solo gira el icono) en vez de volver al skeleton.
+   */
+  const load = useCallback(async (force = false) => {
+    if (force) setRefrescando(true);
+    else setLoading(true);
     setError(false);
     try {
-      setData(await getTasasReferencia());
+      setData(await getTasasReferencia(force));
     } catch {
       setError(true);
     } finally {
       setLoading(false);
+      setRefrescando(false);
     }
   }, []);
 
@@ -139,7 +160,7 @@ export function TasasReferenciaCard({
         severity="warning"
         sx={{ mb: 2 }}
         action={
-          <Button color="inherit" size="small" onClick={load}>
+          <Button color="inherit" size="small" onClick={() => load(true)}>
             Reintentar
           </Button>
         }
@@ -178,9 +199,13 @@ export function TasasReferenciaCard({
             Referencia elTOQUE
           </Typography>
           {data?.actualizadoEn && (
-            <Typography variant="caption" color="text.secondary">
-              · {fmtActualizado(data.actualizadoEn)}
-            </Typography>
+            <Tooltip
+              title={`Consultado a elTOQUE el ${fmtActualizado(data.actualizadoEn)}`}
+            >
+              <Typography variant="caption" color="text.secondary">
+                · {fmtEdad(data.actualizadoEn)}
+              </Typography>
+            </Tooltip>
           )}
           {data?.stale && (
             <Tooltip title="No se pudo contactar a elTOQUE; se muestra el último dato conocido.">
@@ -196,8 +221,16 @@ export function TasasReferenciaCard({
 
         <Stack direction="row" alignItems="center" gap={0.5}>
           <Tooltip title="Actualizar">
-            <IconButton size="small" onClick={load}>
-              <Refresh fontSize="small" />
+            <IconButton
+              size="small"
+              onClick={() => load(true)}
+              disabled={refrescando}
+            >
+              {refrescando ? (
+                <CircularProgress size={16} />
+              ) : (
+                <Refresh fontSize="small" />
+              )}
             </IconButton>
           </Tooltip>
           {desviadas.length > 1 && (

--- a/src/constants/eltoque.ts
+++ b/src/constants/eltoque.ts
@@ -17,12 +17,30 @@ export const ELTOQUE_LOGO_SRC = "/eltoque-logo.png";
 export const ELTOQUE_FUENTE = "ELTOQUE";
 
 // Vida de la caché en BD. La cuota del token es de ~5.000 peticiones/mes para toda la
-// plataforma, así que la caché es global (no por negocio): el primer negocio que
-// consulta tras vencer el TTL trae el dato y el resto lo lee de BD.
-// 360 min = 4 llamadas/día como máximo entre todos los negocios.
-export const ELTOQUE_TTL_MINUTES = 360;
+// plataforma (~166/día), así que la caché es global (no por negocio): el primer negocio
+// que consulta tras vencer el TTL trae el dato y el resto lo lee de BD.
+//
+// 60 min = 24 llamadas/día como máximo por el camino automático. Antes eran 360 min,
+// pero la TRMI es una mediana móvil que se mueve en minutos: con 6 h de caché el panel
+// mostraba números que ya no coincidían con eltoque.com y el botón "Actualizar" no
+// podía hacer nada al respecto.
+export const ELTOQUE_TTL_MINUTES = 60;
+
+// Piso para el refresco manual (botón "Actualizar"): permite traer un dato más nuevo
+// que el TTL normal sin que aporrear el botón queme la cuota.
+// 4 llamadas/hora como techo teórico ⇒ 96/día ⇒ ~2.900/mes, dentro de la cuota.
+export const ELTOQUE_FORCE_MIN_MINUTES = 15;
 
 export const ELTOQUE_TIMEOUT_MS = 8000;
+
+// elTOQUE limita a 1 petición por segundo (responde 429 con un HTML de Cloudflare).
+// Cuando vence el TTL y varias peticiones coinciden, la que pierde reintenta una vez.
+export const ELTOQUE_RATE_LIMIT_RETRY_MS = 1500;
+
+// Zona horaria en la que elTOQUE reporta `date`/`hour`/`minutes`/`seconds`. Sin fijarla
+// el servidor interpretaría esa hora de pared en SU zona (UTC en Vercel) y el dato
+// quedaría corrido 4-5 h.
+export const ELTOQUE_TIMEZONE = "America/Havana";
 
 // Códigos de elTOQUE → códigos ISO 4217 del catálogo `Moneda`.
 // Las monedas ausentes de este mapa (BTC, TRX, USDT_TRC20, BNB…) se descartan:

--- a/src/lib/eltoque.ts
+++ b/src/lib/eltoque.ts
@@ -1,8 +1,11 @@
 import { prisma } from "@/lib/prisma";
 import {
   ELTOQUE_CURRENCY_MAP,
+  ELTOQUE_FORCE_MIN_MINUTES,
   ELTOQUE_FUENTE,
+  ELTOQUE_RATE_LIMIT_RETRY_MS,
   ELTOQUE_TIMEOUT_MS,
+  ELTOQUE_TIMEZONE,
   ELTOQUE_TRMI_URL,
   ELTOQUE_TTL_MINUTES,
 } from "@/constants/eltoque";
@@ -20,6 +23,10 @@ import {
  * negocio que consulta tras vencer el TTL sale a internet y guarda el snapshot; el resto
  * lee de `TasaReferenciaExterna` sin generar ni una petición a elTOQUE. Esto es lo que
  * mantiene el consumo dentro de la cuota del token (~5.000 peticiones/mes).
+ *
+ * El botón "Actualizar" de la UI llega aquí con `force`, que no salta la caché: solo baja
+ * el TTL exigido a `ELTOQUE_FORCE_MIN_MINUTES`. Así el usuario puede pedir un dato más
+ * nuevo (la TRMI se mueve en minutos) sin que aporrear el botón queme la cuota.
  *
  * Este es el único módulo que lee `ELTOQUE_API_TOKEN` y el único que escribe en
  * `TasaReferenciaExterna`. Nunca lanza: si la integración no está configurada o la
@@ -54,14 +61,76 @@ const desdeSnapshot = (
     .filter(([, tasa]) => typeof tasa === "number" && tasa > 0)
     .map(([monedaCode, tasa]) => ({ monedaCode, tasa }));
 
+  // Un snapshot sin monedas útiles no debería existir (el normalizador lo evita), pero
+  // si aparece hay que decir por qué: sin `motivo` la UI se quedaba en blanco sin avisar.
+  if (tasas.length === 0) return noDisponible("ERROR_UPSTREAM");
+
   return {
-    disponible: tasas.length > 0,
+    disponible: true,
     tasas,
-    actualizadoEn: snapshot.fechaDato.toISOString(),
+    // `fetchedAt` y no `fechaDato`: lo que le interesa al usuario es cuándo se consultó,
+    // y es un instante real (no una hora de pared que depende de la zona del servidor).
+    actualizadoEn: snapshot.fetchedAt.toISOString(),
     stale,
     fuente: "elTOQUE",
   };
 };
+
+/**
+ * Offset real de La Habana (CDT −04:00 / CST −05:00) en un instante dado, en ms.
+ * Se calcula con Intl para no hardcodear el horario de verano.
+ */
+function offsetZonaMs(instante: Date): number {
+  const partes = new Intl.DateTimeFormat("en-US", {
+    timeZone: ELTOQUE_TIMEZONE,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(instante);
+
+  const valor = (tipo: string) =>
+    Number(partes.find((p) => p.type === tipo)?.value ?? 0);
+
+  const comoUtc = Date.UTC(
+    valor("year"),
+    valor("month") - 1,
+    valor("day"),
+    valor("hour") % 24, // algunos motores reportan "24" para la medianoche
+    valor("minute"),
+    valor("second"),
+  );
+
+  return comoUtc - instante.getTime();
+}
+
+const dosDigitos = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * Interpreta la hora de pared que reporta elTOQUE como hora de La Habana y devuelve el
+ * instante real. Sin esto `new Date("2026-07-29T18:55:03")` se leía en la zona del
+ * servidor: en Vercel (UTC) el dato quedaba adelantado 4 h respecto al instante real y
+ * el panel lo mostraba 4 h atrasado a los usuarios en Cuba.
+ */
+function instanteDesdeHoraHabana(
+  date: string,
+  hour: number,
+  minutes: number,
+  seconds: number,
+): Date | null {
+  const comoUtc = new Date(
+    `${date}T${dosDigitos(hour)}:${dosDigitos(minutes)}:${dosDigitos(seconds)}Z`,
+  );
+  if (Number.isNaN(comoUtc.getTime())) return null;
+
+  // Dos pasadas: la primera aproxima el instante y la segunda evalúa el offset ahí, para
+  // acertar también en los días de cambio de horario.
+  const aproximado = new Date(comoUtc.getTime() - offsetZonaMs(comoUtc));
+  return new Date(comoUtc.getTime() - offsetZonaMs(aproximado));
+}
 
 /**
  * Normaliza la respuesta cruda de elTOQUE: traduce sus códigos a ISO 4217, descarta las
@@ -83,7 +152,9 @@ export function normalizarRespuestaEltoque(
   const tasas: Record<string, number> = {};
   for (const [codigoEltoque, valor] of Object.entries(parsed.data.tasas)) {
     const monedaCode = ELTOQUE_CURRENCY_MAP[codigoEltoque.toUpperCase()];
-    if (!monedaCode || !Number.isFinite(valor) || valor <= 0) continue;
+    if (!monedaCode) continue;
+    if (typeof valor !== "number" || !Number.isFinite(valor) || valor <= 0)
+      continue;
     tasas[monedaCode] = valor;
   }
 
@@ -98,25 +169,32 @@ export function normalizarRespuestaEltoque(
 
   const { date, hour, minutes, seconds } = parsed.data;
   const fechaDato = date
-    ? new Date(
-        `${date}T${String(hour ?? 0).padStart(2, "0")}:${String(minutes ?? 0).padStart(2, "0")}:${String(seconds ?? 0).padStart(2, "0")}`,
-      )
-    : new Date();
+    ? instanteDesdeHoraHabana(date, hour ?? 0, minutes ?? 0, seconds ?? 0)
+    : null;
 
-  return {
-    tasas,
-    fechaDato: Number.isNaN(fechaDato.getTime()) ? new Date() : fechaDato,
-  };
+  return { tasas, fechaDato: fechaDato ?? new Date() };
 }
 
-async function consultarEltoque(token: string) {
-  // Sin date_from/date_to elTOQUE devuelve la tasa de las últimas 24 h, que es justo lo
-  // que queremos. `no-store`: la caché es la BD, no queremos una segunda capa encima.
-  const res = await fetch(ELTOQUE_TRMI_URL, {
+async function pedirTrmi(token: string) {
+  // Sin date_from/date_to elTOQUE devuelve el valor vigente ahora, que es justo lo que
+  // queremos. `no-store`: la caché es la BD, no queremos una segunda capa encima.
+  return fetch(ELTOQUE_TRMI_URL, {
     headers: { Authorization: `Bearer ${token}` },
     cache: "no-store",
     signal: AbortSignal.timeout(ELTOQUE_TIMEOUT_MS),
   });
+}
+
+async function consultarEltoque(token: string) {
+  let res = await pedirTrmi(token);
+
+  // elTOQUE corta a 1 petición/segundo. Con varios negocios (o varios renders) chocando
+  // justo cuando vence el TTL, el que pierde recibía un 429 y la integración se veía
+  // caída aunque el token estuviera perfecto. Un único reintento espaciado lo resuelve.
+  if (res.status === 429) {
+    await new Promise((r) => setTimeout(r, ELTOQUE_RATE_LIMIT_RETRY_MS));
+    res = await pedirTrmi(token);
+  }
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -128,7 +206,53 @@ async function consultarEltoque(token: string) {
   return normalizarRespuestaEltoque(await res.json());
 }
 
-export async function getTasasReferencia(): Promise<ITasasReferenciaResponse> {
+/**
+ * Trae el dato fresco y lo persiste. Single-flight: si ya hay una consulta en curso en
+ * esta instancia, las demás esperan su resultado en vez de sumar peticiones (y escrituras)
+ * duplicadas contra el rate limit de 1/s.
+ */
+let refrescoEnCurso: Promise<SnapshotPersistido | null> | null = null;
+
+function refrescar(token: string): Promise<SnapshotPersistido | null> {
+  if (!refrescoEnCurso) {
+    refrescoEnCurso = (async () => {
+      try {
+        const fresco = await consultarEltoque(token);
+        if (!fresco) return null;
+
+        const fila = await prisma.tasaReferenciaExterna.create({
+          data: {
+            fuente: ELTOQUE_FUENTE,
+            tasas: fresco.tasas,
+            fechaDato: fresco.fechaDato,
+          },
+          select: { tasas: true, fechaDato: true, fetchedAt: true },
+        });
+        return fila;
+      } catch (error) {
+        console.error("[elTOQUE] Error al consultar la API:", error);
+        return null;
+      } finally {
+        refrescoEnCurso = null;
+      }
+    })();
+  }
+
+  return refrescoEnCurso;
+}
+
+interface OpcionesTasasReferencia {
+  /**
+   * Refresco manual del usuario (botón "Actualizar"): baja el TTL exigido a
+   * `ELTOQUE_FORCE_MIN_MINUTES` para poder traer un dato más nuevo sin dejar la cuota
+   * al descubierto.
+   */
+  force?: boolean;
+}
+
+export async function getTasasReferencia({
+  force = false,
+}: OpcionesTasasReferencia = {}): Promise<ITasasReferenciaResponse> {
   let ultimo: SnapshotPersistido | null = null;
 
   try {
@@ -141,10 +265,12 @@ export async function getTasasReferencia(): Promise<ITasasReferenciaResponse> {
     console.error("[elTOQUE] Error al leer la caché en BD:", error);
   }
 
+  const ttlMinutos = force ? ELTOQUE_FORCE_MIN_MINUTES : ELTOQUE_TTL_MINUTES;
+
   // Camino normal: el snapshot sigue vigente → cero llamadas externas.
   if (ultimo) {
     const edadMinutos = (Date.now() - ultimo.fetchedAt.getTime()) / 60000;
-    if (edadMinutos < ELTOQUE_TTL_MINUTES) {
+    if (edadMinutos < ttlMinutos) {
       return desdeSnapshot(ultimo, false);
     }
   }
@@ -157,21 +283,8 @@ export async function getTasasReferencia(): Promise<ITasasReferenciaResponse> {
       : noDisponible("NO_CONFIGURADO");
   }
 
-  try {
-    const fresco = await consultarEltoque(token);
-    if (fresco) {
-      await prisma.tasaReferenciaExterna.create({
-        data: {
-          fuente: ELTOQUE_FUENTE,
-          tasas: fresco.tasas,
-          fechaDato: fresco.fechaDato,
-        },
-      });
-      return desdeSnapshot({ ...fresco, fetchedAt: new Date() }, false);
-    }
-  } catch (error) {
-    console.error("[elTOQUE] Error al consultar la API:", error);
-  }
+  const fresco = await refrescar(token);
+  if (fresco) return desdeSnapshot(fresco, false);
 
   return ultimo ? desdeSnapshot(ultimo, true) : noDisponible("ERROR_UPSTREAM");
 }

--- a/src/schemas/tasaReferencia.ts
+++ b/src/schemas/tasaReferencia.ts
@@ -2,11 +2,13 @@ import { z } from "zod";
 
 // Respuesta cruda de elTOQUE. La spec OpenAPI no documenta el cuerpo del 200, así que
 // el parseo es deliberadamente tolerante: no exigimos claves concretas dentro de
-// `tasas` ni que vengan los campos de fecha. La normalización a ISO 4217 y el descarte
-// de monedas fuera del catálogo ocurren en `src/lib/eltoque.ts`.
+// `tasas` ni que vengan los campos de fecha. Los valores se declaran `unknown` a
+// propósito — la respuesta trae monedas que no usamos (BTC, TRX, USDT_TRC20…) y basta
+// que UNA venga en null o como string para que un `z.number()` tumbe todo el payload y
+// deje la integración caída. El filtrado por valor ocurre en `src/lib/eltoque.ts`.
 export const eltoqueRawSchema = z
   .object({
-    tasas: z.record(z.string(), z.number()),
+    tasas: z.record(z.string(), z.unknown()),
     date: z.string().optional(),
     hour: z.number().optional(),
     minutes: z.number().optional(),
@@ -29,7 +31,10 @@ export const tasasReferenciaResponseSchema = z.object({
   disponible: z.boolean(),
   motivo: tasasReferenciaMotivoSchema.optional(),
   tasas: z.array(tasaReferenciaSchema),
-  actualizadoEn: z.string().nullable(), // ISO — momento del dato según la fuente
+  // ISO — momento en que se consultó a elTOQUE, que es la única medida real de frescura:
+  // su `date`/`hour` no es la fecha de publicación de la tasa, es la hora a la que se le
+  // preguntó (la TRMI es una mediana móvil, siempre responde "el valor de ahora").
+  actualizadoEn: z.string().nullable(),
   // true ⇒ se sirve un snapshot viejo porque la fuente no respondió
   stale: z.boolean(),
   fuente: z.literal("elTOQUE"),

--- a/src/services/tasaReferenciaService.ts
+++ b/src/services/tasaReferenciaService.ts
@@ -1,8 +1,15 @@
 import axiosClient from "@/lib/axiosClient";
 import type { ITasasReferenciaResponse } from "@/schemas/tasaReferencia";
 
-export const getTasasReferencia =
-  async (): Promise<ITasasReferenciaResponse> => {
-    const res = await axiosClient.get("/api/tasas-referencia");
-    return res.data;
-  };
+/**
+ * @param force refresco pedido explícitamente por el usuario; permite traer un dato más
+ *   nuevo que el TTL normal de la caché (ver `src/constants/eltoque.ts`).
+ */
+export const getTasasReferencia = async (
+  force = false,
+): Promise<ITasasReferenciaResponse> => {
+  const res = await axiosClient.get("/api/tasas-referencia", {
+    params: force ? { force: 1 } : undefined,
+  });
+  return res.data;
+};


### PR DESCRIPTION
### Description

This pull request introduces improvements to TRMI handling and elTOQUE integration, including:

- Addition of a `force` parameter to allow fetching fresher TRMI data on demand without exceeding API quotas.
- Adjusted cache behavior by reducing the default TTL from 6 hours to 1 hour, optimizing updates for TRMI's real-time data.
- Improved date parsing to correctly handle Cuba's timezone, addressing offset issues caused by server time zones (e.g., UTC in Vercel).
- Enhanced the UI by adding relative time formatting and tooltips to better communicate TRMI data recency.
- Improved the API error handling mechanism with rate-limit retry logic to ensure smoother compliance with elTOQUE's 1 request/second limit.
- Strengthened the test suite to cover edge cases, including handling missing or invalid TRMI data.

Please review the changes and provide feedback for any necessary adjustments.