### PR TITLE
Fix: properly close movement dialogs after POST response

### DIFF
--- a/src/components/GestionInventario/dialogs/CreateMovimientoDialog.tsx
+++ b/src/components/GestionInventario/dialogs/CreateMovimientoDialog.tsx
@@ -186,6 +186,10 @@ export function CreateMovimientoDialog({
   const isExtraCurrency = mostrarCosto && monedaCompra !== monedaBase;
 
   const handleSave = async () => {
+    // Guarda contra doble submit: el botón se deshabilita por `saving`, pero
+    // en redes lentas dos clicks pueden entrar antes del re-render.
+    if (saving) return;
+
     const qty = parseFloat(cantidad.replace(",", "."));
     if (!qty || qty <= 0) {
       showMessage("Ingresa una cantidad válida", "warning");
@@ -206,6 +210,9 @@ export function CreateMovimientoDialog({
 
     if (tipo === "COMPRA" && formaPago === "EFECTIVO_CAJA" && costoRaw > 0) {
       const montoCompra = costoRaw * qty;
+      // Bloquear el botón ya desde la verificación de caja: es una petición
+      // más, y dejarlo habilitado durante ella permitía registrar dos veces.
+      setSaving(true);
       try {
         const disponible = await getEfectivoDisponibleCaja(user.localActual.id);
         const disponibleMoneda = disponible[monedaCompra] ?? 0;
@@ -213,7 +220,7 @@ export function CreateMovimientoDialog({
           confirmDialog(
             `La compra (${formatCurrency(montoCompra)} ${monedaCompra}) supera el efectivo disponible en caja (${formatCurrency(disponibleMoneda)} ${monedaCompra}). Se tomarán ${formatCurrency(disponibleMoneda)} ${monedaCompra} de caja y el resto se registrará como fondeo externo. ¿Continuar?`,
             () => ejecutarGuardado(qty, costoRaw),
-            undefined,
+            () => setSaving(false),
             { severity: "warning" },
           );
           return;
@@ -268,6 +275,8 @@ export function CreateMovimientoDialog({
       } else {
         showMessage("Movimiento registrado", "success");
       }
+      // onCreated cierra el diálogo de inmediato y recarga el inventario en
+      // segundo plano — no se espera el listado fresco para cerrar.
       onCreated();
     } catch (e) {
       console.error(e);
@@ -279,7 +288,12 @@ export function CreateMovimientoDialog({
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <Dialog
+        open={open}
+        onClose={saving ? undefined : onClose}
+        maxWidth="xs"
+        fullWidth
+      >
         <DialogTitle>
           Registrar movimiento — {producto.producto.nombre}
         </DialogTitle>

--- a/src/components/GestionInventario/hooks/useGestionInventario.ts
+++ b/src/components/GestionInventario/hooks/useGestionInventario.ts
@@ -123,9 +123,17 @@ export function useGestionInventario() {
       showMessage("Error al cargar el inventario", "error");
     } finally {
       setLoading(false);
-      setCreateMovTarget(null);
     }
   }, [tiendaId]);
+
+  // El diálogo se cierra en cuanto responde el POST del movimiento — nunca
+  // esperando el refetch del inventario. Si se espera, el formulario sigue
+  // vivo con el botón habilitado y en redes lentas admite un segundo submit
+  // que duplica el movimiento.
+  const handleMovimientoCreated = useCallback(() => {
+    setCreateMovTarget(null);
+    void reload();
+  }, [reload]);
 
   useEffect(() => {
     if (!loadingContext) reload();
@@ -461,7 +469,7 @@ export function useGestionInventario() {
     handleChangeQtySave,
     handleCreateProduct,
     handleDeleteProduct,
-    handleMovimientoCreated: reload,
+    handleMovimientoCreated,
 
     reload,
     tiendaId,

--- a/src/components/GestionInventario/movimientos/MovimientosView.tsx
+++ b/src/components/GestionInventario/movimientos/MovimientosView.tsx
@@ -12,6 +12,7 @@ import {
   TableHead,
   TableRow,
   CircularProgress,
+  LinearProgress,
   Stack,
   Alert,
   TextField,
@@ -100,6 +101,9 @@ export default function MovimientosView() {
   const [searchTerm, setSearchTerm] = useState("");
   const { user, loadingContext } = useAppContext();
   const [loadingData, setLoadingData] = useState(true);
+  // Solo la primera carga tapa la pantalla; los refetch posteriores muestran
+  // una barra de progreso sin desmontar la vista ni los diálogos abiertos.
+  const [primeraCarga, setPrimeraCarga] = useState(true);
   const [noLocalActual, setNoLocalActual] = useState(false);
   const [statsExpanded, setStatsExpanded] = useState(false);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
@@ -198,6 +202,7 @@ export default function MovimientosView() {
       setHasMoreData(false);
     } finally {
       setLoadingData(false);
+      setPrimeraCarga(false);
     }
   };
 
@@ -237,9 +242,8 @@ export default function MovimientosView() {
   };
 
   const crearMovimientosRecepción = async (prods) => {
-    setLoadingData(true);
-
     try {
+      setLoadingData(true);
       const localId = user.localActual.id;
       await cretateBatchMovimientos(
         {
@@ -265,15 +269,20 @@ export default function MovimientosView() {
           };
         }),
       );
-
-      fetchMovimientos(0);
-      fecthPendientesRecep();
     } catch (error) {
       console.error(error);
       showMessage("No se pudo crear los movimientos de entrada", "error");
-    } finally {
       setLoadingData(false);
+      return;
     }
+
+    // Ya está registrado: los refetch solo refrescan la vista y un fallo aquí
+    // no debe reportarse como si el movimiento hubiera fallado.
+    // fetchMovimientos apaga el indicador al terminar.
+    await Promise.all([
+      fetchMovimientos(0),
+      fecthPendientesRecep().catch((error) => console.error(error)),
+    ]);
   };
 
   const loadPendientesRecep = async (
@@ -361,7 +370,7 @@ export default function MovimientosView() {
     ...new Set(movimientos.map((m) => m.productoTiendaId)),
   ].length;
 
-  if (loadingContext || loadingData) {
+  if (loadingContext || (primeraCarga && loadingData)) {
     return (
       <Box
         display="flex"
@@ -724,6 +733,8 @@ export default function MovimientosView() {
         noPadding
         fullHeight
       >
+        {loadingData && <LinearProgress />}
+
         {/* Panel de filtros adicionales */}
         <Collapse in={filtersExpanded}>
           <Box sx={{ px: isMobile ? 1.5 : 3, pt: 2, pb: 2 }}>

--- a/src/components/GestionInventario/movimientos/addMovimientoDialog.tsx
+++ b/src/components/GestionInventario/movimientos/addMovimientoDialog.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect } from "react";
+import { FC, useState, useEffect, useRef } from "react";
 
 import {
   Box,
@@ -125,6 +125,9 @@ export const AddMovimientoDialog: FC<IProps> = ({
     [],
   );
   const [saving, setSaving] = useState(false);
+  // Espejo de `saving` en un ref: los handlers creados en el render del click
+  // ven el valor viejo del estado, y `handleClose` necesita el actual.
+  const savingRef = useRef(false);
   const { showMessage } = useMessageContext();
   const { confirmDialog, ConfirmDialogComponent } = useConfirmDialog();
   const [motivo, setMotivo] = useState("");
@@ -272,19 +275,31 @@ export const AddMovimientoDialog: FC<IProps> = ({
     }
   };
 
+  const updateSaving = (value: boolean) => {
+    savingRef.current = value;
+    setSaving(value);
+  };
+
+  const resetForm = () => {
+    setItemsProductos([]);
+    setMotivo("");
+    setProveedor(null);
+    setTipo("COMPRA");
+    setFormaPago("EXTERNO");
+    setCreandoProveedor(false);
+  };
+
   const handleClose = () => {
-    if (!saving) {
-      closeDialog();
-      setItemsProductos([]);
-      setMotivo("");
-      setProveedor(null);
-      setTipo("COMPRA");
-      setFormaPago("EXTERNO");
-      setCreandoProveedor(false);
-    }
+    if (savingRef.current) return;
+    closeDialog();
+    resetForm();
   };
 
   const handleGuardar = async () => {
+    // Guarda contra doble submit: el botón se deshabilita por `saving`, pero
+    // en redes lentas dos clicks pueden entrar antes del re-render.
+    if (savingRef.current) return;
+
     if (tipo === "COMPRA" && formaPago === "EFECTIVO_CAJA") {
       // Agrupar por moneda lo que esta compra le pediría a la caja, y
       // compararlo contra lo realmente disponible ANTES de registrar nada.
@@ -298,6 +313,9 @@ export const AddMovimientoDialog: FC<IProps> = ({
       }
 
       if (Object.keys(solicitadoPorMoneda).length > 0) {
+        // Bloquear el botón ya desde la verificación de caja: es una petición
+        // más, y dejarlo habilitado durante ella permitía guardar dos veces.
+        updateSaving(true);
         try {
           const disponible = await getEfectivoDisponibleCaja(
             user.localActual.id,
@@ -315,7 +333,7 @@ export const AddMovimientoDialog: FC<IProps> = ({
             confirmDialog(
               `Esta compra supera el efectivo disponible en caja (${detalle}). Se tomará lo disponible de caja y el resto se registrará como fondeo externo. ¿Continuar?`,
               () => ejecutarGuardado(),
-              undefined,
+              () => updateSaving(false),
               { severity: "warning" },
             );
             return;
@@ -332,7 +350,7 @@ export const AddMovimientoDialog: FC<IProps> = ({
   };
 
   const ejecutarGuardado = async () => {
-    setSaving(true);
+    updateSaving(true);
 
     try {
       const localId = user.localActual.id;
@@ -393,13 +411,17 @@ export const AddMovimientoDialog: FC<IProps> = ({
       } else {
         showMessage("Movimiento creado exitosamente", "success");
       }
-      handleClose();
-      fetchMovimientos();
+      // Cerrar en cuanto responde el POST y recargar el listado en segundo
+      // plano: esperar el listado fresco dejaba el formulario vivo y admitía
+      // un segundo submit que duplicaba el movimiento.
+      closeDialog();
+      resetForm();
+      void fetchMovimientos();
     } catch (error) {
       console.error(error);
       showMessage("No se pudo guardar el movimiento", "error");
     } finally {
-      setSaving(false);
+      updateSaving(false);
     }
   };
 


### PR DESCRIPTION
### Description

Adjusts the behavior of movement creation dialogs to close immediately after a successful POST response rather than waiting for a refetch, addressing issues with double submission in slow network conditions.

**Key changes:**
- **`useGestionInventario`**: Modified `reload()` logic to close the dialog immediately after handling movement creation, leaving refetch actions in the background.
- **`CreateMovimientoDialog`**: Introduced a guard for double submission and adjusted button behavior to remain disabled during prior validations.
- **`addMovimientoDialog`**: Added a `savingRef` to prevent stale state reads, separated form reset from closing logic, and made refetch non-blocking.
- **`MovimientosView`**: Switched to using `LinearProgress` for refetches, ensuring the main view and dialogs remain mounted; full-screen spinners now only appear on initial load.

### Checklist

- [ ] Tests have been updated to cover new behavior.
- [ ] Relevant documentation has been updated.
- [ ] Code has been reviewed for potential side effects or regressions.

--- 

Let me know if additional details are needed!