### PR TITLE
Improve API idempotency for safe retries and error consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Negocio (tenant root)
 
 ## Code Conventions
 
+- **Language: all new code is written in English** — identifiers, comments, JSDoc, error codes and log messages. Chat and markdown docs stay in Spanish. Parts of the codebase still carry Spanish names (`Producto`, `CreateMoviento`, `verificarPermisoUsuario`); keep using them where they already exist, but never introduce new Spanish identifiers or comments.
 - **Naming:** Components → PascalCase; functions/variables → camelCase; interfaces → PascalCase with `I` prefix
 - **Imports:** Use `@/` alias for all `src/` imports
 - **TypeScript:** Avoid `any`; justify with a comment when unavoidable. Strict mode is disabled.

--- a/docs/idempotencia.md
+++ b/docs/idempotencia.md
@@ -167,6 +167,31 @@ apareció nada nuevo. Los `+=` de `close` y `productos_tienda` son acumuladores
 locales del cálculo, no incrementos en base; `usuarios/[id]` y `notificaciones/[id]`
 se cortan solos con su guarda `deletedAt: null` y escriben valores absolutos.
 
+## Verificación dinámica (2026-07-31)
+
+Se ejecutaron reintentos reales — secuenciales y concurrentes, misma
+`Idempotency-Key` — contra un servidor local para COMPRA, AJUSTE_ENTRADA,
+AJUSTE_SALIDA, MERMA, VENTA (`syncId`), DEVOLUCION_VENTA y
+`DELETE /api/productos/[id]`, verificando en cada caso que el efecto en BD
+(existencia, filas de `MovimientoStock`/`Venta`) se aplica exactamente una
+vez. Dos hallazgos de esa pasada, ambos corregidos:
+
+- **`POST /api/venta/[tiendaId]/devolucion/[ventaId]`** comprobaba
+  `cantidadDisponible` (basado en lo ya devuelto) **antes** de mirar si la
+  clave ya se había procesado. Un reintento que llegaba después de que la
+  ejecución original ya había registrado la devolución se topaba con "0
+  disponibles" y recibía un 400 de negocio en vez del replay — la devolución
+  sí se había aplicado (una sola vez, sin duplicar), pero el reintento dejaba
+  de ser transparente. Se movió `findIdempotentResponse` justo después de
+  construir `claim`, antes de cualquier lectura que dependa del efecto ya
+  aplicado.
+- **`DELETE /api/productos/[id]`** devolvía 404 en un reenvío si esa tienda
+  era la última activa del producto: el borrado también marca `deletedAt` en
+  el `Producto` maestro, y el lookup inicial filtraba por `deletedAt: null`,
+  así que un reintento no encontraba nada. Ahora se busca el producto sin ese
+  filtro y, si ya está eliminado, se responde éxito (`duplicado: true`) en
+  vez de 404 — mismo criterio que el resto de endpoints protegidos.
+
 ### Qué NO cubre esto
 
 - **Doble click / doble submit humano.** La política del interceptor solo

--- a/docs/idempotencia.md
+++ b/docs/idempotencia.md
@@ -1,0 +1,140 @@
+# Idempotencia y reintentos
+
+## La regla
+
+`src/lib/axiosClient.ts` reintenta hasta 2 veces ante `ECONNABORTED` (timeout de
+30 s) y `ERR_NETWORK`. Reintentar es seguro **solo si repetir la petición no
+cambia el resultado**, así que la política es:
+
+- **GET / HEAD / OPTIONS / PUT / DELETE** → se reintentan siempre.
+- **POST / PATCH** → se reintentan **solo** si llevan el header
+  `Idempotency-Key`, o sea si el endpoint sabe reconocer el reenvío.
+
+Por qué importa: cuando axios aborta por timeout, **el servidor no cancela
+nada**. El handler original sigue vivo y termina commiteando igual, así que el
+reintento se solapa con una ejecución todavía en curso. Un POST reintentado a
+ciegas duplica datos (fue el bug de movimientos duplicados en redes lentas).
+
+## Cómo volver reintentable un POST
+
+Hay **una sola tabla de idempotencia para toda la app** (`IdempotencyKey`), no
+una por dominio. Los helpers están en `src/lib/idempotency.ts` y el patrón es
+claim primero, store al final, ambos dentro de la transacción del endpoint:
+
+```ts
+const claim = { key, scopeId: user.negocio.id, endpoint: "POST /api/movimiento" };
+
+// Camino feliz: ya se procesó, se responde lo mismo sin rehacer el trabajo.
+const replayed = await findIdempotentResponse<Payload>(claim);
+if (replayed) return NextResponse.json(replayed, { status: 200 });
+
+const response = await prisma.$transaction(async (tx) => {
+  await claimIdempotencyKey(tx, claim);
+  const result = await elTrabajo(tx);
+  await storeIdempotentResponse(tx, key, result);
+  return result;
+});
+```
+
+Por qué la clave se reserva **dentro** de la transacción: si el trabajo falla, el
+rollback también la libera y el usuario puede reintentar con la misma. Una clave
+escrita en una transacción aparte sobreviviría al fallo y haría que el siguiente
+intento responda "ya se hizo" sobre algo que nunca ocurrió — peor que el
+duplicado que se quería evitar.
+
+Tres detalles que hacen falta:
+
+- **`scopeId` y `endpoint` forman parte del match.** Una clave repetida contra
+  otro negocio u otra ruta se trata como desconocida, nunca se responde con
+  datos de otro tenant.
+- **La respuesta se guarda y se reproduce tal cual.** Un reenvío recibe lo mismo
+  que la ejecución original (por ejemplo las advertencias de caja), no un payload
+  vacío.
+- **Un reenvío devuelve éxito, no error**: la operación sí se aplicó.
+
+Cuando el `DuplicateRequestError` salta, la respuesta ya está almacenada: el
+índice único retiene a la segunda petición hasta que la primera commitea, así
+que solo llega ahí después de que aquella terminó.
+
+Para cubrir además el reintento **manual** del usuario tras un error, la clave
+tiene que sobrevivir a la petición — guardarla en un ref del componente y
+renovarla solo al éxito (`idempotencyKeyRef` en los diálogos de movimiento). El
+header por sí solo cubre únicamente el reintento automático de axios.
+
+La tabla crece una fila por operación protegida, así que se limpia sola: el cron
+`/api/crons/purge-expired-idempotency-keys` (diario, 04:00 UTC, declarado en
+`vercel.json`) borra las claves de más de `IDEMPOTENCY_KEY_TTL_HOURS` (24 h).
+Borrarlas es seguro — cualquier petición que aún pudiera reproducirlas se dio por
+vencida hace rato, y una petición nueva trae una clave nueva.
+
+`Venta.syncId` es un mecanismo equivalente anterior a este helper, y sigue en uso
+en `/api/venta`.
+
+## El patrón para operaciones que revierten efectos
+
+Devolver stock, revertir pagos o cerrar un período **no son idempotentes**:
+repetirlos aplica el efecto dos veces. La protección correcta es siempre la
+misma — **bloquear la fila y re-verificar la precondición como primera operación
+de la transacción**:
+
+```ts
+await prisma.$transaction(async (tx) => {
+  if (!(await lockExistingRow(tx, "Venta", ventaId))) return;
+  // ... el trabajo, seguro de correr una sola vez
+});
+```
+
+La segunda ejecución espera a que la primera termine, ve la fila ya eliminada (o
+ya cerrada) y sale **antes de tocar nada**. Helpers en `src/lib/dbLocks.ts`:
+
+- `lockExistingRow` — la fila debe existir.
+- `lockActiveRow` — además no debe estar soft-deleted (`deletedAt IS NULL`).
+
+Cuando no hay fila que bloquear (crear el primer período de una tienda), la
+herramienta es un **advisory lock** por clave de negocio:
+`pg_advisory_xact_lock(hashtext(tiendaId))`. `FOR UPDATE` no sirve ahí: no
+bloquea nada si el conjunto viene vacío.
+
+> **Ojo con el orden en soft deletes.** Marcar `deletedAt` *antes* del trabajo
+> parece un claim atómico elegante, pero `CreateMoviento` resuelve el
+> `ProductoTienda` filtrando por `deletedAt: null`: marcarlo primero le hace no
+> encontrar la fila y **crear una nueva** en vez de descontar la existencia. Por
+> eso se bloquea y verifica al principio, y se marca al final.
+
+## Auditoría de PUT/DELETE (2026-07-30)
+
+La regla deja 23 PUT y 20 DELETE reintentándose. **PUT y DELETE son idempotentes
+solo si el handler está escrito así** — el verbo no lo garantiza. Se auditaron
+los handlers que aplican deltas (`increment`/`decrement`) o crean registros.
+Los seis con hallazgos ya fueron corregidos con el patrón de arriba:
+
+| Endpoint | Qué pasaba | Corrección |
+|---|---|---|
+| `DELETE /api/productos/[id]` | Sin transacción envolvente y con `CreateMoviento` fuera de tx: un reintento solapado registraba un **segundo AJUSTE_SALIDA / CONSIGNACION_DEVOLUCION** → existencia negativa y kardex con dos salidas. | Todo en una transacción (`CreateMoviento` acepta ahora la tx del llamador) con `lockActiveRow` al inicio y el `deletedAt` al final. |
+| `PUT /api/cierre/[tiendaId]/open` | `FOR UPDATE` no protege sin período previo ni revela el que otra tx acaba de insertar → **dos períodos abiertos**. | Advisory lock por tienda antes de la lectura. |
+| `DELETE /api/venta/[...]/[ventaId]`, `DELETE /api/app/venta/[...]/[ventaId]`, `DELETE /api/venta/[...]/producto/[...]` | Revertían stock con `increment` y solo se salvaban porque el `delete` final lanzaba P2025 y revertía la transacción entera — protección accidental y dependiente del orden de las operaciones. | `lockExistingRow` al inicio: se sale antes de trabajar, en vez de deshacer al final. |
+| `PUT /api/cierre/[...]/close` | La guarda de `fechaFin` estaba fuera de la transacción; solo lo salvaban los `@@unique` de `ResumenMonedaCierre` y `ProductoProveedorLiquidacion`. | `FOR UPDATE` sobre el período y re-verificación de `fechaFin` bajo el lock (`PERIOD_ALREADY_CLOSED` → 400). |
+
+Verificado con ejecuciones concurrentes reales contra la base local: en los tres
+mecanismos (claim de producto, apertura de período, bloqueo de fila) el efecto se
+aplica exactamente una vez.
+
+### Segunda pasada
+
+Se revisaron además los handlers con efectos que la primera búsqueda no cubría
+—envío de correo, notificaciones, llamadas externas y acumuladores en JS— y no
+apareció nada nuevo. Los `+=` de `close` y `productos_tienda` son acumuladores
+locales del cálculo, no incrementos en base; `usuarios/[id]` y `notificaciones/[id]`
+se cortan solos con su guarda `deletedAt: null` y escriben valores absolutos.
+
+### Qué NO cubre esto
+
+- **Doble click / doble submit humano.** La política del interceptor solo
+  gobierna reintentos de red. Los formularios se protegen aparte (guard de
+  `saving` + clave estable en un ref).
+- **Los POST sin clave** (`/api/movimiento/import`, `/api/movimiento/rechazo` y
+  el resto): ya no se reintentan solos, así que el vector de red está cerrado,
+  pero no están blindados contra un reenvío deliberado. Adoptar el helper
+  cuando haga falta.
+- **Los flujos internos que llaman `CreateMoviento`** (venta, devolución,
+  desagregación, import) no llevan clave: no vienen de un cliente que reintente.

--- a/docs/idempotencia.md
+++ b/docs/idempotencia.md
@@ -70,6 +70,46 @@ vencida hace rato, y una petición nueva trae una clave nueva.
 `Venta.syncId` es un mecanismo equivalente anterior a este helper, y sigue en uso
 en `/api/venta`.
 
+### Cuando hay una transición de estado, no hace falta clave
+
+Si la operación tiene una precondición de estado natural (`PENDIENTE` →
+`RECHAZADO`), el compare-and-set es más simple y no depende de que el cliente
+mande nada: se actualiza con la precondición en el `where` y se comprueba el
+`count`.
+
+```ts
+const claimed = await tx.movimientoStock.updateMany({
+  where: { id: movimientoId, state: "PENDIENTE" },
+  data: { state: "RECHAZADO" },
+});
+if (claimed.count === 0) return; // otra ejecución ya lo reclamó
+```
+
+Así está resuelto `POST /api/movimiento/rechazo`, y protege también contra el
+doble click, no solo contra el reintento de red.
+
+### Excepción: trabajo no atómico
+
+`POST /api/movimiento/import` procesa en chunks de 50, cada uno con su propia
+transacción, y admite éxito parcial a propósito. Como no hay una única
+transacción del trabajo, la clave se reserva antes, en su propia escritura, y
+**no se libera si la importación falla**: liberarla dejaría reimportar los chunks
+que sí entraron. Ante un fallo el usuario relanza la importación y el cliente
+genera una clave nueva — una decisión deliberada, no un reintento ciego.
+
+### Cobertura de las operaciones de movimientos
+
+Los diez handlers que crean `MovimientoStock` están protegidos:
+
+| Handler | Mecanismo |
+|---|---|
+| `POST /api/movimiento` | clave de idempotencia |
+| `POST /api/movimiento/import` | clave de idempotencia (reservada aparte, ver arriba) |
+| `POST /api/movimiento/rechazo` | compare-and-set sobre `state` |
+| `POST /api/venta/[tiendaId]/devolucion/[ventaId]` | clave de idempotencia |
+| `POST /api/venta/[tiendaId]/[cierreId]`, `POST /api/app/venta/[...]` | `Venta.syncId` |
+| Los tres `DELETE` de venta y `DELETE /api/productos/[id]` | bloquear y re-verificar (ver abajo) |
+
 ## El patrón para operaciones que revierten efectos
 
 Devolver stock, revertir pagos o cerrar un período **no son idempotentes**:

--- a/prisma/migrations/20260730150000_idempotency_key/migration.sql
+++ b/prisma/migrations/20260730150000_idempotency_key/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable
+ALTER TABLE "MovimientoStock" ADD COLUMN     "batchId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "MovimientoStock_batchId_idx" ON "MovimientoStock"("batchId");
+
+-- CreateTable
+CREATE TABLE "IdempotencyKey" (
+    "key" TEXT NOT NULL,
+    "scopeId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "response" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IdempotencyKey_pkey" PRIMARY KEY ("key")
+);
+
+-- CreateIndex
+CREATE INDEX "IdempotencyKey_scopeId_idx" ON "IdempotencyKey"("scopeId");
+
+-- CreateIndex
+CREATE INDEX "IdempotencyKey_createdAt_idx" ON "IdempotencyKey"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -576,8 +576,43 @@ model MovimientoStock {
 
   state MovimientoState @default(APROBADO)
 
+  // Groups every movement created by a single request, so a batch can be traced
+  // back as one operation. Holds the request's idempotency key. Null for
+  // movements created by internal flows (sale, disaggregation, refund, import)
+  // and for everything recorded before batching existed.
+  batchId String?
+
   @@index([productoTiendaId])
   @@index([fecha])
+  @@index([batchId])
+}
+
+// Generic idempotency store, shared by every endpoint that needs it — no
+// per-domain table.
+//
+// A request that mutates data can arrive twice: the axios interceptor retries on
+// timeout/network error, and aborting the client does NOT cancel the handler, so
+// the original execution is still running and commits anyway. Endpoints claim
+// their key inside their own transaction, which turns the retry into a unique
+// constraint violation instead of duplicated data. See src/lib/idempotency.ts.
+model IdempotencyKey {
+  key String @id // Client-generated, stable across retries of the same operation
+
+  // Tenant that owns the key (negocioId). A key is only ever matched within its
+  // own scope, so one tenant can never read back another tenant's response.
+  scopeId String
+
+  // Route that claimed the key: reusing the same key elsewhere must not return
+  // an unrelated response.
+  endpoint String
+
+  // Response of the original execution, replayed verbatim on a retry.
+  response Json?
+
+  createdAt DateTime @default(now())
+
+  @@index([scopeId])
+  @@index([createdAt]) // TTL cleanup
 }
 
 // =====================

--- a/src/app/api/app/venta/[tiendaId]/[periodoId]/[ventaId]/route.ts
+++ b/src/app/api/app/venta/[tiendaId]/[periodoId]/[ventaId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { MovimientoTipo } from "@prisma/client";
+import { lockExistingRow } from "@/lib/dbLocks";
 import { isMovimientoBaja } from "@/utils/tipoMovimiento";
 import { getSessionFromRequest } from "@/utils/authFromRequest";
 import { verificarPermisoUsuario } from "@/utils/permisos_back";
@@ -89,6 +90,13 @@ export async function DELETE(
 
     // Ejecutar la reversión completa en una transacción
     await prisma.$transaction(async (tx) => {
+      // Lock the sale and confirm it is still there before reverting stock:
+      // repeating the reversal would add the quantities back twice. See
+      // lockExistingRow.
+      if (!(await lockExistingRow(tx, "Venta", ventaId))) {
+        return;
+      }
+
       // Existencia resultante por productoTienda: una misma venta puede generar
       // varios movimientos sobre el mismo producto (VENTA + DESAGREGACION_*),
       // así que la existencia anterior de cada ajuste es el resultado del ajuste

--- a/src/app/api/cierre/[tiendaId]/[cierreId]/close/route.ts
+++ b/src/app/api/cierre/[tiendaId]/[cierreId]/close/route.ts
@@ -202,6 +202,22 @@ export async function PUT(
       );
 
     const [periodoCerrado] = await prisma.$transaction(async (tx) => {
+      // The "already closed" check above runs outside the transaction, so two
+      // concurrent closes both passed it. Here the period is locked and the
+      // check repeated under that lock: the second execution waits, sees the
+      // fechaFin already written and aborts before duplicating the per-currency
+      // summaries and the consignment settlements.
+      const [lockedPeriod] = await tx.$queryRaw<
+        Array<{ fechaFin: Date | null }>
+      >`
+        SELECT "fechaFin" FROM "CierrePeriodo"
+        WHERE "id" = ${ultimoPeriodo.id}
+        FOR UPDATE
+      `;
+      if (!lockedPeriod || lockedPeriod.fechaFin) {
+        throw new Error("PERIOD_ALREADY_CLOSED");
+      }
+
       // Eliminar desgloses de billetes temporales antes de cerrar
       await tx.cashBreakdownCierre.deleteMany({
         where: { cierrePeriodoId: ultimoPeriodo.id },
@@ -417,6 +433,14 @@ export async function PUT(
 
     return NextResponse.json(periodoCerrado, { status: 201 });
   } catch (error) {
+    // A concurrent close won the race; the period is already closed.
+    if (error instanceof Error && error.message === "PERIOD_ALREADY_CLOSED") {
+      return NextResponse.json(
+        { error: "El período ya fue cerrado" },
+        { status: 400 },
+      );
+    }
+
     console.error("❌ Error al cerrar el período:", error);
     return NextResponse.json(
       { error: "Error al cerrar el período" },

--- a/src/app/api/cierre/[tiendaId]/open/route.ts
+++ b/src/app/api/cierre/[tiendaId]/open/route.ts
@@ -4,31 +4,41 @@ import { prisma } from "@/lib/prisma";
 // 3. Cerrar el período actual y abrir uno nuevo
 export async function PUT(
   req: NextRequest,
-  { params }: { params: Promise<{ tiendaId: string }> }
+  { params }: { params: Promise<{ tiendaId: string }> },
 ) {
   try {
-    
     const { tiendaId } = await params;
 
     if (!tiendaId) {
       return NextResponse.json(
         { error: "Tienda ID es requerido" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
     // Usar transacción con lock para prevenir race conditions
     const nuevoPeriodo = await prisma.$transaction(async (tx) => {
-      // Buscar el último período con lock FOR UPDATE para prevenir duplicados
-      const ultimoPeriodos = await tx.$queryRaw<Array<{ id: string; fechaFin: Date | null }>>`
-        SELECT "id", "fechaFin" FROM "CierrePeriodo" 
-        WHERE "tiendaId" = ${tiendaId} 
-        ORDER BY "fechaInicio" DESC 
-        LIMIT 1 
+      // Advisory lock per store: serialises concurrent openings for this store.
+      // `FOR UPDATE` alone is not enough — it locks nothing when the store has no
+      // periods yet, and under READ COMMITTED it does not reveal the period
+      // another transaction just inserted and has not committed, so two
+      // simultaneous openings could leave two open periods.
+      // Released when the transaction ends (xact_lock).
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${tiendaId})::bigint)`;
+
+      // Under the lock this read can no longer be stale.
+      const ultimoPeriodos = await tx.$queryRaw<
+        Array<{ id: string; fechaFin: Date | null }>
+      >`
+        SELECT "id", "fechaFin" FROM "CierrePeriodo"
+        WHERE "tiendaId" = ${tiendaId}
+        ORDER BY "fechaInicio" DESC
+        LIMIT 1
         FOR UPDATE
       `;
 
-      const ultimoPeriodo = ultimoPeriodos.length > 0 ? ultimoPeriodos[0] : null;
+      const ultimoPeriodo =
+        ultimoPeriodos.length > 0 ? ultimoPeriodos[0] : null;
 
       // Verificar si ya existe un período abierto
       if (ultimoPeriodo && !ultimoPeriodo.fechaFin) {
@@ -45,20 +55,18 @@ export async function PUT(
     });
 
     return NextResponse.json(nuevoPeriodo, { status: 201 });
-
   } catch (error) {
-    
     // Manejar el error específico de período ya abierto
     if (error instanceof Error && error.message === "PERIODO_ABIERTO") {
       return NextResponse.json(
         { error: "Último período continúa abierto" },
-        { status: 400 }
+        { status: 400 },
       );
     }
-    
+
     return NextResponse.json(
       { error: "Error al abrir el período" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/crons/purge-expired-idempotency-keys/route.ts
+++ b/src/app/api/crons/purge-expired-idempotency-keys/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server";
+import {
+  purgeExpiredIdempotencyKeys,
+  IDEMPOTENCY_KEY_TTL_HOURS,
+} from "@/lib/idempotency";
+
+/**
+ * Drops idempotency keys past their TTL. The table grows one row per protected
+ * operation, so it needs a sweep to stay bounded.
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const deleted = await purgeExpiredIdempotencyKeys();
+    console.log(
+      `🧹 Idempotency: ${deleted} claves de más de ${IDEMPOTENCY_KEY_TTL_HOURS}h eliminadas`,
+    );
+    return Response.json({ success: true, deleted });
+  } catch (error) {
+    console.error("❌ Idempotency: error purgando claves vencidas:", error);
+    return Response.json(
+      { success: false, error: "Error al purgar claves de idempotencia" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/movimiento/import/route.ts
+++ b/src/app/api/movimiento/import/route.ts
@@ -1,7 +1,19 @@
 import { ImportarExcelMovimiento } from "@/lib/movimiento/import";
 import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  claimIdempotencyKey,
+  findIdempotentResponse,
+  storeIdempotentResponse,
+  DuplicateRequestError,
+} from "@/lib/idempotency";
+import { IDEMPOTENCY_KEY_HEADER } from "@/constants/idempotency";
+
+const IDEMPOTENCY_ENDPOINT = "POST /api/movimiento/import";
 
 export async function POST(req: NextRequest) {
+  let claim: { key: string; scopeId: string; endpoint: string } | undefined;
+
   try {
     const body = await req.json();
     const { data, items } = body;
@@ -9,42 +21,79 @@ export async function POST(req: NextRequest) {
     // Validación básica de la estructura de datos
     if (!data || !items) {
       return NextResponse.json(
-        { 
+        {
           success: false,
           message: "Datos requeridos faltantes",
-          errorCause: "Se requieren 'data' e 'items' en el cuerpo de la petición"
+          errorCause:
+            "Se requieren 'data' e 'items' en el cuerpo de la petición",
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
     // Validar estructura de data
     if (!data.usuarioId || !data.negocioId || !data.localId) {
       return NextResponse.json(
-        { 
+        {
           success: false,
           message: "Datos de negocio incompletos",
-          errorCause: "usuarioId, negocioId y localId son obligatorios"
+          errorCause: "usuarioId, negocioId y localId son obligatorios",
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
     // Validar que items sea un array
     if (!Array.isArray(items) || items.length === 0) {
       return NextResponse.json(
-        { 
+        {
           success: false,
           message: "Items inválidos",
-          errorCause: "items debe ser un array no vacío"
+          errorCause: "items debe ser un array no vacío",
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
+    const idempotencyKey = req.headers.get(IDEMPOTENCY_KEY_HEADER);
+    if (!idempotencyKey) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Falta la clave de idempotencia",
+          errorCause: `Se requiere la cabecera ${IDEMPOTENCY_KEY_HEADER}`,
+        },
+        { status: 400 },
+      );
+    }
+    claim = {
+      key: idempotencyKey,
+      scopeId: data.negocioId,
+      endpoint: IDEMPOTENCY_ENDPOINT,
+    };
+
+    const replayed = await findIdempotentResponse(claim);
+    if (replayed) {
+      return NextResponse.json(
+        { ...replayed, duplicado: true },
+        { status: 200 },
+      );
+    }
+
+    // A diferencia del resto de endpoints, la clave NO se reserva dentro de la
+    // transacción del trabajo: la importación procesa en chunks de 50, cada uno
+    // con su propia transacción, y admite éxito parcial a propósito. Se reserva
+    // antes, en su propia escritura.
+    //
+    // Y NO se libera si la importación falla, justamente por ese éxito parcial:
+    // liberarla dejaría reimportar los chunks que sí entraron. Ante un fallo, el
+    // usuario vuelve a lanzar la importación y el cliente genera una clave
+    // nueva, que es una decisión deliberada suya y no un reintento ciego.
+    await claimIdempotencyKey(prisma, claim);
 
     // Llamar a la función de importación
     const resultado = await ImportarExcelMovimiento(data, items);
+    await storeIdempotentResponse(prisma, claim.key, resultado);
 
     // Retornar el resultado
     if (resultado.success) {
@@ -52,30 +101,45 @@ export async function POST(req: NextRequest) {
     } else {
       return NextResponse.json(resultado, { status: 400 });
     }
-
   } catch (error) {
-    console.error('💥 Error en endpoint de importación:', error);
-    
+    // Otra petición con la misma clave ya importó este archivo.
+    if (error instanceof DuplicateRequestError && claim) {
+      const stored = await findIdempotentResponse(claim);
+      return stored
+        ? NextResponse.json({ ...stored, duplicado: true }, { status: 200 })
+        : NextResponse.json(
+            {
+              success: false,
+              message: "La importación ya está en curso",
+              errorCause: "Otra petición con la misma clave sigue procesando",
+            },
+            { status: 409 },
+          );
+    }
+
+    console.error("💥 Error en endpoint de importación:", error);
+
     // Manejar errores específicos
     if (error instanceof SyntaxError) {
       return NextResponse.json(
-        { 
+        {
           success: false,
           message: "Error en formato de datos",
-          errorCause: "El JSON enviado no es válido"
+          errorCause: "El JSON enviado no es válido",
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
     // Error genérico
     return NextResponse.json(
-      { 
+      {
         success: false,
         message: "Error interno del servidor",
-        errorCause: error instanceof Error ? error.message : "Error desconocido"
+        errorCause:
+          error instanceof Error ? error.message : "Error desconocido",
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -85,9 +149,9 @@ export async function OPTIONS() {
   return new NextResponse(null, {
     status: 200,
     headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
     },
   });
-} 
+}

--- a/src/app/api/movimiento/rechazo/route.ts
+++ b/src/app/api/movimiento/rechazo/route.ts
@@ -7,43 +7,60 @@ export async function POST(req: Request) {
     const { movimientoId, motivo } = await req.json();
 
     if (!movimientoId) {
-      return NextResponse.json({ error: "ID de movimiento requerido" }, { status: 400 });
+      return NextResponse.json(
+        { error: "ID de movimiento requerido" },
+        { status: 400 },
+      );
     }
 
     // 1. Buscar el movimiento original (debe ser un TRASPASO_SALIDA PENDIENTE)
     const movimientoOriginal = await prisma.movimientoStock.findUnique({
       where: { id: movimientoId },
       include: {
-        productoTienda: true
-      }
+        productoTienda: true,
+      },
     });
 
     if (!movimientoOriginal) {
-      return NextResponse.json({ error: "Movimiento no encontrado" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Movimiento no encontrado" },
+        { status: 404 },
+      );
     }
 
-    if (movimientoOriginal.state !== 'PENDIENTE' || movimientoOriginal.tipo !== MovimientoTipo.TRASPASO_SALIDA) {
-      return NextResponse.json({ error: "El movimiento no puede ser rechazado en su estado actual" }, { status: 400 });
+    if (
+      movimientoOriginal.state !== "PENDIENTE" ||
+      movimientoOriginal.tipo !== MovimientoTipo.TRASPASO_SALIDA
+    ) {
+      return NextResponse.json(
+        { error: "El movimiento no puede ser rechazado en su estado actual" },
+        { status: 400 },
+      );
     }
 
-    await prisma.$transaction(async (tx) => {
-      // 2. Marcar el movimiento original como RECHAZADO
-      // Nota: Asegúrate de que 'RECHAZADO' sea un valor válido en tu esquema Prisma para el campo 'state'
-      // Si no existe, podrías usar un campo motivo o similar, pero aquí asumimos que state puede ser RECHAZADO
-      await tx.movimientoStock.update({
-        where: { id: movimientoId },
-        data: { 
-          state: 'RECHAZADO',
-          motivo: motivo ? `RECHAZADO: ${motivo}` : 'RECHAZADO'
-        }
+    const alreadyRejected = await prisma.$transaction(async (tx) => {
+      // 2. Marcar el movimiento original como RECHAZADO.
+      // The PENDIENTE check above runs outside the transaction, so two
+      // concurrent rejections both passed it and returned the stock twice.
+      // This update is the compare-and-set: only the execution that finds the
+      // movement still PENDIENTE claims it, the other one gets count 0 and
+      // leaves without touching stock.
+      const claimed = await tx.movimientoStock.updateMany({
+        where: { id: movimientoId, state: "PENDIENTE" },
+        data: {
+          state: "RECHAZADO",
+          motivo: motivo ? `RECHAZADO: ${motivo}` : "RECHAZADO",
+        },
       });
+
+      if (claimed.count === 0) return true;
 
       // 3. Devolver el stock a la tienda de origen
       // La tienda de origen es movimientoOriginal.tiendaId
       // El productoTiendaId es movimientoOriginal.productoTiendaId
-      
+
       const productoTiendaOrigen = await tx.productoTienda.findUnique({
-        where: { id: movimientoOriginal.productoTiendaId }
+        where: { id: movimientoOriginal.productoTiendaId },
       });
 
       if (!productoTiendaOrigen) {
@@ -57,9 +74,9 @@ export async function POST(req: Request) {
         where: { id: productoTiendaOrigen.id },
         data: {
           existencia: {
-            increment: cantidadRechazada
-          }
-        }
+            increment: cantidadRechazada,
+          },
+        },
       });
 
       // 4. Crear un movimiento de entrada por devolución de rechazo
@@ -71,20 +88,28 @@ export async function POST(req: Request) {
           tiendaId: movimientoOriginal.tiendaId,
           usuarioId: movimientoOriginal.usuarioId, // O el usuario que rechaza si se pasara
           existenciaAnterior: existenciaAnterior,
-          motivo: `DEVOLUCIÓN POR RECHAZO: ${motivo || 'Sin motivo'}`,
+          motivo: `DEVOLUCIÓN POR RECHAZO: ${motivo || "Sin motivo"}`,
           referenciaId: movimientoOriginal.id,
           costoUnitario: movimientoOriginal.costoUnitario,
-          costoTotal: (movimientoOriginal.costoUnitario || 0) * cantidadRechazada,
-        }
+          costoTotal:
+            (movimientoOriginal.costoUnitario || 0) * cantidadRechazada,
+        },
       });
+
+      return false;
     });
 
-    return NextResponse.json({ success: true }, { status: 200 });
+    // Resend of an already-processed rejection: success for the client, the
+    // movement is rejected and the stock is back.
+    return NextResponse.json(
+      { success: true, ...(alreadyRejected && { duplicado: true }) },
+      { status: 200 },
+    );
   } catch (error) {
     console.error("Error al rechazar movimiento:", error);
     return NextResponse.json(
       { error: "Error al procesar el rechazo", details: error.message },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/movimiento/route.ts
+++ b/src/app/api/movimiento/route.ts
@@ -1,4 +1,11 @@
-import { CreateMoviento } from "@/lib/movimiento";
+import { CreateMoviento, MOVIMIENTO_TX_OPTIONS } from "@/lib/movimiento";
+import {
+  claimIdempotencyKey,
+  findIdempotentResponse,
+  storeIdempotentResponse,
+  DuplicateRequestError,
+} from "@/lib/idempotency";
+import { IDEMPOTENCY_KEY_HEADER } from "@/constants/idempotency";
 import { prisma } from "@/lib/prisma";
 import { MovimientoTipo } from "@prisma/client";
 import { NextResponse } from "next/server";
@@ -6,7 +13,14 @@ import { startOfNextDay } from "@/utils/date";
 import { getSession } from "@/utils/auth";
 import { verificarPermisoUsuario } from "@/utils/permisos_back";
 import { movimientoBatchCreateSchema } from "@/schemas/movimiento";
-import type { ITipoMovimiento } from "@/schemas/movimiento";
+import type {
+  ITipoMovimiento,
+  IAdvertenciaCajaInsuficiente,
+} from "@/schemas/movimiento";
+
+const IDEMPOTENCY_ENDPOINT = "POST /api/movimiento";
+
+type MovimientoResponse = { advertenciasCaja: IAdvertenciaCajaInsuficiente[] };
 
 // Permiso requerido para crear cada tipo de movimiento manual. Mantener en
 // sync con MovimientoTipoCreableEnum (src/schemas/movimiento.ts).
@@ -167,9 +181,23 @@ export async function GET(req: Request) {
 }
 
 export async function POST(req: Request) {
+  // Declared outside the try so the duplicate-request handler can look the
+  // stored response up again.
+  let claim: { key: string; scopeId: string; endpoint: string } | undefined;
+
   try {
     const session = await getSession();
     const user = session.user;
+
+    // Required: without a key this POST is not replayable, and the axios
+    // interceptor would refuse to retry it anyway.
+    const idempotencyKey = req.headers.get(IDEMPOTENCY_KEY_HEADER);
+    if (!idempotencyKey) {
+      return NextResponse.json(
+        { error: `Falta la cabecera ${IDEMPOTENCY_KEY_HEADER}` },
+        { status: 400 },
+      );
+    }
 
     const body = await req.json();
     const parsed = movimientoBatchCreateSchema.safeParse(body);
@@ -203,14 +231,54 @@ export async function POST(req: Request) {
       );
     }
 
-    // usuarioId nunca se toma del cliente: siempre el usuario autenticado.
-    const { advertenciasCaja } = await CreateMoviento(
-      { ...data, usuarioId: user.id },
-      items,
-    );
+    claim = {
+      key: idempotencyKey,
+      scopeId: user.negocio.id,
+      endpoint: IDEMPOTENCY_ENDPOINT,
+    };
 
-    return NextResponse.json({ advertenciasCaja }, { status: 201 });
+    // Fast path: this batch was already processed, so replay its response
+    // instead of doing the work again. The overlapping case — a retry that
+    // arrives while the first execution is still running — is caught by the
+    // unique index inside the transaction below.
+    const replayed = await findIdempotentResponse<MovimientoResponse>(claim);
+    if (replayed) {
+      return NextResponse.json(
+        { ...replayed, duplicado: true },
+        { status: 200 },
+      );
+    }
+
+    const response = await prisma.$transaction(async (tx) => {
+      await claimIdempotencyKey(tx, claim);
+
+      // usuarioId nunca se toma del cliente: siempre el usuario autenticado.
+      const { advertenciasCaja } = await CreateMoviento(
+        { ...data, usuarioId: user.id, batchId: idempotencyKey },
+        items,
+        tx,
+      );
+
+      const payload = { advertenciasCaja };
+      await storeIdempotentResponse(tx, idempotencyKey, payload);
+      return payload;
+    }, MOVIMIENTO_TX_OPTIONS);
+
+    return NextResponse.json(response, { status: 201 });
   } catch (error) {
+    // A concurrent request with the same key got there first. It only reaches
+    // this point after that request committed — the unique index holds the
+    // second one until then — so its response is already stored.
+    if (error instanceof DuplicateRequestError && claim) {
+      const stored = await findIdempotentResponse<MovimientoResponse>(claim);
+      return stored
+        ? NextResponse.json({ ...stored, duplicado: true }, { status: 200 })
+        : NextResponse.json(
+            { error: "La operación ya está en curso" },
+            { status: 409 },
+          );
+    }
+
     console.error(error);
 
     return NextResponse.json(

--- a/src/app/api/productos/[id]/route.ts
+++ b/src/app/api/productos/[id]/route.ts
@@ -143,13 +143,25 @@ export async function DELETE(
     }
 
     const producto = await prisma.producto.findUnique({
-      where: { id, negocioId: user.negocio.id, deletedAt: null },
+      where: { id, negocioId: user.negocio.id },
     });
 
     if (!producto) {
       return NextResponse.json(
         { error: "Producto no encontrado" },
         { status: 404 },
+      );
+    }
+
+    // El maestro solo se marca eliminado cuando esta fue la última tienda
+    // activa, así que si ya está eliminado no queda ninguna fila de
+    // ProductoTienda activa para reintentar. Responder éxito, no 404: DELETE
+    // siempre se reintenta ante fallos de red, y un reenvío que llega después
+    // de que el borrado ya terminó no debe leerse como un error.
+    if (producto.deletedAt) {
+      return NextResponse.json(
+        { message: "Producto eliminado de esta tienda", duplicado: true },
+        { status: 200 },
       );
     }
 

--- a/src/app/api/productos/[id]/route.ts
+++ b/src/app/api/productos/[id]/route.ts
@@ -3,7 +3,8 @@ import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { getSession } from "@/utils/auth";
 import { verificarPermisoUsuario } from "@/utils/permisos_back";
-import { CreateMoviento } from "@/lib/movimiento";
+import { CreateMoviento, MOVIMIENTO_TX_OPTIONS } from "@/lib/movimiento";
+import { lockActiveRow } from "@/lib/dbLocks";
 
 const MOTIVO_ELIMINACION = "Eliminación de producto";
 
@@ -185,47 +186,74 @@ export async function DELETE(
       }
     }
 
-    if (productoTienda.existencia > 0) {
-      await CreateMoviento(
-        {
-          tipo: productoTienda.proveedorId
-            ? "CONSIGNACION_DEVOLUCION"
-            : "AJUSTE_SALIDA",
-          tiendaId,
-          usuarioId: user.id,
-          motivo: MOTIVO_ELIMINACION,
-          ...(productoTienda.proveedorId && {
-            proveedorId: productoTienda.proveedorId,
-          }),
-        },
-        [{ productoId: id, cantidad: productoTienda.existencia }],
-      );
-    }
+    // One transaction: the outbound adjustment and the soft delete describe the
+    // same fact. Applying one without the other leaves phantom stock (flagged as
+    // deleted but never discounted) or an adjustment with no deletion.
+    const alreadyDeleted = await prisma.$transaction(async (tx) => {
+      // Lock the row and confirm it is still active. Two concurrent executions —
+      // the axios retry overlapping the original request, still alive because
+      // the server cancels nothing — meet here: the second one waits, sees the
+      // row already flagged and leaves without recording a second adjustment.
+      //
+      // `deletedAt` is written at the end and not here on purpose: CreateMoviento
+      // resolves the ProductoTienda filtering by `deletedAt: null`, so flagging
+      // it earlier would make it miss the row and create a new one instead of
+      // discounting the existing stock.
+      if (!(await lockActiveRow(tx, "ProductoTienda", productoTienda.id))) {
+        return true;
+      }
 
-    await prisma.productoTienda.update({
-      where: { id: productoTienda.id },
-      data: { deletedAt: new Date() },
-    });
+      if (productoTienda.existencia > 0) {
+        await CreateMoviento(
+          {
+            tipo: productoTienda.proveedorId
+              ? "CONSIGNACION_DEVOLUCION"
+              : "AJUSTE_SALIDA",
+            tiendaId,
+            usuarioId: user.id,
+            motivo: MOTIVO_ELIMINACION,
+            ...(productoTienda.proveedorId && {
+              proveedorId: productoTienda.proveedorId,
+            }),
+          },
+          [{ productoId: id, cantidad: productoTienda.existencia }],
+          tx,
+        );
+      }
 
-    // Si ya no queda ninguna tienda activa para este producto, liberar
-    // también el Producto maestro (mismo patrón de soft delete + renombrado
-    // para liberar el nombre único por negocio).
-    const tiendasActivasRestantes = await prisma.productoTienda.count({
-      where: { productoId: id, deletedAt: null },
-    });
-
-    if (tiendasActivasRestantes === 0) {
-      await prisma.producto.update({
-        where: { id },
-        data: {
-          deletedAt: new Date(),
-          nombre: `${producto.nombre}_ELIMINADO_${Date.now()}`,
-        },
+      // Only now flag the row: the outbound adjustment is already recorded.
+      await tx.productoTienda.update({
+        where: { id: productoTienda.id },
+        data: { deletedAt: new Date() },
       });
-    }
 
+      // Si ya no queda ninguna tienda activa para este producto, liberar
+      // también el Producto maestro (mismo patrón de soft delete + renombrado
+      // para liberar el nombre único por negocio).
+      const tiendasActivasRestantes = await tx.productoTienda.count({
+        where: { productoId: id, deletedAt: null },
+      });
+
+      if (tiendasActivasRestantes === 0) {
+        await tx.producto.update({
+          where: { id },
+          data: {
+            deletedAt: new Date(),
+            nombre: `${producto.nombre}_ELIMINADO_${Date.now()}`,
+          },
+        });
+      }
+
+      return false;
+    }, MOVIMIENTO_TX_OPTIONS);
+
+    // Resend of an already-applied deletion: success from the client's point of
+    // view, the product is effectively out of the store.
     return NextResponse.json(
-      { message: "Producto eliminado de esta tienda" },
+      {
+        message: "Producto eliminado de esta tienda",
+        ...(alreadyDeleted && { duplicado: true }),
+      },
       { status: 200 },
     );
   } catch (error) {

--- a/src/app/api/venta/[tiendaId]/[cierreId]/[ventaId]/producto/[ventaProductoId]/route.ts
+++ b/src/app/api/venta/[tiendaId]/[cierreId]/[ventaId]/producto/[ventaProductoId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { MovimientoTipo } from "@prisma/client";
+import { lockExistingRow } from "@/lib/dbLocks";
 import { getSession } from "@/utils/auth";
 import { verificarPermisoUsuario } from "@/utils/permisos_back";
 import {
@@ -127,6 +128,15 @@ export async function DELETE(
     );
 
     await prisma.$transaction(async (tx) => {
+      // Lock the sale line and confirm it is still there before returning stock:
+      // repeating the return would increment the quantity twice. The second
+      // execution waits here and finds it already deleted.
+      if (
+        !(await lockExistingRow(tx, "VentaProducto", ventaProductoId))
+      ) {
+        return;
+      }
+
       // 1. Actualizar existencia del producto (devolver al inventario).
       // Se lee la existencia previa dentro de la transacción para dejarla
       // registrada en el movimiento y no romper el kardex.

--- a/src/app/api/venta/[tiendaId]/[cierreId]/[ventaId]/route.ts
+++ b/src/app/api/venta/[tiendaId]/[cierreId]/[ventaId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma"; // Asegúrate de tener la configuración de Prisma en `lib/prisma.ts`
 import { MovimientoTipo } from "@prisma/client";
+import { lockExistingRow } from "@/lib/dbLocks";
 import { isMovimientoBaja } from "@/utils/tipoMovimiento";
 import { getSession } from "@/utils/auth";
 import { verificarPermisoUsuario } from "@/utils/permisos_back";
@@ -70,6 +71,15 @@ export async function DELETE(
     // Eliminamos la venta y sus dependencias con prodoctos
 
     await prisma.$transaction(async (tx) => {
+      // Before reverting anything: lock the sale and confirm it is still there.
+      // Reverting stock is not idempotent, so a second execution — the network
+      // retry overlapping the original, still running — would add the quantities
+      // back twice. With the lock, the second one waits, finds the sale already
+      // deleted and leaves without touching anything.
+      if (!(await lockExistingRow(tx, "Venta", ventaId))) {
+        return;
+      }
+
       // Existencia resultante por productoTienda: una misma venta puede generar
       // varios movimientos sobre el mismo producto (VENTA + DESAGREGACION_*),
       // así que la existencia anterior de cada ajuste es el resultado del ajuste

--- a/src/app/api/venta/[tiendaId]/devolucion/[ventaId]/route.ts
+++ b/src/app/api/venta/[tiendaId]/devolucion/[ventaId]/route.ts
@@ -6,16 +6,42 @@ import { devolucionVentaCreateSchema } from "@/schemas/devolucionVenta";
 import type { ITasaSnapshot } from "@/schemas/tasaCambio";
 import { convertToBase } from "@/lib/currency";
 import { DEFAULT_CURRENCY } from "@/constants/billDenominations";
-import { CreateMoviento } from "@/lib/movimiento";
+import { CreateMoviento, MOVIMIENTO_TX_OPTIONS } from "@/lib/movimiento";
+import {
+  claimIdempotencyKey,
+  findIdempotentResponse,
+  storeIdempotentResponse,
+  DuplicateRequestError,
+} from "@/lib/idempotency";
+import { IDEMPOTENCY_KEY_HEADER } from "@/constants/idempotency";
+
+const IDEMPOTENCY_ENDPOINT = "POST /api/venta/devolucion";
 
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ tiendaId: string; ventaId: string }> },
 ) {
+  // Declared outside the try so the duplicate-request handler can look the
+  // stored response up again.
+  let claim: { key: string; scopeId: string; endpoint: string } | undefined;
+
   try {
     const { tiendaId, ventaId } = await params;
     const session = await getSession();
     const user = session.user;
+
+    const idempotencyKey = req.headers.get(IDEMPOTENCY_KEY_HEADER);
+    if (!idempotencyKey) {
+      return NextResponse.json(
+        { error: `Falta la cabecera ${IDEMPOTENCY_KEY_HEADER}` },
+        { status: 400 },
+      );
+    }
+    claim = {
+      key: idempotencyKey,
+      scopeId: user.negocio.id,
+      endpoint: IDEMPOTENCY_ENDPOINT,
+    };
 
     if (
       !verificarPermisoUsuario(
@@ -135,32 +161,63 @@ export async function POST(
     const tasaUsada =
       monedaPrecio === monedaBase ? 1 : (tasasHistoricas[monedaPrecio] ?? 1);
 
-    await CreateMoviento(
-      {
-        tipo: "DEVOLUCION_VENTA",
-        tiendaId,
-        usuarioId: user.id,
-        referenciaId: ventaId,
-        motivo: motivo || "Devolución de venta",
-      },
-      [
+    // Devolver es acumulativo —"devolver N unidades"— así que repetirlo devuelve
+    // el doble. No hay transición de estado que sirva de guarda natural, de ahí
+    // la clave de idempotencia.
+    const replayed = await findIdempotentResponse(claim);
+    if (replayed) {
+      return NextResponse.json(
+        { ...replayed, duplicado: true },
+        { status: 200 },
+      );
+    }
+
+    await prisma.$transaction(async (tx) => {
+      await claimIdempotencyKey(tx, claim);
+
+      await CreateMoviento(
         {
-          productoId: vp.producto.productoId,
-          cantidad,
-          costoTotal,
-          montoReembolso,
-          monedaOriginal: monedaPrecio,
-          montoOriginal: vp.precio * cantidad,
-          tasaUsada,
-          ...(vp.producto.proveedorId && {
-            proveedorId: vp.producto.proveedorId,
-          }),
+          tipo: "DEVOLUCION_VENTA",
+          tiendaId,
+          usuarioId: user.id,
+          referenciaId: ventaId,
+          motivo: motivo || "Devolución de venta",
+          batchId: claim.key,
         },
-      ],
-    );
+        [
+          {
+            productoId: vp.producto.productoId,
+            cantidad,
+            costoTotal,
+            montoReembolso,
+            monedaOriginal: monedaPrecio,
+            montoOriginal: vp.precio * cantidad,
+            tasaUsada,
+            ...(vp.producto.proveedorId && {
+              proveedorId: vp.producto.proveedorId,
+            }),
+          },
+        ],
+        tx,
+      );
+
+      await storeIdempotentResponse(tx, claim.key, { ok: true });
+    }, MOVIMIENTO_TX_OPTIONS);
 
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (error) {
+    // Otra petición con la misma clave llegó primero: la devolución ya quedó
+    // registrada, así que para el cliente esto es un éxito.
+    if (error instanceof DuplicateRequestError && claim) {
+      const stored = await findIdempotentResponse(claim);
+      return stored
+        ? NextResponse.json({ ...stored, duplicado: true }, { status: 200 })
+        : NextResponse.json(
+            { error: "La devolución ya está en curso" },
+            { status: 409 },
+          );
+    }
+
     console.error("Error al registrar devolución de venta:", error);
     return NextResponse.json(
       { error: "Error al registrar la devolución" },

--- a/src/app/api/venta/[tiendaId]/devolucion/[ventaId]/route.ts
+++ b/src/app/api/venta/[tiendaId]/devolucion/[ventaId]/route.ts
@@ -43,6 +43,19 @@ export async function POST(
       endpoint: IDEMPOTENCY_ENDPOINT,
     };
 
+    // Fast path primero: si esta clave ya se procesó, responder lo mismo sin
+    // reevaluar nada. Importa el orden — `cantidadDisponible` más abajo
+    // refleja el efecto que la ejecución original ya aplicó, así que un
+    // reintento que llegara hasta ahí vería "0 disponibles" y recibiría un
+    // 400 de negocio en vez del replay, sobre una devolución que sí ocurrió.
+    const replayed = await findIdempotentResponse(claim);
+    if (replayed) {
+      return NextResponse.json(
+        { ...replayed, duplicado: true },
+        { status: 200 },
+      );
+    }
+
     if (
       !verificarPermisoUsuario(
         user.permisos,
@@ -163,15 +176,7 @@ export async function POST(
 
     // Devolver es acumulativo —"devolver N unidades"— así que repetirlo devuelve
     // el doble. No hay transición de estado que sirva de guarda natural, de ahí
-    // la clave de idempotencia.
-    const replayed = await findIdempotentResponse(claim);
-    if (replayed) {
-      return NextResponse.json(
-        { ...replayed, duplicado: true },
-        { status: 200 },
-      );
-    }
-
+    // la clave de idempotencia (chequeada arriba, antes de `cantidadDisponible`).
     await prisma.$transaction(async (tx) => {
       await claimIdempotencyKey(tx, claim);
 

--- a/src/components/GestionInventario/dialogs/CreateMovimientoDialog.tsx
+++ b/src/components/GestionInventario/dialogs/CreateMovimientoDialog.tsx
@@ -18,7 +18,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { IProductoTiendaV2 } from "@/schemas/producto";
 import { IProveedor } from "@/schemas/proveedor";
 import { ILocal } from "@/schemas/tienda";
@@ -33,6 +33,7 @@ import { useAppContext } from "@/context/AppContext";
 import { useMessageContext } from "@/context/MessageContext";
 import { IFormaPagoCompra } from "@/schemas/movimiento";
 import { formatAdvertenciasCaja, formatCurrency } from "@/utils/formatters";
+import { generateUUID } from "@/utils/uuid";
 import useConfirmDialog from "@/components/confirmDialog";
 import { FormaPagoCompraSelect } from "@/components/GestionInventario/FormaPagoCompraSelect";
 
@@ -104,6 +105,10 @@ export function CreateMovimientoDialog({
   const [monedaCompra, setMonedaCompra] = useState<string>(monedaBase);
   const [formaPago, setFormaPago] = useState<IFormaPagoCompra>("EXTERNO");
   const [saving, setSaving] = useState(false);
+  // Identifies the batch on the server. Preserved across retries of the same
+  // save — including the one the user triggers after a network error — and
+  // renewed only once the movement is recorded.
+  const idempotencyKeyRef = useRef<string | null>(null);
 
   const monedasParaCompra = useMemo(() => {
     const lista = [monedaBase];
@@ -237,6 +242,7 @@ export function CreateMovimientoDialog({
 
   const ejecutarGuardado = async (qty: number, costoRaw: number) => {
     setSaving(true);
+    idempotencyKeyRef.current ??= generateUUID();
     try {
       const { advertenciasCaja } = await cretateBatchMovimientos(
         {
@@ -269,12 +275,15 @@ export function CreateMovimientoDialog({
               }),
           },
         ],
+        idempotencyKeyRef.current,
       );
       if (advertenciasCaja?.length) {
         showMessage(formatAdvertenciasCaja(advertenciasCaja), "warning");
       } else {
         showMessage("Movimiento registrado", "success");
       }
+      // Batch recorded: the next save needs a fresh key.
+      idempotencyKeyRef.current = null;
       // onCreated cierra el diálogo de inmediato y recarga el inventario en
       // segundo plano — no se espera el listado fresco para cerrar.
       onCreated();

--- a/src/components/GestionInventario/movimientos/addMovimientoDialog.tsx
+++ b/src/components/GestionInventario/movimientos/addMovimientoDialog.tsx
@@ -66,6 +66,7 @@ import {
 import { ILocal } from "@/schemas/tienda";
 import { getLocales } from "@/services/localesService";
 import { usePermisos } from "@/utils/permisos_front";
+import { generateUUID } from "@/utils/uuid";
 
 interface IProductoMovimiento {
   nombre: string;
@@ -128,6 +129,10 @@ export const AddMovimientoDialog: FC<IProps> = ({
   // Espejo de `saving` en un ref: los handlers creados en el render del click
   // ven el valor viejo del estado, y `handleClose` necesita el actual.
   const savingRef = useRef(false);
+  // Identifies the batch on the server. Kept while the form holds its content,
+  // so a user retry after a network error does not record the movement twice;
+  // renewed only once the save succeeds.
+  const idempotencyKeyRef = useRef<string | null>(null);
   const { showMessage } = useMessageContext();
   const { confirmDialog, ConfirmDialogComponent } = useConfirmDialog();
   const [motivo, setMotivo] = useState("");
@@ -287,6 +292,7 @@ export const AddMovimientoDialog: FC<IProps> = ({
     setTipo("COMPRA");
     setFormaPago("EXTERNO");
     setCreandoProveedor(false);
+    idempotencyKeyRef.current = null;
   };
 
   const handleClose = () => {
@@ -351,6 +357,7 @@ export const AddMovimientoDialog: FC<IProps> = ({
 
   const ejecutarGuardado = async () => {
     updateSaving(true);
+    idempotencyKeyRef.current ??= generateUUID();
 
     try {
       const localId = user.localActual.id;
@@ -404,6 +411,7 @@ export const AddMovimientoDialog: FC<IProps> = ({
               }),
           };
         }),
+        idempotencyKeyRef.current,
       );
 
       if (advertenciasCaja?.length) {

--- a/src/constants/idempotency.ts
+++ b/src/constants/idempotency.ts
@@ -1,0 +1,9 @@
+/**
+ * Standard header (IETF draft, popularised by Stripe) marking a request as
+ * safe to replay: the server recognises the resend and does not apply it twice.
+ *
+ * Lives here, free of dependencies, because both sides need it — the browser
+ * axios client and the API routes — and neither should pull the other's imports
+ * (next-auth on one side, Prisma on the other).
+ */
+export const IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";

--- a/src/lib/axiosClient.ts
+++ b/src/lib/axiosClient.ts
@@ -1,9 +1,50 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { signOut } from "next-auth/react";
+import { IDEMPOTENCY_KEY_HEADER } from "@/constants/idempotency";
 
 export interface RetryConfig extends AxiosRequestConfig {
   _retryCount?: number;
 }
+
+export { IDEMPOTENCY_KEY_HEADER };
+
+const MAX_RETRIES = 2;
+
+// Idempotent by HTTP semantics: repeating them does not change the outcome, so
+// retrying needs no coordination with the server.
+// NOTE: PUT and DELETE only qualify if the handler is written that way — a
+// DELETE that applies a delta (reverting stock, recording an adjustment) is not
+// idempotent no matter what the verb promises. See docs/idempotencia.md.
+const IDEMPOTENT_METHODS = new Set(["get", "head", "options", "put", "delete"]);
+
+/**
+ * Blindly retrying a POST duplicates data: the client times out, but the server
+ * cancels nothing, so the original request stays alive and commits anyway (this
+ * caused duplicated stock movements on slow networks).
+ *
+ * Hence the safe-by-default policy: POST/PATCH are retried only when they carry
+ * an idempotency key, meaning the endpoint knows how to recognise the resend
+ * and not apply it twice.
+ */
+const canRetry = (config: RetryConfig): boolean => {
+  const method = (config.method ?? "get").toLowerCase();
+  if (IDEMPOTENT_METHODS.has(method)) return true;
+
+  const headers = config.headers ?? {};
+  return Boolean(
+    headers[IDEMPOTENCY_KEY_HEADER] ??
+    headers[IDEMPOTENCY_KEY_HEADER.toLowerCase()],
+  );
+};
+
+/**
+ * Exponential backoff with jitter. Without the jitter, several tills coming back
+ * from the same outage retry in lockstep and hammer each other.
+ */
+const retryDelayMs = (attempt: number): number => {
+  const base = 1000 * 2 ** (attempt - 1); // 1s, 2s
+  return base + Math.random() * 500;
+};
 
 const axiosClient = axios.create({
   timeout: 30000,
@@ -12,7 +53,8 @@ const axiosClient = axios.create({
   },
 });
 
-// Retry interceptor — network errors and timeouts only, max 2 retries
+// Retry interceptor — network errors and timeouts only, and only when repeating
+// the request is safe (see canRetry).
 axiosClient.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -21,11 +63,16 @@ axiosClient.interceptors.response.use(
     if (
       (error.code === "ECONNABORTED" || error.code === "ERR_NETWORK") &&
       config &&
-      (config._retryCount ?? 0) < 2
+      (config._retryCount ?? 0) < MAX_RETRIES &&
+      canRetry(config)
     ) {
       config._retryCount = (config._retryCount ?? 0) + 1;
-      console.log(`🔄 Reintentando petición (intento ${config._retryCount}/2)...`);
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      console.log(
+        `🔄 Reintentando petición (intento ${config._retryCount}/${MAX_RETRIES})...`,
+      );
+      await new Promise((resolve) =>
+        setTimeout(resolve, retryDelayMs(config._retryCount)),
+      );
       return axiosClient(config);
     }
 
@@ -39,12 +86,14 @@ axiosClient.interceptors.response.use(
     if (status === 403) {
       const url = error.config?.url ?? "recurso desconocido";
       return Promise.reject(
-        new Error(`Acceso denegado a ${url}. Por favor asigne los permisos necesarios.`)
+        new Error(
+          `Acceso denegado a ${url}. Por favor asigne los permisos necesarios.`,
+        ),
       );
     }
 
     return Promise.reject(error);
-  }
+  },
 );
 
 export default axiosClient;

--- a/src/lib/dbLocks.ts
+++ b/src/lib/dbLocks.ts
@@ -1,0 +1,56 @@
+import { Prisma } from "@prisma/client";
+
+/**
+ * Locks a row by id inside the transaction and reports whether it still exists.
+ * Returns `false` when another transaction already deleted it.
+ *
+ * What it is for: an operation that reverses effects (returning stock, undoing
+ * payments) is not idempotent, so repeating it applies the effect twice. The
+ * real-world case is a network retry overlapping the original request, which is
+ * still running because the server does not cancel anything when the client
+ * aborts.
+ *
+ * Called as the first operation of the transaction, the second execution waits
+ * for the first one to finish and then sees the row gone, so it bails out before
+ * touching anything. Without the lock it would read the previous state and
+ * duplicate the work.
+ *
+ * The table name is interpolated into the SQL: that is why it is a closed union
+ * and can never come from user input. The id is parameterised.
+ */
+export type LockableTable =
+  "Venta" | "VentaProducto" | "CierrePeriodo" | "ProductoTienda";
+
+export const lockExistingRow = async (
+  tx: Prisma.TransactionClient,
+  table: LockableTable,
+  id: string,
+): Promise<boolean> => {
+  const rows = await tx.$queryRawUnsafe<Array<{ id: string }>>(
+    `SELECT "id" FROM "${table}" WHERE "id" = $1 FOR UPDATE`,
+    id,
+  );
+  return rows.length > 0;
+};
+
+/**
+ * Same as `lockExistingRow`, but for tables with soft delete: returns `false`
+ * if the row was already flagged as deleted.
+ *
+ * Used when the work being protected needs the row to stay *active* while it
+ * runs — for instance the outbound adjustment when deleting a product, which
+ * resolves the `ProductoTienda` by `deletedAt: null`. Hence the lock-and-check
+ * up front, with `deletedAt` written only at the end: flagging it earlier would
+ * make the work itself stop finding the row.
+ */
+export const lockActiveRow = async (
+  tx: Prisma.TransactionClient,
+  table: LockableTable,
+  id: string,
+): Promise<boolean> => {
+  const rows = await tx.$queryRawUnsafe<Array<{ id: string }>>(
+    `SELECT "id" FROM "${table}" WHERE "id" = $1 AND "deletedAt" IS NULL FOR UPDATE`,
+    id,
+  );
+  return rows.length > 0;
+};

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -1,0 +1,129 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "./prisma";
+
+/**
+ * Generic idempotency support, reusable by any endpoint — there is no
+ * per-domain table.
+ *
+ * Why it is needed: a mutating request can arrive twice. The axios interceptor
+ * retries on timeout/network error, and aborting the client does not cancel the
+ * handler, so the original execution keeps running and commits anyway. Without a
+ * shared key, the retry applies the same work a second time.
+ *
+ * Usage — claim first, store last, both inside the endpoint's own transaction:
+ *
+ *   const response = await prisma.$transaction(async (tx) => {
+ *     await claimIdempotencyKey(tx, { key, scopeId, endpoint });
+ *     const result = await doTheWork(tx);
+ *     await storeIdempotentResponse(tx, key, result);
+ *     return result;
+ *   });
+ *
+ * Claiming inside the transaction is what makes this safe: if the work fails,
+ * the rollback releases the key too, so the caller can retry with the same one.
+ * A key written in a separate transaction would survive a failed handler and
+ * make the next attempt answer "already done" for something that never
+ * happened — worse than the duplicate it was meant to prevent.
+ */
+
+/**
+ * How long a key stays around. It only has to outlive the retries of its own
+ * request — the axios interceptor gives up after ~1 minute, and a user retrying
+ * by hand takes minutes at most. A day is a wide margin that also keeps the
+ * recent history readable while debugging.
+ */
+export const IDEMPOTENCY_KEY_TTL_HOURS = 24;
+
+/** Thrown when the key was already claimed by an earlier execution. */
+export class DuplicateRequestError extends Error {
+  constructor(readonly key: string) {
+    super(`Request ${key} was already processed`);
+    this.name = "DuplicateRequestError";
+  }
+}
+
+interface IdempotencyClaim {
+  key: string;
+  /** Tenant that owns the key, normally negocioId. */
+  scopeId: string;
+  /** Route claiming the key, e.g. "POST /api/movimiento". */
+  endpoint: string;
+}
+
+/**
+ * Reserves the key as the first operation of the transaction, so a concurrent
+ * retry collides on the unique index before redoing any work.
+ *
+ * @throws {DuplicateRequestError} if another execution already claimed it.
+ */
+export const claimIdempotencyKey = async (
+  tx: Prisma.TransactionClient,
+  { key, scopeId, endpoint }: IdempotencyClaim,
+): Promise<void> => {
+  try {
+    await tx.idempotencyKey.create({ data: { key, scopeId, endpoint } });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw new DuplicateRequestError(key);
+    }
+    throw error;
+  }
+};
+
+/**
+ * Records the response of the original execution so a later retry can replay it
+ * verbatim instead of answering with an empty payload.
+ */
+export const storeIdempotentResponse = async (
+  tx: Prisma.TransactionClient,
+  key: string,
+  response: unknown,
+): Promise<void> => {
+  await tx.idempotencyKey.update({
+    where: { key },
+    data: { response: response as Prisma.InputJsonValue },
+  });
+};
+
+/**
+ * Looks up the response of an already-processed request. Scope and endpoint are
+ * part of the match: a key replayed against another tenant or another route is
+ * treated as unknown rather than answered with someone else's response.
+ *
+ * Returns `undefined` when the key is unknown, and `null` when it was claimed
+ * but holds no response yet — meaning the original execution is still in flight.
+ */
+export const findIdempotentResponse = async <
+  T extends object = Record<string, unknown>,
+>({
+  key,
+  scopeId,
+  endpoint,
+}: IdempotencyClaim): Promise<T | null | undefined> => {
+  const stored = await prisma.idempotencyKey.findFirst({
+    where: { key, scopeId, endpoint },
+    select: { response: true },
+  });
+  if (!stored) return undefined;
+  return (stored.response as T | null) ?? null;
+};
+
+/**
+ * Drops keys past their TTL. The table grows one row per protected operation, so
+ * without this it never stops growing.
+ *
+ * Deleting an expired key is safe: any request that could still be replaying it
+ * gave up long ago, and a brand new request carries a brand new key.
+ */
+export const purgeExpiredIdempotencyKeys = async (): Promise<number> => {
+  const expiresBefore = new Date(
+    Date.now() - IDEMPOTENCY_KEY_TTL_HOURS * 60 * 60 * 1000,
+  );
+  const { count } = await prisma.idempotencyKey.deleteMany({
+    where: { createdAt: { lt: expiresBefore } },
+  });
+  return count;
+};

--- a/src/lib/movimiento/index.ts
+++ b/src/lib/movimiento/index.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "../prisma";
 import { isMovimientoBaja } from "@/utils/tipoMovimiento";
 import { calcularCPP, requiereCPP } from "../cpp-calculator";
@@ -27,6 +28,10 @@ type ICreateMovimientoData = {
   proveedorId?: string;
   destinationId?: string;
   formaPago?: IFormaPagoCompra;
+  // Tags every movement of this call as one batch, so the group can be traced
+  // back as a single operation. Callers reached through the HTTP endpoint pass
+  // the request's idempotency key; internal flows leave it unset.
+  batchId?: string;
 };
 
 // Opciones de transacción para creación de movimientos. El loop procesa cada item
@@ -35,11 +40,19 @@ type ICreateMovimientoData = {
 // agota el default de Prisma (5000 ms) bajo el transaction pooler. Antes solo la rama
 // COMPRA+EFECTIVO_CAJA tenía timeout; ahora aplica a todos los tipos.
 // Ver PERFORMANCE_ISSUES.md (P2.1).
-const MOVIMIENTO_TX_OPTIONS = { timeout: 20000, maxWait: 10000 };
+export const MOVIMIENTO_TX_OPTIONS = { timeout: 20000, maxWait: 10000 };
 
+/**
+ * @param externalTx the caller's transaction. Pass it when creating the movement
+ * has to be atomic together with other writes — for instance the outbound
+ * adjustment when deleting a product, which must apply exactly once alongside
+ * the soft delete. Without it the caller would open a second connection and
+ * deadlock against its own locks.
+ */
 export const CreateMoviento = async (
   data: ICreateMovimientoData,
   items: IMovimientoCreate[],
+  externalTx?: Prisma.TransactionClient,
 ) => {
   const {
     tipo,
@@ -50,6 +63,7 @@ export const CreateMoviento = async (
     proveedorId,
     destinationId,
     formaPago,
+    batchId,
   } = data;
 
   // Fetch exchange rates once for the whole batch
@@ -72,316 +86,321 @@ export const CreateMoviento = async (
     tipo === "COMPRA" && formaPago === "EFECTIVO_CAJA";
   const advertenciasCaja: IAdvertenciaCajaInsuficiente[] = [];
 
-  await prisma.$transaction(
-    async (tx) => {
-      // Lock de aplicación por tienda: serializa transacciones concurrentes que
-      // comprometen efectivo de caja para que no lean el mismo "disponible"
-      // antes de que la otra confirme (evitaría dejar la caja en negativo).
-      // Se libera solo al terminar esta transacción (xact_lock).
-      if (esCompraEfectivoCaja) {
-        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${tiendaId})::bigint)`;
-      }
+  const run = async (tx: Prisma.TransactionClient) => {
+    // Lock de aplicación por tienda: serializa transacciones concurrentes que
+    // comprometen efectivo de caja para que no lean el mismo "disponible"
+    // antes de que la otra confirme (evitaría dejar la caja en negativo).
+    // Se libera solo al terminar esta transacción (xact_lock).
+    if (esCompraEfectivoCaja) {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${tiendaId})::bigint)`;
+    }
 
-      // Efectivo realmente disponible por moneda, calculado DENTRO de la
-      // transacción y bajo el lock anterior — ya no puede quedar stale frente
-      // a otra compra concurrente. Si la compra supera lo disponible, se cubre
-      // lo que se pueda de caja y el resto queda como fondeo externo (MIXTO).
-      const restanteDisponible: Record<string, number> = esCompraEfectivoCaja
-        ? await calcularEfectivoDisponiblePorMoneda(tiendaId, monedaBase, tx)
-        : {};
+    // Efectivo realmente disponible por moneda, calculado DENTRO de la
+    // transacción y bajo el lock anterior — ya no puede quedar stale frente
+    // a otra compra concurrente. Si la compra supera lo disponible, se cubre
+    // lo que se pueda de caja y el resto queda como fondeo externo (MIXTO).
+    const restanteDisponible: Record<string, number> = esCompraEfectivoCaja
+      ? await calcularEfectivoDisponiblePorMoneda(tiendaId, monedaBase, tx)
+      : {};
 
-      for (const movimiento of items) {
-        const {
-          productoId,
-          cantidad,
-          costoUnitario,
-          monedaCompra,
-          proveedorId: itemProveedorId,
-          movimientoOrigenId,
-          fechaVencimiento,
-          precio,
-          monedaPrecio,
-          monedaOriginal,
-          montoOriginal,
-          tasaUsada: tasaUsadaItem,
-          costoTotal: costoTotalOverride, // MERMA (opcional) y DEVOLUCION_VENTA (requerido): valor en moneda base
-          montoReembolso, // Solo DEVOLUCION_VENTA
-        } = movimiento;
+    for (const movimiento of items) {
+      const {
+        productoId,
+        cantidad,
+        costoUnitario,
+        monedaCompra,
+        proveedorId: itemProveedorId,
+        movimientoOrigenId,
+        fechaVencimiento,
+        precio,
+        monedaPrecio,
+        monedaOriginal,
+        montoOriginal,
+        tasaUsada: tasaUsadaItem,
+        costoTotal: costoTotalOverride, // MERMA (opcional) y DEVOLUCION_VENTA (requerido): valor en moneda base
+        montoReembolso, // Solo DEVOLUCION_VENTA
+      } = movimiento;
 
-        // 0. Si es COMPRA con EFECTIVO_CAJA, topear al efectivo realmente
-        // disponible en esa moneda; el excedente pasa a fondeo externo (MIXTO).
-        let formaPagoItem = formaPago;
-        let montoEfectivoCajaItem: number | undefined;
-        if (tipo === "COMPRA" && formaPago === "EFECTIVO_CAJA") {
-          const montoCompra =
-            montoOriginal ??
-            (costoUnitario && cantidad ? costoUnitario * cantidad : 0);
-          const moneda = monedaOriginal ?? monedaBase;
-          const disponibleMoneda = Math.max(0, restanteDisponible[moneda] ?? 0);
+      // 0. Si es COMPRA con EFECTIVO_CAJA, topear al efectivo realmente
+      // disponible en esa moneda; el excedente pasa a fondeo externo (MIXTO).
+      let formaPagoItem = formaPago;
+      let montoEfectivoCajaItem: number | undefined;
+      if (tipo === "COMPRA" && formaPago === "EFECTIVO_CAJA") {
+        const montoCompra =
+          montoOriginal ??
+          (costoUnitario && cantidad ? costoUnitario * cantidad : 0);
+        const moneda = monedaOriginal ?? monedaBase;
+        const disponibleMoneda = Math.max(0, restanteDisponible[moneda] ?? 0);
 
-          if (montoCompra > disponibleMoneda) {
-            formaPagoItem = disponibleMoneda > 0 ? "MIXTO" : "EXTERNO";
-            montoEfectivoCajaItem =
-              disponibleMoneda > 0 ? disponibleMoneda : undefined;
-            restanteDisponible[moneda] = 0;
-            advertenciasCaja.push({
-              moneda,
-              solicitado: montoCompra,
-              disponible: disponibleMoneda,
-              tomadoDeCaja: montoEfectivoCajaItem ?? 0,
-              fondeoExterno: montoCompra - (montoEfectivoCajaItem ?? 0),
-            });
-          } else {
-            montoEfectivoCajaItem = montoCompra;
-            restanteDisponible[moneda] = disponibleMoneda - montoCompra;
-          }
-        }
-
-        // 1. Obtener el productoTienda existente
-        let existenciaAnterior = 0;
-        const productoTiendaExistente = await tx.productoTienda.findFirst({
-          where: {
-            tiendaId,
-            productoId,
-            proveedorId: itemProveedorId || proveedorId || null,
-            deletedAt: null,
-          },
-        });
-
-        let productoTienda;
-        let calculoCPP = null;
-        // Moneda efectiva del costo para este movimiento
-        const monedaEfectiva = monedaCompra ?? monedaBase;
-
-        if (productoTiendaExistente) {
-          existenciaAnterior = productoTiendaExistente.existencia;
-
-          let nuevoCosto = productoTiendaExistente.costo;
-          let nuevaMonedaCosto = productoTiendaExistente.monedaCostoCode;
-
-          if (requiereCPP(tipo) && costoUnitario) {
-            // Resolver la moneda actual del producto (null = monedaBase)
-            const monedaActual =
-              productoTiendaExistente.monedaCostoCode ?? monedaBase;
-
-            // Si la moneda cambia, convertir el costo anterior a la nueva moneda
-            const costoAnteriorEnNuevaMoneda =
-              monedaActual === monedaEfectiva
-                ? productoTiendaExistente.costo
-                : convertFromBase(
-                    convertToBase(
-                      productoTiendaExistente.costo,
-                      monedaActual,
-                      tasas,
-                      monedaBase,
-                    ),
-                    monedaEfectiva,
-                    tasas,
-                    monedaBase,
-                  );
-
-            try {
-              calculoCPP = calcularCPP(
-                existenciaAnterior,
-                costoAnteriorEnNuevaMoneda,
-                cantidad,
-                costoUnitario,
-              );
-              nuevoCosto = calculoCPP.costoNuevo;
-              nuevaMonedaCosto = monedaEfectiva;
-            } catch (error) {
-              console.error("❌ Error calculando CPP:", error.message);
-              nuevoCosto = productoTiendaExistente.costo;
-            }
-          }
-
-          // Calcular fecha de vencimiento mínima
-          let minFechaVencimiento: Date | undefined = undefined;
-          if (!isMovimientoBaja(tipo) && fechaVencimiento) {
-            const nuevaFecha = new Date(fechaVencimiento);
-            minFechaVencimiento = productoTiendaExistente.fechaVencimiento
-              ? new Date(
-                  Math.min(
-                    productoTiendaExistente.fechaVencimiento.getTime(),
-                    nuevaFecha.getTime(),
-                  ),
-                )
-              : nuevaFecha;
-          }
-
-          productoTienda = await tx.productoTienda.update({
-            where: { id: productoTiendaExistente.id },
-            data: {
-              existencia: {
-                ...(isMovimientoBaja(tipo)
-                  ? { decrement: cantidad }
-                  : { increment: cantidad }),
-              },
-              ...(requiereCPP(tipo) &&
-                costoUnitario && {
-                  costo: nuevoCosto,
-                  monedaCostoCode: nuevaMonedaCosto,
-                }),
-              ...(minFechaVencimiento && {
-                fechaVencimiento: minFechaVencimiento,
-              }),
-            },
+        if (montoCompra > disponibleMoneda) {
+          formaPagoItem = disponibleMoneda > 0 ? "MIXTO" : "EXTERNO";
+          montoEfectivoCajaItem =
+            disponibleMoneda > 0 ? disponibleMoneda : undefined;
+          restanteDisponible[moneda] = 0;
+          advertenciasCaja.push({
+            moneda,
+            solicitado: montoCompra,
+            disponible: disponibleMoneda,
+            tomadoDeCaja: montoEfectivoCajaItem ?? 0,
+            fondeoExterno: montoCompra - (montoEfectivoCajaItem ?? 0),
           });
         } else {
-          // Producto nuevo en esta tienda
-          productoTienda = await tx.productoTienda.create({
-            data: {
-              tiendaId,
-              productoId,
-              costo: costoUnitario || 0,
-              // TRASPASO_ENTRADA trae el precio de venta de la tienda origen;
-              // el resto de movimientos no lo envía y arranca en 0 como antes.
-              precio: precio ?? 0,
-              // Moneda del precio traído de la tienda origen — igual que
-              // monedaCostoCode, null significa monedaBase (mismo negocio en
-              // ambas tiendas, por lo que null es seguro de conservar tal cual).
-              monedaPrecioCode: precio ? (monedaPrecio ?? null) : null,
-              existencia: cantidad,
-              monedaCostoCode: costoUnitario ? monedaEfectiva : null,
-              proveedorId: itemProveedorId || proveedorId || null,
-              ...(!isMovimientoBaja(tipo) &&
-                fechaVencimiento && {
-                  fechaVencimiento: new Date(fechaVencimiento),
-                }),
-            },
-          });
-
-          if (requiereCPP(tipo) && costoUnitario) {
-            calculoCPP = {
-              costoAnterior: 0,
-              costoNuevo: costoUnitario,
-              valorInventarioAnterior: 0,
-              valorInventarioNuevo: cantidad * costoUnitario,
-              existenciaAnterior: 0,
-              existenciaNueva: cantidad,
-              cantidadCompra: cantidad,
-              costoUnitarioCompra: costoUnitario,
-              costoTotalCompra: cantidad * costoUnitario,
-            };
-          }
+          montoEfectivoCajaItem = montoCompra;
+          restanteDisponible[moneda] = disponibleMoneda - montoCompra;
         }
+      }
 
-        // 2b. Valorización de MERMA / DEVOLUCION_VENTA (no participan del CPP)
-        let valorMermaODevolucion: number | undefined;
-        if (tipo === "MERMA") {
-          if (costoTotalOverride != null) {
-            valorMermaODevolucion = costoTotalOverride;
-          } else {
-            const costoVigente =
-              productoTiendaExistente?.costo ?? costoUnitario;
-            if (costoVigente == null) {
-              throw new Error(
-                `No se pudo valorizar la MERMA del producto ${productoId}: no existe stock previo en esta tienda ni se indicó costoUnitario/costoTotal.`,
-              );
-            }
-            // El costo del producto puede estar en una moneda distinta a monedaBase
-            // (monedaCostoCode) — convertir antes de valorizar la pérdida.
-            const costoVigenteBase = convertToBase(
-              costoVigente,
-              productoTiendaExistente?.monedaCostoCode ?? monedaBase,
-              tasas,
-              monedaBase,
+      // 1. Obtener el productoTienda existente
+      let existenciaAnterior = 0;
+      const productoTiendaExistente = await tx.productoTienda.findFirst({
+        where: {
+          tiendaId,
+          productoId,
+          proveedorId: itemProveedorId || proveedorId || null,
+          deletedAt: null,
+        },
+      });
+
+      let productoTienda;
+      let calculoCPP = null;
+      // Moneda efectiva del costo para este movimiento
+      const monedaEfectiva = monedaCompra ?? monedaBase;
+
+      if (productoTiendaExistente) {
+        existenciaAnterior = productoTiendaExistente.existencia;
+
+        let nuevoCosto = productoTiendaExistente.costo;
+        let nuevaMonedaCosto = productoTiendaExistente.monedaCostoCode;
+
+        if (requiereCPP(tipo) && costoUnitario) {
+          // Resolver la moneda actual del producto (null = monedaBase)
+          const monedaActual =
+            productoTiendaExistente.monedaCostoCode ?? monedaBase;
+
+          // Si la moneda cambia, convertir el costo anterior a la nueva moneda
+          const costoAnteriorEnNuevaMoneda =
+            monedaActual === monedaEfectiva
+              ? productoTiendaExistente.costo
+              : convertFromBase(
+                  convertToBase(
+                    productoTiendaExistente.costo,
+                    monedaActual,
+                    tasas,
+                    monedaBase,
+                  ),
+                  monedaEfectiva,
+                  tasas,
+                  monedaBase,
+                );
+
+          try {
+            calculoCPP = calcularCPP(
+              existenciaAnterior,
+              costoAnteriorEnNuevaMoneda,
+              cantidad,
+              costoUnitario,
             );
-            valorMermaODevolucion = cantidad * costoVigenteBase;
-          }
-        } else if (tipo === "DEVOLUCION_VENTA") {
-          // Requerido: el llamador calcula el costo histórico de la venta original
-          valorMermaODevolucion = costoTotalOverride ?? 0;
-        }
-
-        // 3. Actualizar productos fraccionados
-        const productosFraccionados = await tx.producto.findMany({
-          where: { fraccionDeId: productoId },
-        });
-
-        for (const productoFraccion of productosFraccionados) {
-          const productoTiendaFraccionado = await tx.productoTienda.findFirst({
-            where: { productoId: productoFraccion.id, tiendaId },
-          });
-          if (calculoCPP) {
-            const costoFraccion =
-              calculoCPP.costoNuevo / productoFraccion.unidadesPorFraccion;
-            if (productoTiendaFraccionado) {
-              await tx.productoTienda.update({
-                where: { id: productoTiendaFraccionado.id },
-                data: {
-                  costo: costoFraccion,
-                  ...(monedaEfectiva && { monedaCostoCode: monedaEfectiva }),
-                },
-              });
-            } else {
-              await tx.productoTienda.create({
-                data: {
-                  productoId: productoFraccion.id,
-                  tiendaId,
-                  costo: costoFraccion,
-                  precio: 0,
-                  existencia: 0,
-                  monedaCostoCode: monedaEfectiva,
-                  proveedorId: itemProveedorId || proveedorId || null,
-                },
-              });
-            }
+            nuevoCosto = calculoCPP.costoNuevo;
+            nuevaMonedaCosto = monedaEfectiva;
+          } catch (error) {
+            console.error("❌ Error calculando CPP:", error.message);
+            nuevoCosto = productoTiendaExistente.costo;
           }
         }
 
-        // 4. Crear el movimiento
-        await tx.movimientoStock.create({
+        // Calcular fecha de vencimiento mínima
+        let minFechaVencimiento: Date | undefined = undefined;
+        if (!isMovimientoBaja(tipo) && fechaVencimiento) {
+          const nuevaFecha = new Date(fechaVencimiento);
+          minFechaVencimiento = productoTiendaExistente.fechaVencimiento
+            ? new Date(
+                Math.min(
+                  productoTiendaExistente.fechaVencimiento.getTime(),
+                  nuevaFecha.getTime(),
+                ),
+              )
+            : nuevaFecha;
+        }
+
+        productoTienda = await tx.productoTienda.update({
+          where: { id: productoTiendaExistente.id },
           data: {
-            tipo,
-            cantidad,
-            productoTiendaId: productoTienda.id,
-            tiendaId,
-            usuarioId,
-            existenciaAnterior,
-
-            ...(calculoCPP && {
-              costoUnitario: calculoCPP.costoUnitarioCompra,
-              costoTotal: calculoCPP.costoTotalCompra,
-              costoAnterior: calculoCPP.costoAnterior,
-              costoNuevo: calculoCPP.costoNuevo,
-            }),
-            ...(valorMermaODevolucion !== undefined && {
-              costoTotal: valorMermaODevolucion,
-            }),
-
-            ...(referenciaId && { referenciaId }),
-            ...(motivo && { motivo }),
-            ...(proveedorId && { proveedorId }),
-            ...(itemProveedorId && { proveedorId: itemProveedorId }),
-            ...(destinationId && { destinationId }),
-            ...(tipo === "TRASPASO_SALIDA" && { state: "PENDIENTE" }),
-            ...(monedaOriginal && {
-              monedaOriginal,
-              montoOriginal,
-              tasaUsada: tasaUsadaItem,
-            }),
-            ...(tipo === "COMPRA" &&
-              formaPagoItem && { formaPago: formaPagoItem }),
-            ...(tipo === "COMPRA" &&
-              montoEfectivoCajaItem !== undefined && {
-                montoEfectivoCaja: montoEfectivoCajaItem,
+            existencia: {
+              ...(isMovimientoBaja(tipo)
+                ? { decrement: cantidad }
+                : { increment: cantidad }),
+            },
+            ...(requiereCPP(tipo) &&
+              costoUnitario && {
+                costo: nuevoCosto,
+                monedaCostoCode: nuevaMonedaCosto,
               }),
-            ...(tipo === "DEVOLUCION_VENTA" &&
-              montoReembolso !== undefined && { montoReembolso }),
+            ...(minFechaVencimiento && {
+              fechaVencimiento: minFechaVencimiento,
+            }),
+          },
+        });
+      } else {
+        // Producto nuevo en esta tienda
+        productoTienda = await tx.productoTienda.create({
+          data: {
+            tiendaId,
+            productoId,
+            costo: costoUnitario || 0,
+            // TRASPASO_ENTRADA trae el precio de venta de la tienda origen;
+            // el resto de movimientos no lo envía y arranca en 0 como antes.
+            precio: precio ?? 0,
+            // Moneda del precio traído de la tienda origen — igual que
+            // monedaCostoCode, null significa monedaBase (mismo negocio en
+            // ambas tiendas, por lo que null es seguro de conservar tal cual).
+            monedaPrecioCode: precio ? (monedaPrecio ?? null) : null,
+            existencia: cantidad,
+            monedaCostoCode: costoUnitario ? monedaEfectiva : null,
+            proveedorId: itemProveedorId || proveedorId || null,
+            ...(!isMovimientoBaja(tipo) &&
+              fechaVencimiento && {
+                fechaVencimiento: new Date(fechaVencimiento),
+              }),
           },
         });
 
-        if (tipo === "TRASPASO_ENTRADA") {
-          await tx.movimientoStock.update({
-            where: { id: movimientoOrigenId },
-            data: { state: "APROBADO" },
-          });
+        if (requiereCPP(tipo) && costoUnitario) {
+          calculoCPP = {
+            costoAnterior: 0,
+            costoNuevo: costoUnitario,
+            valorInventarioAnterior: 0,
+            valorInventarioNuevo: cantidad * costoUnitario,
+            existenciaAnterior: 0,
+            existenciaNueva: cantidad,
+            cantidadCompra: cantidad,
+            costoUnitarioCompra: costoUnitario,
+            costoTotalCompra: cantidad * costoUnitario,
+          };
         }
       }
-    },
-    MOVIMIENTO_TX_OPTIONS,
-  );
+
+      // 2b. Valorización de MERMA / DEVOLUCION_VENTA (no participan del CPP)
+      let valorMermaODevolucion: number | undefined;
+      if (tipo === "MERMA") {
+        if (costoTotalOverride != null) {
+          valorMermaODevolucion = costoTotalOverride;
+        } else {
+          const costoVigente = productoTiendaExistente?.costo ?? costoUnitario;
+          if (costoVigente == null) {
+            throw new Error(
+              `No se pudo valorizar la MERMA del producto ${productoId}: no existe stock previo en esta tienda ni se indicó costoUnitario/costoTotal.`,
+            );
+          }
+          // El costo del producto puede estar en una moneda distinta a monedaBase
+          // (monedaCostoCode) — convertir antes de valorizar la pérdida.
+          const costoVigenteBase = convertToBase(
+            costoVigente,
+            productoTiendaExistente?.monedaCostoCode ?? monedaBase,
+            tasas,
+            monedaBase,
+          );
+          valorMermaODevolucion = cantidad * costoVigenteBase;
+        }
+      } else if (tipo === "DEVOLUCION_VENTA") {
+        // Requerido: el llamador calcula el costo histórico de la venta original
+        valorMermaODevolucion = costoTotalOverride ?? 0;
+      }
+
+      // 3. Actualizar productos fraccionados
+      const productosFraccionados = await tx.producto.findMany({
+        where: { fraccionDeId: productoId },
+      });
+
+      for (const productoFraccion of productosFraccionados) {
+        const productoTiendaFraccionado = await tx.productoTienda.findFirst({
+          where: { productoId: productoFraccion.id, tiendaId },
+        });
+        if (calculoCPP) {
+          const costoFraccion =
+            calculoCPP.costoNuevo / productoFraccion.unidadesPorFraccion;
+          if (productoTiendaFraccionado) {
+            await tx.productoTienda.update({
+              where: { id: productoTiendaFraccionado.id },
+              data: {
+                costo: costoFraccion,
+                ...(monedaEfectiva && { monedaCostoCode: monedaEfectiva }),
+              },
+            });
+          } else {
+            await tx.productoTienda.create({
+              data: {
+                productoId: productoFraccion.id,
+                tiendaId,
+                costo: costoFraccion,
+                precio: 0,
+                existencia: 0,
+                monedaCostoCode: monedaEfectiva,
+                proveedorId: itemProveedorId || proveedorId || null,
+              },
+            });
+          }
+        }
+      }
+
+      // 4. Crear el movimiento
+      await tx.movimientoStock.create({
+        data: {
+          tipo,
+          cantidad,
+          productoTiendaId: productoTienda.id,
+          tiendaId,
+          usuarioId,
+          existenciaAnterior,
+
+          ...(calculoCPP && {
+            costoUnitario: calculoCPP.costoUnitarioCompra,
+            costoTotal: calculoCPP.costoTotalCompra,
+            costoAnterior: calculoCPP.costoAnterior,
+            costoNuevo: calculoCPP.costoNuevo,
+          }),
+          ...(valorMermaODevolucion !== undefined && {
+            costoTotal: valorMermaODevolucion,
+          }),
+
+          ...(referenciaId && { referenciaId }),
+          ...(motivo && { motivo }),
+          ...(proveedorId && { proveedorId }),
+          ...(itemProveedorId && { proveedorId: itemProveedorId }),
+          ...(destinationId && { destinationId }),
+          ...(tipo === "TRASPASO_SALIDA" && { state: "PENDIENTE" }),
+          ...(monedaOriginal && {
+            monedaOriginal,
+            montoOriginal,
+            tasaUsada: tasaUsadaItem,
+          }),
+          ...(tipo === "COMPRA" &&
+            formaPagoItem && { formaPago: formaPagoItem }),
+          ...(tipo === "COMPRA" &&
+            montoEfectivoCajaItem !== undefined && {
+              montoEfectivoCaja: montoEfectivoCajaItem,
+            }),
+          ...(tipo === "DEVOLUCION_VENTA" &&
+            montoReembolso !== undefined && { montoReembolso }),
+          ...(batchId && { batchId }),
+        },
+      });
+
+      if (tipo === "TRASPASO_ENTRADA") {
+        await tx.movimientoStock.update({
+          where: { id: movimientoOrigenId },
+          data: { state: "APROBADO" },
+        });
+      }
+    }
+  };
+
+  // Reuse the caller's transaction so its work and these movements commit or
+  // roll back together; otherwise open a dedicated one.
+  if (externalTx) {
+    await run(externalTx);
+  } else {
+    await prisma.$transaction(run, MOVIMIENTO_TX_OPTIONS);
+  }
 
   return { advertenciasCaja };
 };

--- a/src/services/devolucionVentaService.ts
+++ b/src/services/devolucionVentaService.ts
@@ -1,4 +1,5 @@
-import axiosClient from "@/lib/axiosClient";
+import axiosClient, { IDEMPOTENCY_KEY_HEADER } from "@/lib/axiosClient";
+import { generateUUID } from "@/utils/uuid";
 import {
   IBuscarVentasResponse,
   IDevolucionVentaCreate,
@@ -14,10 +15,26 @@ export const buscarVentas = async (
   return response.data;
 };
 
+/**
+ * Registers a sale return.
+ *
+ * Returning is cumulative, so replaying the request would give the stock back
+ * twice. The idempotency key lets the server recognise the resend; callers that
+ * also want to cover a manual retry must pass a stable one.
+ */
 export const registrarDevolucionVenta = async (
   tiendaId: string,
   ventaId: string,
   data: IDevolucionVentaCreate,
+  idempotencyKey?: string,
 ): Promise<void> => {
-  await axiosClient.post(`/api/venta/${tiendaId}/devolucion/${ventaId}`, data);
+  await axiosClient.post(
+    `/api/venta/${tiendaId}/devolucion/${ventaId}`,
+    data,
+    {
+      headers: {
+        [IDEMPOTENCY_KEY_HEADER]: idempotencyKey ?? generateUUID(),
+      },
+    },
+  );
 };

--- a/src/services/movimientoService.ts
+++ b/src/services/movimientoService.ts
@@ -1,4 +1,5 @@
-import axiosClient from "@/lib/axiosClient";
+import axiosClient, { IDEMPOTENCY_KEY_HEADER } from "@/lib/axiosClient";
+import { generateUUID } from "@/utils/uuid";
 import type {
   ITipoMovimiento,
   IImportData,
@@ -14,14 +15,32 @@ import type {
 
 const API_URL = `/api/movimiento`;
 
+/**
+ * Creates a batch of stock movements.
+ *
+ * The idempotency key identifies the batch and lets the server deduplicate it.
+ * Generating one here already covers the automatic axios retry, since the retry
+ * reuses the same config and therefore the same key. Callers that also want to
+ * cover a manual retry by the user after an error must pass a stable key, kept
+ * outside the render and renewed only once the save succeeds.
+ */
 export const cretateBatchMovimientos = async (
   data,
   items,
-): Promise<{ advertenciasCaja: IAdvertenciaCajaInsuficiente[] }> => {
-  const res = await axiosClient.post(API_URL, {
-    data: data,
-    items: items,
-  });
+  idempotencyKey?: string,
+): Promise<{
+  advertenciasCaja: IAdvertenciaCajaInsuficiente[];
+  duplicado?: boolean;
+}> => {
+  const res = await axiosClient.post(
+    API_URL,
+    { data, items },
+    {
+      headers: {
+        [IDEMPOTENCY_KEY_HEADER]: idempotencyKey ?? generateUUID(),
+      },
+    },
+  );
   return res.data;
 };
 

--- a/src/services/movimientoService.ts
+++ b/src/services/movimientoService.ts
@@ -87,10 +87,15 @@ export const importarMovimientosExcel = async (
   items: IImportarItemsMov[],
 ): Promise<IImportarResponse> => {
   try {
-    const response = await axiosClient.post(`${API_URL}/import`, {
-      data,
-      items,
-    });
+    const response = await axiosClient.post(
+      `${API_URL}/import`,
+      { data, items },
+      // Reimportar el mismo archivo duplicaría todo el lote. La clave se genera
+      // por invocación: cubre el reintento automático de axios, mientras que
+      // volver a lanzar la importación a mano es una decisión deliberada del
+      // usuario y sí debe registrarse como una importación nueva.
+      { headers: { [IDEMPOTENCY_KEY_HEADER]: generateUUID() } },
+    );
 
     return response.data;
   } catch (error) {

--- a/src/services/sellService.ts
+++ b/src/services/sellService.ts
@@ -1,9 +1,13 @@
-import axiosClient, { RetryConfig } from "@/lib/axiosClient";
+import axiosClient, {
+  RetryConfig,
+  IDEMPOTENCY_KEY_HEADER,
+} from "@/lib/axiosClient";
 import { IVenta } from "@/schemas/venta";
 import { IProductoVenta } from "@/schemas/producto";
 import type { IMultimonedaExtras } from "@/app/pos/components/PaymentModal";
 
-const API_URL = (tiendaId: string, cierreId: string) => `/api/venta/${tiendaId}/${cierreId}`;
+const API_URL = (tiendaId: string, cierreId: string) =>
+  `/api/venta/${tiendaId}/${cierreId}`;
 
 export const createSell = async (
   tiendaId: string,
@@ -19,7 +23,7 @@ export const createSell = async (
   wasOffline?: boolean,
   syncAttempts?: number,
   discountCodes?: string[],
-  multimoneda?: IMultimonedaExtras
+  multimoneda?: IMultimonedaExtras,
 ): Promise<IVenta> => {
   try {
     const response = await axiosClient.post(
@@ -36,35 +40,52 @@ export const createSell = async (
         syncAttempts,
         transferDestinationId,
         ...(discountCodes && discountCodes.length > 0 ? { discountCodes } : {}),
-        ...(multimoneda ? {
-          monedaCobro: multimoneda.monedaCobro,
-          pagosDetalle: multimoneda.pagosDetalle,
-          vueltoDetalle: multimoneda.vueltoDetalle,
-          tasaSnapshot: multimoneda.tasaSnapshot,
-        } : {})
+        ...(multimoneda
+          ? {
+              monedaCobro: multimoneda.monedaCobro,
+              pagosDetalle: multimoneda.pagosDetalle,
+              vueltoDetalle: multimoneda.vueltoDetalle,
+              tasaSnapshot: multimoneda.tasaSnapshot,
+            }
+          : {}),
       },
-      { _retryCount: 0 } as RetryConfig
+      {
+        _retryCount: 0,
+        // The sale is deduplicated by `syncId` on the server, so retrying is
+        // safe. Without this header the interceptor no longer retries POSTs.
+        headers: { [IDEMPOTENCY_KEY_HEADER]: syncId },
+      } as RetryConfig,
     );
 
     return response.data;
   } catch (error) {
-    console.error("❌ [createSell] Error en la petición:", error.response?.data || error.message);
+    console.error(
+      "❌ [createSell] Error en la petición:",
+      error.response?.data || error.message,
+    );
 
     if (error.code === "ECONNABORTED") {
-      throw new Error("TIMEOUT_ERROR: La petición tardó demasiado en responder");
+      throw new Error(
+        "TIMEOUT_ERROR: La petición tardó demasiado en responder",
+      );
     } else if (error.code === "ERR_NETWORK") {
       throw new Error("NETWORK_ERROR: Error de conexión de red");
     } else if (error.response?.status >= 500) {
       throw new Error("SERVER_ERROR: Error interno del servidor");
     } else if (error.response?.status >= 400) {
-      throw new Error(`CLIENT_ERROR: ${error.response?.data?.error || "Error en los datos enviados"}`);
+      throw new Error(
+        `CLIENT_ERROR: ${error.response?.data?.error || "Error en los datos enviados"}`,
+      );
     }
 
     throw error;
   }
 };
 
-export const getSells = async (tiendaId: string, cierreId: string): Promise<IVenta[]> => {
+export const getSells = async (
+  tiendaId: string,
+  cierreId: string,
+): Promise<IVenta[]> => {
   const response = await axiosClient.get(API_URL(tiendaId, cierreId));
   return response.data;
 };
@@ -73,11 +94,14 @@ export const removeSell = async (
   tiendaId: string,
   cierreId: string,
   ventaId: string,
-  usuarioId: string
+  usuarioId: string,
 ) => {
-  const removed = await axiosClient.delete(`${API_URL(tiendaId, cierreId)}/${ventaId}`, {
-    params: { usuarioId }
-  });
+  const removed = await axiosClient.delete(
+    `${API_URL(tiendaId, cierreId)}/${ventaId}`,
+    {
+      params: { usuarioId },
+    },
+  );
   return removed.data;
 };
 
@@ -85,10 +109,10 @@ export const removeProductFromSale = async (
   tiendaId: string,
   cierreId: string,
   ventaId: string,
-  ventaProductoId: string
+  ventaProductoId: string,
 ) => {
   const response = await axiosClient.delete(
-    `${API_URL(tiendaId, cierreId)}/${ventaId}/producto/${ventaProductoId}`
+    `${API_URL(tiendaId, cierreId)}/${ventaId}/producto/${ventaProductoId}`,
   );
   return response.data;
 };

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,15 @@
+/**
+ * Generates a v4 UUID. `crypto.randomUUID` only exists in secure contexts
+ * (HTTPS or localhost); it is unavailable on a POS served over plain HTTP by IP,
+ * hence the fallback.
+ */
+export const generateUUID = (): string => {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    return (c === "x" ? r : (r & 0x3) | 0x8).toString(16);
+  });
+};

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
       {
         "path": "/api/crons/purge-expired-freemium-landing-business",
         "schedule": "0 0 * * *"
+      },
+      {
+        "path": "/api/crons/purge-expired-idempotency-keys",
+        "schedule": "0 4 * * *"
       }
     ]
   }


### PR DESCRIPTION
### Description

This pull request introduces comprehensive improvements to ensure idempotency across various API endpoints, enhancing their reliability and error consistency during retries.

### Changes Included:

- Implemented early idempotency checks for `/api/venta/devolucion` to ensure consistent responses on retries.
- Adjusted `/api/productos` to handle retry attempts for already-deleted products.
- Made all stock movement operations safe to replay using idempotency keys or state-based verification.
- Added a reusable idempotency store backed by a shared table (`IdempotencyKey`) for tracking and replaying responses safely.
- Updated handlers for `PUT` and `DELETE` endpoints to use row locks and transactions for double safety.
- Introduced safe backoff retry policies for network requests in Axios, retrying only requests marked as idempotent.
- Documented the idempotency policy and audit findings for better understanding and consistency.
  
### Verification

- Concurrent execution tests confirmed correctness and ensured no duplicate effects on retries.
- Updated documentation reflects the new mechanisms and supporting details.

### Co-Authorship
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>