### PR TITLE
Introduce initial cash fund management for periods

### DIFF
--- a/prisma/migrations/20260801031700_add_initial_cash_fund/migration.sql
+++ b/prisma/migrations/20260801031700_add_initial_cash_fund/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "InitialCashFund" (
+    "id" TEXT NOT NULL,
+    "cierrePeriodoId" TEXT NOT NULL,
+    "amounts" JSONB NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "InitialCashFund_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "InitialCashFund_cierrePeriodoId_createdAt_idx" ON "InitialCashFund"("cierrePeriodoId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "InitialCashFund" ADD CONSTRAINT "InitialCashFund_cierrePeriodoId_fkey" FOREIGN KEY ("cierrePeriodoId") REFERENCES "CierrePeriodo"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InitialCashFund" ADD CONSTRAINT "InitialCashFund_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "Usuario"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -260,6 +260,7 @@ model Usuario {
   MovimientoStock     MovimientoStock[]
   tasasCambio         TasaCambio[]
   historialMonedaBase HistorialMonedaBase[]
+  initialCashFundEntries InitialCashFund[]
 
   // 🆕 Relación con proveedores asociados
   proveedores Proveedor[] @relation("ProveedorUsuario")
@@ -495,10 +496,28 @@ model CierrePeriodo {
   resumenMonedas      ResumenMonedaCierre[]
   cashBreakdownMoneda CashBreakdownMoneda[]
 
+  initialCashFundEntries InitialCashFund[]
+
   // Idices
   @@index([fechaInicio])
   @@index([fechaFin])
   @@index([tiendaId])
+}
+
+// Fondo inicial de caja por moneda, para un período. Append-only: cada edición
+// inserta una fila nueva con el snapshot completo de todas las monedas; la más
+// reciente por createdAt es la vigente. Nunca se borra — es dato histórico del
+// cierre, y la lista completa por cierrePeriodoId ya es el historial de auditoría.
+model InitialCashFund {
+  id              String        @id @default(uuid())
+  cierrePeriodo   CierrePeriodo @relation(fields: [cierrePeriodoId], references: [id], onDelete: Cascade)
+  cierrePeriodoId String
+  amounts         Json // Record<monedaCode, number>, ej. {"CUP": 5000, "USD": 20}
+  createdById     String
+  createdBy       Usuario       @relation(fields: [createdById], references: [id])
+  createdAt       DateTime      @default(now())
+
+  @@index([cierrePeriodoId, createdAt])
 }
 
 model CashBreakdownCierre {

--- a/src/app/api/cierre/[tiendaId]/[cierreId]/cash-balance/route.ts
+++ b/src/app/api/cierre/[tiendaId]/[cierreId]/cash-balance/route.ts
@@ -1,44 +1,44 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/utils/auth";
-import type { IPagoLinea, IVueltoLinea } from "@/schemas/pago";
+import { calcularEfectivoDisponiblePorMoneda } from "@/lib/movimiento/caja";
 
-// Returns net cash on hand per currency for the given period:
-// sum(cash received per currency) - sum(change given per currency)
+// Returns real cash available per currency for the currently open period of
+// this store: ventas en efectivo - vueltos - gastos - compras/devoluciones +
+// fondo inicial. Única fuente de verdad — antes este endpoint tenía su propio
+// cálculo simplificado (solo pagos - vueltos), inconsistente con el resto del
+// sistema porque no restaba gastos ni compras en efectivo.
 export async function GET(
   _req: NextRequest,
-  { params }: { params: Promise<{ tiendaId: string; cierreId: string }> }
+  { params }: { params: Promise<{ tiendaId: string; cierreId: string }> },
 ) {
   try {
-    const { cierreId } = await params;
-    await getSession();
+    const { tiendaId } = await params;
+    const session = await getSession();
+    const user = session.user;
 
-    const ventas = await prisma.venta.findMany({
-      where: { cierrePeriodoId: cierreId },
-      select: { pagosDetalle: true, vueltoDetalle: true },
+    const tienda = await prisma.tienda.findFirst({
+      where: { id: tiendaId, negocioId: user.negocio.id },
+      select: { negocio: { select: { monedaBase: true } } },
     });
-
-    const balance: Record<string, number> = {};
-
-    for (const venta of ventas) {
-      if (venta.pagosDetalle) {
-        const pagos = venta.pagosDetalle as unknown as IPagoLinea[];
-        for (const pago of pagos) {
-          if (pago.tipo === 'cash') {
-            balance[pago.moneda] = (balance[pago.moneda] ?? 0) + pago.monto;
-          }
-        }
-      }
-      if (venta.vueltoDetalle) {
-        const vueltos = venta.vueltoDetalle as unknown as IVueltoLinea[];
-        for (const vuelto of vueltos) {
-          balance[vuelto.moneda] = (balance[vuelto.moneda] ?? 0) - vuelto.monto;
-        }
-      }
+    if (!tienda) {
+      return NextResponse.json(
+        { error: "Tienda no encontrada" },
+        { status: 404 },
+      );
     }
+    const monedaBase = tienda.negocio?.monedaBase ?? "CUP";
+
+    const balance = await calcularEfectivoDisponiblePorMoneda(
+      tiendaId,
+      monedaBase,
+    );
 
     return NextResponse.json(balance, { status: 200 });
   } catch {
-    return NextResponse.json({ error: "Error al obtener el balance de caja" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Error al obtener el balance de caja" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/cierre/[tiendaId]/[cierreId]/close/route.ts
+++ b/src/app/api/cierre/[tiendaId]/[cierreId]/close/route.ts
@@ -8,7 +8,9 @@ import { convertToBase, buildTasaSnapshot } from "@/lib/currency";
 import { applyGastosToResumenMap, calcularGananciaFinal } from "@/lib/gastos";
 import {
   applyComprasYDevolucionesToResumenMap,
+  applyInitialFundToResumenMap,
   calcularTotalesMovimientosPeriodo,
+  getCurrentInitialCashFundAmounts,
 } from "@/lib/movimiento/caja";
 
 export async function PUT(
@@ -201,6 +203,12 @@ export async function PUT(
         tasasGastos,
       );
 
+    // InitialCashFund es append-only y no cambia por el cierre de otro
+    // proceso — se puede leer fuera de la transacción, igual que movimientosPeriodo.
+    const initialFundAmounts = await getCurrentInitialCashFundAmounts(
+      ultimoPeriodo.id,
+    );
+
     const [periodoCerrado] = await prisma.$transaction(async (tx) => {
       // The "already closed" check above runs outside the transaction, so two
       // concurrent closes both passed it. Here the period is locked and the
@@ -334,6 +342,15 @@ export async function PUT(
           }
         }
       }
+
+      // Fondo inicial de caja — no es una deducción, es el punto de partida
+      // del efectivo (igual que las ventas en efectivo del período).
+      applyInitialFundToResumenMap(
+        resumenMonedaMap,
+        initialFundAmounts,
+        monedaBase,
+        tasasGastos,
+      );
 
       // Deduct ad-hoc/recurring expenses from the per-currency cash summary
       // (todos los gastos, sin importar naturaleza — la caja siempre refleja el efectivo real que salió)

--- a/src/app/api/cierre/[tiendaId]/[cierreId]/initial-cash-fund/route.ts
+++ b/src/app/api/cierre/[tiendaId]/[cierreId]/initial-cash-fund/route.ts
@@ -1,0 +1,176 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/utils/auth";
+import { verificarPermisoUsuario } from "@/utils/permisos_back";
+import { initialCashFundInputSchema } from "@/schemas/initialCashFund";
+
+type Params = { tiendaId: string; cierreId: string };
+
+// Devuelve el historial completo del fondo inicial de este período, ordenado
+// del más reciente al más antiguo — el primer elemento es el vigente.
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  try {
+    const { tiendaId, cierreId } = await params;
+    const session = await getSession();
+    const user = session.user;
+
+    if (
+      !verificarPermisoUsuario(
+        user.permisos,
+        "operaciones.cierre.acceder",
+        user.rol,
+      )
+    ) {
+      return NextResponse.json(
+        { error: "Acceso no autorizado" },
+        { status: 403 },
+      );
+    }
+
+    const tienda = await prisma.tienda.findFirst({
+      where: { id: tiendaId, negocioId: user.negocio.id },
+    });
+    if (!tienda) {
+      return NextResponse.json(
+        { error: "Tienda no encontrada" },
+        { status: 404 },
+      );
+    }
+
+    const periodo = await prisma.cierrePeriodo.findFirst({
+      where: { id: cierreId, tiendaId },
+    });
+    if (!periodo) {
+      return NextResponse.json(
+        { error: "Período no encontrado" },
+        { status: 404 },
+      );
+    }
+
+    const entries = await prisma.initialCashFund.findMany({
+      where: { cierrePeriodoId: cierreId },
+      orderBy: { createdAt: "desc" },
+      include: { createdBy: { select: { nombre: true } } },
+    });
+
+    return NextResponse.json(
+      entries.map((e) => ({
+        id: e.id,
+        cierrePeriodoId: e.cierrePeriodoId,
+        amounts: e.amounts,
+        createdById: e.createdById,
+        createdByName: e.createdBy.nombre,
+        createdAt: e.createdAt,
+      })),
+      { status: 200 },
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Error al obtener el fondo inicial" },
+      { status: 500 },
+    );
+  }
+}
+
+// Registra una nueva edición del fondo inicial (INSERT append-only, nunca
+// UPDATE) — el cliente manda el snapshot completo de todas las monedas.
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  try {
+    const { tiendaId, cierreId } = await params;
+    const session = await getSession();
+    const user = session.user;
+
+    if (
+      !verificarPermisoUsuario(
+        user.permisos,
+        "operaciones.cierre.fondoinicial",
+        user.rol,
+      )
+    ) {
+      return NextResponse.json(
+        { error: "Acceso no autorizado" },
+        { status: 403 },
+      );
+    }
+
+    const body = initialCashFundInputSchema.parse(await req.json());
+
+    const tienda = await prisma.tienda.findFirst({
+      where: { id: tiendaId, negocioId: user.negocio.id },
+    });
+    if (!tienda) {
+      return NextResponse.json(
+        { error: "Tienda no encontrada" },
+        { status: 404 },
+      );
+    }
+
+    const periodo = await prisma.cierrePeriodo.findFirst({
+      where: { id: cierreId, tiendaId },
+    });
+    if (!periodo) {
+      return NextResponse.json(
+        { error: "Período no encontrado" },
+        { status: 404 },
+      );
+    }
+    if (periodo.fechaFin) {
+      return NextResponse.json(
+        {
+          error:
+            "El período ya está cerrado, no se puede modificar el fondo inicial",
+        },
+        { status: 400 },
+      );
+    }
+
+    const monedasActivas = await prisma.negocioMoneda.findMany({
+      where: { negocioId: user.negocio.id, activo: true },
+      select: { monedaCode: true },
+    });
+    const monedasActivasSet = new Set(monedasActivas.map((m) => m.monedaCode));
+    const monedasInvalidas = Object.keys(body.amounts).filter(
+      (monedaCode) => !monedasActivasSet.has(monedaCode),
+    );
+    if (monedasInvalidas.length > 0) {
+      return NextResponse.json(
+        {
+          error: `Moneda(s) no válida(s) para este negocio: ${monedasInvalidas.join(", ")}`,
+        },
+        { status: 400 },
+      );
+    }
+
+    const entry = await prisma.initialCashFund.create({
+      data: {
+        cierrePeriodoId: cierreId,
+        amounts: body.amounts,
+        createdById: user.id,
+      },
+      include: { createdBy: { select: { nombre: true } } },
+    });
+
+    return NextResponse.json(
+      {
+        id: entry.id,
+        cierrePeriodoId: entry.cierrePeriodoId,
+        amounts: entry.amounts,
+        createdById: entry.createdById,
+        createdByName: entry.createdBy.nombre,
+        createdAt: entry.createdAt,
+      },
+      { status: 201 },
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Error al guardar el fondo inicial" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/cierre/[tiendaId]/[cierreId]/route.ts
+++ b/src/app/api/cierre/[tiendaId]/[cierreId]/route.ts
@@ -12,7 +12,9 @@ import {
 import { applyGastosToResumenMap, calcularGananciaFinal } from "@/lib/gastos";
 import {
   applyComprasYDevolucionesToResumenMap,
+  applyInitialFundToResumenMap,
   buildResumenMonedas,
+  getCurrentInitialCashFundAmounts,
   montoCompraEnCaja,
 } from "@/lib/movimiento/caja";
 
@@ -529,6 +531,19 @@ export async function GET(
       return acc;
     }, {});
 
+    // El fondo inicial no es una deducción — es el punto de partida del
+    // efectivo, igual que las ventas del día — por eso se suma ANTES del
+    // snapshot "bruto" para que quede reflejado tanto en bruto como en final.
+    const initialFundAmounts = await getCurrentInitialCashFundAmounts(
+      cierre.id,
+    );
+    applyInitialFundToResumenMap(
+      resumenMonedaMap,
+      initialFundAmounts,
+      monedaBase,
+      tasasFallback,
+    );
+
     // Snapshot del bruto (antes de restar gastos/compras/devoluciones) para
     // poder mostrar "bruto tachado -> final" en el desglose por moneda
     const resumenMonedaBrutoMap: Record<
@@ -606,6 +621,7 @@ export async function GET(
           equivalenteBaseBruto:
             resumenMonedaBrutoMap[monedaCode]?.equivalenteBase ??
             vals.equivalenteBase,
+          initialFund: initialFundAmounts[monedaCode] ?? 0,
         }),
       ),
       productosVendidos: Object.values(productosVendidos)

--- a/src/app/api/movimiento/[tiendaId]/caja-resumen/route.ts
+++ b/src/app/api/movimiento/[tiendaId]/caja-resumen/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/utils/auth";
+import { verificarPermisoUsuario } from "@/utils/permisos_back";
+import { calcularResumenCajaPorMoneda } from "@/lib/movimiento/caja";
+import { DEFAULT_CURRENCY } from "@/constants/billDenominations";
+import { IResumenCajaResponse } from "@/schemas/resumenCaja";
+
+// Desglose de caja (fondo inicial vs. ventas reales) del período abierto de
+// la tienda — usado por el widget de caja del POS.
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ tiendaId: string }> },
+): Promise<NextResponse<IResumenCajaResponse | { error: string }>> {
+  try {
+    const { tiendaId } = await params;
+    const session = await getSession();
+    const user = session.user;
+
+    if (
+      !verificarPermisoUsuario(
+        user.permisos,
+        "operaciones.cierre.acceder",
+        user.rol,
+      )
+    ) {
+      return NextResponse.json(
+        { error: "Acceso no autorizado" },
+        { status: 403 },
+      );
+    }
+
+    const tienda = await prisma.tienda.findFirst({
+      where: { id: tiendaId, negocioId: user.negocio.id },
+      select: { negocio: { select: { monedaBase: true } } },
+    });
+    if (!tienda) {
+      return NextResponse.json(
+        { error: "Tienda no encontrada" },
+        { status: 404 },
+      );
+    }
+    const monedaBase = tienda.negocio?.monedaBase ?? DEFAULT_CURRENCY;
+
+    const resumen = await calcularResumenCajaPorMoneda(tiendaId, monedaBase);
+
+    return NextResponse.json({ monedaBase, resumen });
+  } catch (error) {
+    console.error("Error al calcular el resumen de caja:", error);
+    return NextResponse.json(
+      { error: "Error al calcular el resumen de caja" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/venta/[tiendaId]/[cierreId]/route.ts
+++ b/src/app/api/venta/[tiendaId]/[cierreId]/route.ts
@@ -2,7 +2,22 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { IVenta } from "@/schemas/venta";
+import type { IPagoLinea, IVueltoLinea } from "@/schemas/pago";
 import { applyDiscountsForSale } from "@/lib/discounts";
+import { calcularEfectivoDisponiblePorMoneda } from "@/lib/movimiento/caja";
+
+// El vuelto solicitado en una venta en tiempo real supera el efectivo
+// realmente disponible en esa moneda. Ver la validación dentro de la
+// transacción más abajo para el porqué de la excepción con wasOffline.
+class InsufficientCashForChangeError extends Error {
+  constructor(
+    public readonly currency: string,
+    public readonly requestedChange: number,
+    public readonly available: number,
+  ) {
+    super("INSUFFICIENT_CASH_FOR_CHANGE");
+  }
+}
 
 // Tipos auxiliares estrictos para evitar usos de any
 interface IncomingProduct {
@@ -247,276 +262,350 @@ export async function POST(
       discountCalcResult = null;
     }
 
+    // Solo hace falta para validar el vuelto contra la caja real (ver más
+    // abajo) — si la venta no da vuelto en efectivo, esta query es innecesaria,
+    // pero es barata y mantiene el código simple.
+    const tiendaConNegocio = await prisma.tienda.findUnique({
+      where: { id: tiendaId },
+      select: { negocio: { select: { monedaBase: true } } },
+    });
+    const monedaBase = tiendaConNegocio?.negocio?.monedaBase ?? "CUP";
+
     // **TRANSACCIÓN ATÓMICA: Todo o nada (SOLO escrituras)**
-    const result = await prisma.$transaction(async (tx) => {
-      // 3. Crear la venta
-      const venta = await tx.venta.create({
-        data: {
-          tiendaId,
-          usuarioId,
-          // El frontend envía `total` ya convertido a moneda base (useCartTotal + descuento aplicado).
-          // NO usar discountCalcResult.finalTotal: suma precios crudos en monedas mezcladas → incorrecto.
-          total: Math.max(0, Number(total) || 0),
-          totalcash,
-          totaltransfer,
-          cierrePeriodoId: ultimoPeriodo.id,
-          syncId,
-          // 🆕 NUEVOS CAMPOS
-          frontendCreatedAt: createdAt ? new Date(createdAt) : null,
-          wasOffline: wasOffline || false,
-          syncAttempts: syncAttempts || 0, // 🆕 Usar syncAttempts enviado desde frontend
-          discountTotal: discountTotalCalc || 0,
-          productos: {
-            create: productosMegrados.map((p) => ({
-              productoTiendaId: p.productoTiendaId,
-              cantidad: p.cantidad,
-              costo: p.costo,
-              precio: p.precio,
-              monedaCostoCode: p.monedaCostoCode ?? null,
-              monedaPrecioCode: p.monedaPrecioCode ?? null,
-            })),
-          },
-          ...(transferDestinationId &&
-            totaltransfer > 0 && { transferDestinationId }),
-          // Multimoneda
-          ...(monedaCobro && { monedaCobro }),
-          ...(pagosDetalle && { pagosDetalle }),
-          ...(vueltoDetalle && { vueltoDetalle }),
-          ...(tasaSnapshot && { tasaSnapshot }),
-        },
-        include: {
-          productos: true,
-        },
-      });
+    const result = await prisma.$transaction(
+      async (tx) => {
+        // 0. Validar que el vuelto solicitado esté cubierto por el efectivo
+        // realmente disponible en caja (fondo inicial + ventas - vueltos -
+        // gastos - compras, ver calcularEfectivoDisponiblePorMoneda). Mismo
+        // lock por tienda que usa COMPRA (src/lib/movimiento/index.ts) —
+        // compras y ventas compiten por el mismo efectivo físico y deben
+        // serializarse entre sí para no leer un "disponible" que la otra ya
+        // comprometió.
+        const vueltos = (vueltoDetalle as IVueltoLinea[] | undefined) ?? [];
+        const pagos = (pagosDetalle as IPagoLinea[] | undefined) ?? [];
+        const tieneVueltoEnEfectivo = vueltos.some((v) => v.monto > 0);
 
-      // 3.1 Persistir AppliedDiscount si corresponde (batch, un solo round-trip)
-      try {
-        const applied = discountCalcResult?.applied || [];
-        if ((discountTotalCalc || 0) > 0 && applied.length > 0) {
-          await tx.appliedDiscount.createMany({
-            data: applied.map((a) => ({
-              ventaId: venta.id,
-              discountRuleId: a.discountRuleId,
-              amount: a.amount,
-              productsAffected: a.productsAffected ?? null,
-            })),
-          });
-        }
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        console.error(
-          "❌ [POST /api/venta] Error guardando AppliedDiscount:",
-          msg,
-        );
-      }
-
-      // 3. Manejar productos fraccionables (si aplica) - PRIMERO
-      const productosFraccionables = await tx.productoTienda.findMany({
-        where: {
-          id: {
-            in: productos.map((p) => p.productoTiendaId),
-          },
-          producto: {
-            fraccionDeId: {
-              not: null,
-            },
-          },
-        },
-        include: {
-          producto: {
-            select: {
-              fraccionDeId: true,
-              unidadesPorFraccion: true,
-            },
-          },
-        },
-      });
-
-      if (productosFraccionables.length > 0) {
-        const productosFraccionablesData = productosFraccionables.filter(
-          (pf) => pf.producto.fraccionDeId,
-        );
-
-        // Usar existencias originales para el cálculo
-        const productosFraccionablesNeedDesagregateData =
-          productosFraccionablesData.filter((prodFracc) => {
-            const prod = productos.find(
-              (p) => p.productoTiendaId === prodFracc.id,
-            );
-            if (prod) {
-              if (prodFracc.producto.unidadesPorFraccion <= prod.cantidad) {
-                throw new Error(
-                  `Vendes más unidades sueltas de las que lleva una caja en una misma venta`,
-                );
-              }
-              // Usar existencia original (antes de cualquier modificación)
-              return prodFracc.existencia < prod.cantidad;
+        if (tieneVueltoEnEfectivo) {
+          await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${tiendaId})::bigint)`;
+          const disponible = await calcularEfectivoDisponiblePorMoneda(
+            tiendaId,
+            monedaBase,
+            tx,
+          );
+          const pagoCashPorMoneda: Record<string, number> = {};
+          for (const p of pagos) {
+            if (p.tipo === "cash") {
+              pagoCashPorMoneda[p.moneda] =
+                (pagoCashPorMoneda[p.moneda] ?? 0) + p.monto;
             }
-            return false;
-          });
-
-        const itemsDesagregaciónBaja = [];
-        const itemsDesagregaciónAlta = [];
-
-        productosFraccionablesNeedDesagregateData.forEach((item) => {
-          itemsDesagregaciónAlta.push({
-            cantidad: item.producto.unidadesPorFraccion,
-            productoId: item.productoId,
-          });
-          itemsDesagregaciónBaja.push({
-            cantidad: 1,
-            productoId: item.producto.fraccionDeId,
-          });
-        });
-
-        // Crear movimientos de desagregación dentro de la misma transacción
-        if (itemsDesagregaciónBaja.length > 0) {
-          for (const item of itemsDesagregaciónBaja) {
-            const productoTiendaDesagregar = await tx.productoTienda.findFirst({
-              where: {
-                tiendaId,
-                productoId: item.productoId,
-                proveedorId: null, // Solo productos propios para desagregación
-              },
-            });
-
-            if (productoTiendaDesagregar) {
-              const existenciaAnterior = productoTiendaDesagregar.existencia;
-
-              if (existenciaAnterior < item.cantidad) {
-                throw new Error(
-                  `Existencia insuficiente, no hay suficiente existencia para desagregar. Existencia: ${existenciaAnterior}, Cantidad a desagregar: ${item.cantidad}`,
+          }
+          for (const v of vueltos) {
+            if (v.monto <= 0) continue;
+            const disponibleMoneda =
+              (disponible[v.moneda] ?? 0) + (pagoCashPorMoneda[v.moneda] ?? 0);
+            if (v.monto > disponibleMoneda + 0.01) {
+              // Una venta offline ya ocurrió físicamente antes de que el
+              // servidor tuviera visibilidad — el cajero ya entregó ese
+              // cambio. Rechazarla no deshace lo ya sucedido y solo dejaría
+              // la venta atascada reintentando en el dispositivo offline.
+              // Se registra para visibilidad, sin bloquear la sincronización.
+              if (!wasOffline) {
+                throw new InsufficientCashForChangeError(
+                  v.moneda,
+                  v.monto,
+                  disponibleMoneda,
                 );
               }
-
-              await tx.productoTienda.update({
-                where: { id: productoTiendaDesagregar.id },
-                data: {
-                  existencia: {
-                    decrement: item.cantidad,
-                  },
-                },
-              });
-
-              await tx.movimientoStock.create({
-                data: {
-                  tipo: "DESAGREGACION_BAJA",
-                  cantidad: item.cantidad,
-                  productoTiendaId: productoTiendaDesagregar.id,
-                  tiendaId,
-                  usuarioId,
-                  existenciaAnterior,
-                  referenciaId: venta.id,
-                  motivo: `Desagregación para venta ${venta.id}`,
-                },
-              });
+              console.warn(
+                `⚠️ [POST /api/venta] Venta offline con vuelto no cubierto por caja: moneda=${v.moneda} vuelto=${v.monto} disponible=${disponibleMoneda.toFixed(2)} syncId=${syncId}`,
+              );
             }
           }
         }
 
-        if (itemsDesagregaciónAlta.length > 0) {
-          for (const item of itemsDesagregaciónAlta) {
-            const productoTiendaAgregar = await tx.productoTienda.findFirst({
-              where: {
-                tiendaId,
-                productoId: item.productoId,
-                proveedorId: null, // Solo productos propios para desagregación
-              },
-            });
-
-            if (productoTiendaAgregar) {
-              const existenciaAnterior = productoTiendaAgregar.existencia;
-
-              await tx.productoTienda.update({
-                where: { id: productoTiendaAgregar.id },
-                data: {
-                  existencia: {
-                    increment: item.cantidad,
-                  },
-                },
-              });
-
-              await tx.movimientoStock.create({
-                data: {
-                  tipo: "DESAGREGACION_ALTA",
-                  cantidad: item.cantidad,
-                  productoTiendaId: productoTiendaAgregar.id,
-                  tiendaId,
-                  usuarioId,
-                  existenciaAnterior,
-                  referenciaId: venta.id,
-                  motivo: `Desagregación para venta ${venta.id}`,
-                },
-              });
-            }
-          }
-        }
-      }
-
-      // 4. Actualizar existencias y acumular movimientos de venta - ÚLTIMO
-      const movimientosVenta: Prisma.MovimientoStockCreateManyInput[] = [];
-      for (const producto of productos) {
-        const productoTienda = productosExistentes.find(
-          (p) => p.id === producto.productoTiendaId,
-        );
-        if (!productoTienda) continue;
-
-        // Obtener la existencia actual (después de desagregaciones si las hubo)
-        const productoTiendaActual = await tx.productoTienda.findUnique({
-          where: { id: producto.productoTiendaId },
-          select: { existencia: true },
+        // 3. Crear la venta
+        const venta = await tx.venta.create({
+          data: {
+            tiendaId,
+            usuarioId,
+            // El frontend envía `total` ya convertido a moneda base (useCartTotal + descuento aplicado).
+            // NO usar discountCalcResult.finalTotal: suma precios crudos en monedas mezcladas → incorrecto.
+            total: Math.max(0, Number(total) || 0),
+            totalcash,
+            totaltransfer,
+            cierrePeriodoId: ultimoPeriodo.id,
+            syncId,
+            // 🆕 NUEVOS CAMPOS
+            frontendCreatedAt: createdAt ? new Date(createdAt) : null,
+            wasOffline: wasOffline || false,
+            syncAttempts: syncAttempts || 0, // 🆕 Usar syncAttempts enviado desde frontend
+            discountTotal: discountTotalCalc || 0,
+            productos: {
+              create: productosMegrados.map((p) => ({
+                productoTiendaId: p.productoTiendaId,
+                cantidad: p.cantidad,
+                costo: p.costo,
+                precio: p.precio,
+                monedaCostoCode: p.monedaCostoCode ?? null,
+                monedaPrecioCode: p.monedaPrecioCode ?? null,
+              })),
+            },
+            ...(transferDestinationId &&
+              totaltransfer > 0 && { transferDestinationId }),
+            // Multimoneda
+            ...(monedaCobro && { monedaCobro }),
+            ...(pagosDetalle && { pagosDetalle }),
+            ...(vueltoDetalle && { vueltoDetalle }),
+            ...(tasaSnapshot && { tasaSnapshot }),
+          },
+          include: {
+            productos: true,
+          },
         });
 
-        if (!productoTiendaActual) continue;
-
-        const existenciaAnterior = productoTiendaActual.existencia;
-
-        if (existenciaAnterior < producto.cantidad) {
-          throw new Error(
-            `Existencia insuficiente para realizar la venta de productoTiendaId: ${producto.productoTiendaId}. Existencia: ${existenciaAnterior}, Cantidad a vender: ${producto.cantidad}`,
+        // 3.1 Persistir AppliedDiscount si corresponde (batch, un solo round-trip)
+        try {
+          const applied = discountCalcResult?.applied || [];
+          if ((discountTotalCalc || 0) > 0 && applied.length > 0) {
+            await tx.appliedDiscount.createMany({
+              data: applied.map((a) => ({
+                ventaId: venta.id,
+                discountRuleId: a.discountRuleId,
+                amount: a.amount,
+                productsAffected: a.productsAffected ?? null,
+              })),
+            });
+          }
+        } catch (e: unknown) {
+          const msg = e instanceof Error ? e.message : String(e);
+          console.error(
+            "❌ [POST /api/venta] Error guardando AppliedDiscount:",
+            msg,
           );
         }
 
-        // Actualizar existencia
-        await tx.productoTienda.update({
-          where: { id: producto.productoTiendaId },
-          data: {
-            existencia: {
-              decrement: producto.cantidad,
+        // 3. Manejar productos fraccionables (si aplica) - PRIMERO
+        const productosFraccionables = await tx.productoTienda.findMany({
+          where: {
+            id: {
+              in: productos.map((p) => p.productoTiendaId),
+            },
+            producto: {
+              fraccionDeId: {
+                not: null,
+              },
+            },
+          },
+          include: {
+            producto: {
+              select: {
+                fraccionDeId: true,
+                unidadesPorFraccion: true,
+              },
             },
           },
         });
 
-        // Acumular movimiento de venta
-        movimientosVenta.push({
-          tipo: "VENTA",
-          cantidad: producto.cantidad,
-          productoTiendaId: producto.productoTiendaId,
-          tiendaId,
-          usuarioId,
-          existenciaAnterior,
-          referenciaId: venta.id,
-          motivo: `Venta ${venta.id}`,
-          ...(productoTienda.proveedorId && {
-            proveedorId: productoTienda.proveedorId,
-          }),
-        });
-      }
+        if (productosFraccionables.length > 0) {
+          const productosFraccionablesData = productosFraccionables.filter(
+            (pf) => pf.producto.fraccionDeId,
+          );
 
-      // Insertar todos los movimientos de venta en un solo round-trip
-      if (movimientosVenta.length > 0) {
-        await tx.movimientoStock.createMany({ data: movimientosVenta });
-      }
+          // Usar existencias originales para el cálculo
+          const productosFraccionablesNeedDesagregateData =
+            productosFraccionablesData.filter((prodFracc) => {
+              const prod = productos.find(
+                (p) => p.productoTiendaId === prodFracc.id,
+              );
+              if (prod) {
+                if (prodFracc.producto.unidadesPorFraccion <= prod.cantidad) {
+                  throw new Error(
+                    `Vendes más unidades sueltas de las que lleva una caja en una misma venta`,
+                  );
+                }
+                // Usar existencia original (antes de cualquier modificación)
+                return prodFracc.existencia < prod.cantidad;
+              }
+              return false;
+            });
 
-      return venta;
-    }, {
-      // Red de seguridad ante la latencia del transaction pooler.
-      maxWait: 10000,
-      timeout: 20000,
-    });
+          const itemsDesagregaciónBaja = [];
+          const itemsDesagregaciónAlta = [];
+
+          productosFraccionablesNeedDesagregateData.forEach((item) => {
+            itemsDesagregaciónAlta.push({
+              cantidad: item.producto.unidadesPorFraccion,
+              productoId: item.productoId,
+            });
+            itemsDesagregaciónBaja.push({
+              cantidad: 1,
+              productoId: item.producto.fraccionDeId,
+            });
+          });
+
+          // Crear movimientos de desagregación dentro de la misma transacción
+          if (itemsDesagregaciónBaja.length > 0) {
+            for (const item of itemsDesagregaciónBaja) {
+              const productoTiendaDesagregar =
+                await tx.productoTienda.findFirst({
+                  where: {
+                    tiendaId,
+                    productoId: item.productoId,
+                    proveedorId: null, // Solo productos propios para desagregación
+                  },
+                });
+
+              if (productoTiendaDesagregar) {
+                const existenciaAnterior = productoTiendaDesagregar.existencia;
+
+                if (existenciaAnterior < item.cantidad) {
+                  throw new Error(
+                    `Existencia insuficiente, no hay suficiente existencia para desagregar. Existencia: ${existenciaAnterior}, Cantidad a desagregar: ${item.cantidad}`,
+                  );
+                }
+
+                await tx.productoTienda.update({
+                  where: { id: productoTiendaDesagregar.id },
+                  data: {
+                    existencia: {
+                      decrement: item.cantidad,
+                    },
+                  },
+                });
+
+                await tx.movimientoStock.create({
+                  data: {
+                    tipo: "DESAGREGACION_BAJA",
+                    cantidad: item.cantidad,
+                    productoTiendaId: productoTiendaDesagregar.id,
+                    tiendaId,
+                    usuarioId,
+                    existenciaAnterior,
+                    referenciaId: venta.id,
+                    motivo: `Desagregación para venta ${venta.id}`,
+                  },
+                });
+              }
+            }
+          }
+
+          if (itemsDesagregaciónAlta.length > 0) {
+            for (const item of itemsDesagregaciónAlta) {
+              const productoTiendaAgregar = await tx.productoTienda.findFirst({
+                where: {
+                  tiendaId,
+                  productoId: item.productoId,
+                  proveedorId: null, // Solo productos propios para desagregación
+                },
+              });
+
+              if (productoTiendaAgregar) {
+                const existenciaAnterior = productoTiendaAgregar.existencia;
+
+                await tx.productoTienda.update({
+                  where: { id: productoTiendaAgregar.id },
+                  data: {
+                    existencia: {
+                      increment: item.cantidad,
+                    },
+                  },
+                });
+
+                await tx.movimientoStock.create({
+                  data: {
+                    tipo: "DESAGREGACION_ALTA",
+                    cantidad: item.cantidad,
+                    productoTiendaId: productoTiendaAgregar.id,
+                    tiendaId,
+                    usuarioId,
+                    existenciaAnterior,
+                    referenciaId: venta.id,
+                    motivo: `Desagregación para venta ${venta.id}`,
+                  },
+                });
+              }
+            }
+          }
+        }
+
+        // 4. Actualizar existencias y acumular movimientos de venta - ÚLTIMO
+        const movimientosVenta: Prisma.MovimientoStockCreateManyInput[] = [];
+        for (const producto of productos) {
+          const productoTienda = productosExistentes.find(
+            (p) => p.id === producto.productoTiendaId,
+          );
+          if (!productoTienda) continue;
+
+          // Obtener la existencia actual (después de desagregaciones si las hubo)
+          const productoTiendaActual = await tx.productoTienda.findUnique({
+            where: { id: producto.productoTiendaId },
+            select: { existencia: true },
+          });
+
+          if (!productoTiendaActual) continue;
+
+          const existenciaAnterior = productoTiendaActual.existencia;
+
+          if (existenciaAnterior < producto.cantidad) {
+            throw new Error(
+              `Existencia insuficiente para realizar la venta de productoTiendaId: ${producto.productoTiendaId}. Existencia: ${existenciaAnterior}, Cantidad a vender: ${producto.cantidad}`,
+            );
+          }
+
+          // Actualizar existencia
+          await tx.productoTienda.update({
+            where: { id: producto.productoTiendaId },
+            data: {
+              existencia: {
+                decrement: producto.cantidad,
+              },
+            },
+          });
+
+          // Acumular movimiento de venta
+          movimientosVenta.push({
+            tipo: "VENTA",
+            cantidad: producto.cantidad,
+            productoTiendaId: producto.productoTiendaId,
+            tiendaId,
+            usuarioId,
+            existenciaAnterior,
+            referenciaId: venta.id,
+            motivo: `Venta ${venta.id}`,
+            ...(productoTienda.proveedorId && {
+              proveedorId: productoTienda.proveedorId,
+            }),
+          });
+        }
+
+        // Insertar todos los movimientos de venta en un solo round-trip
+        if (movimientosVenta.length > 0) {
+          await tx.movimientoStock.createMany({ data: movimientosVenta });
+        }
+
+        return venta;
+      },
+      {
+        // Red de seguridad ante la latencia del transaction pooler.
+        maxWait: 10000,
+        timeout: 20000,
+      },
+    );
 
     return NextResponse.json(result, { status: 201 });
   } catch (error: unknown) {
+    if (error instanceof InsufficientCashForChangeError) {
+      return NextResponse.json(
+        {
+          error: `Efectivo insuficiente en caja (${error.currency}) para dar el vuelto solicitado`,
+          currency: error.currency,
+          requestedChange: error.requestedChange,
+          available: error.available,
+        },
+        { status: 400 },
+      );
+    }
+
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&
       error.code === "P2002"

--- a/src/app/cierre/components/InitialCashFundDialog.tsx
+++ b/src/app/cierre/components/InitialCashFundDialog.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import MoneyField from "@/components/MoneyField";
+import {
+  fetchInitialCashFundHistory,
+  saveInitialCashFund,
+} from "@/services/cierrePeriodService";
+import { IInitialCashFundEntry } from "@/schemas/initialCashFund";
+import { INegocioMoneda } from "@/schemas/moneda";
+import { formatDateTime, formatMontoEnMoneda } from "@/utils/formatters";
+
+interface Props {
+  open: boolean;
+  tiendaId: string;
+  cierreId: string;
+  monedasActivas: INegocioMoneda[];
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function InitialCashFundDialog({
+  open,
+  tiendaId,
+  cierreId,
+  monedasActivas,
+  onClose,
+  onSaved,
+}: Props) {
+  const [history, setHistory] = useState<IInitialCashFundEntry[]>([]);
+  const [amounts, setAmounts] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  const monedasConEfectivo = monedasActivas.filter((m) => m.admiteEfectivo);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setHistoryOpen(false);
+    fetchInitialCashFundHistory(tiendaId, cierreId)
+      .then((entries) => {
+        setHistory(entries);
+        const current = entries[0]?.amounts ?? {};
+        setAmounts(
+          monedasConEfectivo.reduce<Record<string, string>>((acc, m) => {
+            acc[m.monedaCode] = String(current[m.monedaCode] ?? 0);
+            return acc;
+          }, {}),
+        );
+      })
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, tiendaId, cierreId]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const parsedAmounts = Object.fromEntries(
+        Object.entries(amounts).map(([monedaCode, value]) => [
+          monedaCode,
+          Math.max(0, Number(value) || 0),
+        ]),
+      );
+      await saveInitialCashFund(tiendaId, cierreId, parsedAmounts);
+      onSaved();
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Fondo inicial de caja</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} mt={0.5}>
+          <Typography variant="body2" color="text.secondary">
+            Efectivo con el que se abre la caja en cada moneda. Se puede ajustar
+            en cualquier momento mientras el período siga abierto.
+          </Typography>
+
+          {monedasConEfectivo.map((m) => (
+            <MoneyField
+              key={m.monedaCode}
+              label={`Fondo inicial (${m.monedaCode})`}
+              value={amounts[m.monedaCode] ?? "0"}
+              onChange={(e) =>
+                setAmounts((prev) => ({
+                  ...prev,
+                  [m.monedaCode]: e.target.value,
+                }))
+              }
+              currencySymbol={m.moneda?.simbolo ?? m.monedaCode}
+              disabled={loading}
+              fullWidth
+            />
+          ))}
+
+          {history.length > 0 && (
+            <Box>
+              <Button
+                size="small"
+                endIcon={historyOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                onClick={() => setHistoryOpen((v) => !v)}
+              >
+                Historial de cambios ({history.length})
+              </Button>
+              <Collapse in={historyOpen}>
+                <Stack
+                  spacing={1}
+                  divider={<Divider flexItem />}
+                  sx={{ mt: 1 }}
+                >
+                  {history.map((entry) => (
+                    <Box key={entry.id}>
+                      <Typography variant="caption" color="text.secondary">
+                        {entry.createdByName ?? "Usuario"} —{" "}
+                        {formatDateTime(entry.createdAt)}
+                      </Typography>
+                      <Typography variant="body2">
+                        {Object.entries(entry.amounts)
+                          .map(([monedaCode, amount]) =>
+                            formatMontoEnMoneda(amount, monedaCode),
+                          )
+                          .join(" · ") || "Sin montos"}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Stack>
+              </Collapse>
+            </Box>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancelar
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={saving || loading}
+        >
+          {saving ? "Guardando..." : "Guardar"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/app/cierre/components/MonedaBreakdownRow.tsx
+++ b/src/app/cierre/components/MonedaBreakdownRow.tsx
@@ -31,6 +31,7 @@ interface Props {
   equivalenteBase: number;
   totalEfectivoBruto?: number;
   equivalenteBaseBruto?: number;
+  initialFund?: number;
   tiendaId: string;
   cierreId: string;
   isOpen: boolean;
@@ -66,6 +67,7 @@ const MonedaBreakdownRow: FC<Props> = ({
   equivalenteBase,
   totalEfectivoBruto,
   equivalenteBaseBruto,
+  initialFund = 0,
   tiendaId,
   cierreId,
   isOpen,
@@ -162,6 +164,16 @@ const MonedaBreakdownRow: FC<Props> = ({
           variant="outlined"
         />
         <Stack direction="row" gap={3} flexWrap="wrap" alignItems="center">
+          {initialFund > 0 && (
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Fondo inicial
+              </Typography>
+              <Typography variant="body2" fontWeight="medium">
+                {formatMontoEnMoneda(initialFund, monedaCode)}
+              </Typography>
+            </Box>
+          )}
           <Box>
             <Typography variant="caption" color="text.secondary">
               Efectivo

--- a/src/app/cierre/page.tsx
+++ b/src/app/cierre/page.tsx
@@ -55,6 +55,8 @@ import { IGastoAdHocCreate, IGastoPreview } from "@/schemas/gastos";
 import MonedaBreakdownRow from "@/app/cierre/components/MonedaBreakdownRow";
 import { DENOMINACIONES } from "@/constants/billDenominations";
 import GananciaCard from "@/app/cierre/components/GananciaCard";
+import InitialCashFundDialog from "@/app/cierre/components/InitialCashFundDialog";
+import SavingsIcon from "@mui/icons-material/Savings";
 
 const CierreCajaPage = () => {
   const { user, loadingContext, gotToPath, monedasNegocio, monedaBase } =
@@ -75,11 +77,15 @@ const CierreCajaPage = () => {
   const [categoriasGastos, setCategoriasGastos] = useState<string[]>([]);
   const [deletingGastoId, setDeletingGastoId] = useState<string | null>(null);
   const [cerrarCajaDialogOpen, setCerrarCajaDialogOpen] = useState(false);
+  const [initialFundDialogOpen, setInitialFundDialogOpen] = useState(false);
   const { clearSales, sales } = useSalesStore();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const { verificarPermiso } = usePermisos();
   const canManageGastos = verificarPermiso("operaciones.gastos.gestionar");
+  const canManageInitialFund = verificarPermiso(
+    "operaciones.cierre.fondoinicial",
+  );
 
   const handleSaveAdHoc = async (data: IGastoAdHocCreate) => {
     if (!currentPeriod) return;
@@ -187,9 +193,19 @@ const CierreCajaPage = () => {
       }
 
       setCurrentPeriod(currentPeriod);
+      // Los gastos son datos opcionales de esta vista (solo alimentan el
+      // Autocomplete de categorías del diálogo de gasto ad-hoc, que ni
+      // siquiera se renderiza sin `canManageGastos`) — no deben impedir que
+      // se muestre el cierre si el usuario no tiene permiso para verlos o si
+      // la petición falla por cualquier otro motivo.
       const [data, gastosTienda] = await Promise.all([
         fetchCierreData(localId, currentPeriod.id),
-        getGastosTienda(localId),
+        canManageGastos
+          ? getGastosTienda(localId).catch((error) => {
+              console.error("Error al cargar categorías de gastos:", error);
+              return [];
+            })
+          : Promise.resolve([]),
       ]);
 
       setCierreData(data);
@@ -292,6 +308,16 @@ const CierreCajaPage = () => {
           <RefreshIcon />
         </IconButton>
       </Tooltip>
+      {canManageInitialFund && currentPeriod && !currentPeriod.fechaFin && (
+        <Button
+          variant="outlined"
+          size={isMobile ? "small" : "medium"}
+          startIcon={<SavingsIcon />}
+          onClick={() => setInitialFundDialogOpen(true)}
+        >
+          {isMobile ? "Fondo" : "Fondo inicial"}
+        </Button>
+      )}
       {canManageGastos && currentPeriod && !currentPeriod.fechaFin && (
         <Button
           variant="outlined"
@@ -544,6 +570,7 @@ const CierreCajaPage = () => {
                     equivalenteBase={rm.equivalenteBase}
                     totalEfectivoBruto={rm.totalEfectivoBruto}
                     equivalenteBaseBruto={rm.equivalenteBaseBruto}
+                    initialFund={rm.initialFund}
                     tiendaId={user?.localActual?.id ?? ""}
                     cierreId={currentPeriod.id}
                     isOpen={!currentPeriod.fechaFin}
@@ -584,6 +611,17 @@ const CierreCajaPage = () => {
           onClose={() => setCerrarCajaDialogOpen(false)}
           onConfirm={handleConfirmarCierre}
         />
+
+        {canManageInitialFund && (
+          <InitialCashFundDialog
+            open={initialFundDialogOpen}
+            tiendaId={user.localActual.id}
+            cierreId={currentPeriod.id}
+            monedasActivas={monedasNegocio}
+            onClose={() => setInitialFundDialogOpen(false)}
+            onSaved={getInitData}
+          />
+        )}
 
         {canManageGastos && (
           <GastoAdHocDialog

--- a/src/app/configuracion/categorias/page.tsx
+++ b/src/app/configuracion/categorias/page.tsx
@@ -30,7 +30,7 @@ import {
   Collapse,
   Divider,
   FormControlLabel,
-  Switch
+  Switch,
 } from "@mui/material";
 import {
   Delete,
@@ -44,20 +44,28 @@ import {
   Refresh,
   ExpandLess,
   ExpandMore,
-  Public
+  Public,
 } from "@mui/icons-material";
-import { fetchCategories, createCategory, updateCategory, deleteCategory } from "@/services/categoryService";
+import {
+  fetchCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from "@/services/categoryService";
 import { useMessageContext } from "@/context/MessageContext";
 import useConfirmDialog from "@/components/confirmDialog";
 import { PageContainer } from "@/components/PageContainer";
 import { ContentCard } from "@/components/ContentCard";
+import SelectableTextField from "@/components/SelectableTextField";
 import { useSession } from "next-auth/react";
 import type { ICategory } from "@/schemas/categoria";
 
 export default function CategoriasPage() {
   const [categories, setCategories] = useState<ICategory[]>([]);
   const [open, setOpen] = useState(false);
-  const [editingCategory, setEditingCategory] = useState<ICategory | null>(null);
+  const [editingCategory, setEditingCategory] = useState<ICategory | null>(
+    null,
+  );
   const [nombre, setNombre] = useState("");
   const [color, setColor] = useState("#1976d2");
   const [createAsGlobal, setCreateAsGlobal] = useState(false);
@@ -70,7 +78,7 @@ export default function CategoriasPage() {
   const isSuperAdmin = session?.user?.rol === "SUPER_ADMIN";
 
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const [statsExpanded, setStatsExpanded] = useState(false);
 
@@ -112,27 +120,30 @@ export default function CategoriasPage() {
     try {
       if (editingCategory) {
         await updateCategory(editingCategory.id, nombre, color);
-        showMessage('Categoría actualizada exitosamente', 'success');
+        showMessage("Categoría actualizada exitosamente", "success");
       } else {
         await createCategory(nombre, color, isSuperAdmin && createAsGlobal);
-        showMessage('Categoría creada exitosamente', 'success');
+        showMessage("Categoría creada exitosamente", "success");
       }
       await loadCategories();
       handleClose();
     } catch (error) {
       console.error("Error al guardar categoría:", error);
-      showMessage('Error al guardar la categoría', 'error');
+      showMessage("Error al guardar la categoría", "error");
     }
   };
 
   const handleDelete = async (id: string) => {
-    confirmDialog('¿Está seguro que desea eliminar la categoría?', async () => {
+    confirmDialog("¿Está seguro que desea eliminar la categoría?", async () => {
       try {
         await deleteCategory(id);
-        showMessage('Categoría eliminada', 'success');
+        showMessage("Categoría eliminada", "success");
       } catch (error) {
         console.error(error);
-        showMessage('Error al intentar eliminar la categoría. Es probable que esté en uso!', 'error');
+        showMessage(
+          "Error al intentar eliminar la categoría. Es probable que esté en uso!",
+          "error",
+        );
       } finally {
         await loadCategories();
       }
@@ -140,18 +151,18 @@ export default function CategoriasPage() {
   };
 
   const filteredCategories = categories.filter((category) =>
-    category.nombre.toLowerCase().includes(searchTerm.toLowerCase())
+    category.nombre.toLowerCase().includes(searchTerm.toLowerCase()),
   );
 
   // Cálculos para estadísticas
   const totalCategorias = categories.length;
-  const coloresUnicos = [...new Set(categories.map(c => c.color))].length;
+  const coloresUnicos = [...new Set(categories.map((c) => c.color))].length;
   const categoriasVisibles = filteredCategories.length;
 
   const breadcrumbs = [
-    { label: 'Inicio', href: '/home' },
-    { label: 'Configuración', href: '/configuracion' },
-    { label: 'Categorías' }
+    { label: "Inicio", href: "/home" },
+    { label: "Configuración", href: "/configuracion" },
+    { label: "Categorías" },
   ];
 
   const headerActions = (
@@ -162,8 +173,15 @@ export default function CategoriasPage() {
         </IconButton>
       </Tooltip>
       {isMobile && (
-        <Tooltip title={statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"}>
-          <IconButton onClick={() => setStatsExpanded(!statsExpanded)} size="small">
+        <Tooltip
+          title={
+            statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"
+          }
+        >
+          <IconButton
+            onClick={() => setStatsExpanded(!statsExpanded)}
+            size="small"
+          >
             {statsExpanded ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         </Tooltip>
@@ -180,8 +198,18 @@ export default function CategoriasPage() {
   );
 
   // Componente de estadística móvil optimizado
-  const StatCard = ({ icon, value, label, color }: { icon: React.ReactNode, value: string, label: string, color: string }) => (
-    <Card sx={{ height: '100%' }}>
+  const StatCard = ({
+    icon,
+    value,
+    label,
+    color,
+  }: {
+    icon: React.ReactNode;
+    value: string;
+    label: string;
+    color: string;
+  }) => (
+    <Card sx={{ height: "100%" }}>
       <CardContent sx={{ p: isMobile ? 1.5 : 3 }}>
         <Stack direction="row" alignItems="center" spacing={isMobile ? 1 : 2}>
           <Box
@@ -189,29 +217,28 @@ export default function CategoriasPage() {
               p: isMobile ? 0.75 : 1.5,
               borderRadius: 2,
               bgcolor: color,
-              color: 'white',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
+              color: "white",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
               minWidth: isMobile ? 32 : 48,
               minHeight: isMobile ? 32 : 48,
             }}
           >
             {React.isValidElement(icon)
               ? React.cloneElement(icon, {
-                  fontSize: isMobile ? "small" : "large"
+                  fontSize: isMobile ? "small" : "large",
                 } as Record<string, unknown>)
-              : icon
-            }
+              : icon}
           </Box>
           <Box sx={{ minWidth: 0, flex: 1 }}>
             <Typography
               variant={isMobile ? "subtitle1" : "h4"}
               fontWeight="bold"
               sx={{
-                fontSize: isMobile ? '1rem' : '2rem',
+                fontSize: isMobile ? "1rem" : "2rem",
                 lineHeight: 1.2,
-                wordBreak: 'break-all'
+                wordBreak: "break-all",
               }}
             >
               {value}
@@ -220,8 +247,8 @@ export default function CategoriasPage() {
               variant="body2"
               color="text.secondary"
               sx={{
-                fontSize: isMobile ? '0.6875rem' : '0.875rem',
-                lineHeight: 1.2
+                fontSize: isMobile ? "0.6875rem" : "0.875rem",
+                lineHeight: 1.2,
               }}
             >
               {label}
@@ -234,7 +261,12 @@ export default function CategoriasPage() {
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="200px"
+      >
         <CircularProgress />
         <Typography variant="body2" sx={{ mt: 2, ml: 2 }}>
           Cargando categorías...
@@ -246,7 +278,11 @@ export default function CategoriasPage() {
   return (
     <PageContainer
       title="Gestión de Categorías"
-      subtitle={!isMobile ? "Organiza tus productos con categorías personalizadas" : undefined}
+      subtitle={
+        !isMobile
+          ? "Organiza tus productos con categorías personalizadas"
+          : undefined
+      }
       breadcrumbs={breadcrumbs}
       headerActions={headerActions}
       maxWidth="xl"
@@ -316,9 +352,13 @@ export default function CategoriasPage() {
       {/* Lista de categorías */}
       <ContentCard
         title="Lista de Categorías"
-        subtitle={!isMobile ? "Las categorías globales son compartidas por todos los negocios" : undefined}
+        subtitle={
+          !isMobile
+            ? "Las categorías globales son compartidas por todos los negocios"
+            : undefined
+        }
         headerActions={
-          <TextField
+          <SelectableTextField
             size="small"
             placeholder={isMobile ? "Buscar..." : "Buscar categoría..."}
             value={searchTerm}
@@ -332,7 +372,7 @@ export default function CategoriasPage() {
             }}
             sx={{
               minWidth: isMobile ? 160 : 250,
-              maxWidth: isMobile ? 200 : 'none'
+              maxWidth: isMobile ? 200 : "none",
             }}
           />
         }
@@ -341,13 +381,17 @@ export default function CategoriasPage() {
       >
         {filteredCategories.length === 0 ? (
           <Box sx={{ p: 2 }}>
-            <Box sx={{ textAlign: 'center', py: 8 }}>
-              <Category sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }} />
+            <Box sx={{ textAlign: "center", py: 8 }}>
+              <Category sx={{ fontSize: 48, color: "text.secondary", mb: 2 }} />
               <Typography variant="h6" color="text.secondary">
-                {searchTerm ? 'No se encontraron categorías' : 'No hay categorías registradas'}
+                {searchTerm
+                  ? "No se encontraron categorías"
+                  : "No hay categorías registradas"}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                {searchTerm ? 'Intenta con otros términos de búsqueda' : 'Agrega categorías para organizar mejor tus productos'}
+                {searchTerm
+                  ? "Intenta con otros términos de búsqueda"
+                  : "Agrega categorías para organizar mejor tus productos"}
               </Typography>
             </Box>
           </Box>
@@ -362,15 +406,21 @@ export default function CategoriasPage() {
                     key={categoria.id}
                     onClick={() => handleOpen(categoria)}
                     sx={{
-                      cursor: isGlobalReadOnly ? 'default' : 'pointer',
-                      '&:hover': {
-                        backgroundColor: isGlobalReadOnly ? undefined : 'action.hover',
+                      cursor: isGlobalReadOnly ? "default" : "pointer",
+                      "&:hover": {
+                        backgroundColor: isGlobalReadOnly
+                          ? undefined
+                          : "action.hover",
                       },
                     }}
                   >
-                    <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
+                    <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
                       <Stack spacing={1.5}>
-                        <Box display="flex" justifyContent="space-between" alignItems="center">
+                        <Box
+                          display="flex"
+                          justifyContent="space-between"
+                          alignItems="center"
+                        >
                           <Box display="flex" alignItems="center" gap={1}>
                             <Box
                               sx={{
@@ -378,25 +428,43 @@ export default function CategoriasPage() {
                                 height: 20,
                                 borderRadius: 1,
                                 bgcolor: categoria.color,
-                                border: '1px solid',
-                                borderColor: 'divider'
+                                border: "1px solid",
+                                borderColor: "divider",
                               }}
                             />
-                            <Typography variant="subtitle2" fontWeight="medium" sx={{ fontSize: '0.875rem' }}>
+                            <Typography
+                              variant="subtitle2"
+                              fontWeight="medium"
+                              sx={{ fontSize: "0.875rem" }}
+                            >
                               {categoria.nombre}
                             </Typography>
                             {categoria.esGlobal && (
                               <Chip
-                                icon={<Public sx={{ fontSize: '0.75rem !important' }} />}
+                                icon={
+                                  <Public
+                                    sx={{ fontSize: "0.75rem !important" }}
+                                  />
+                                }
                                 label="Global"
                                 size="small"
                                 color="info"
                                 variant="outlined"
-                                sx={{ fontSize: '0.65rem', height: 18, '& .MuiChip-label': { px: 0.5 } }}
+                                sx={{
+                                  fontSize: "0.65rem",
+                                  height: 18,
+                                  "& .MuiChip-label": { px: 0.5 },
+                                }}
                               />
                             )}
                           </Box>
-                          <Tooltip title={isGlobalReadOnly ? "Las categorías globales no se pueden eliminar" : "Eliminar categoría"}>
+                          <Tooltip
+                            title={
+                              isGlobalReadOnly
+                                ? "Las categorías globales no se pueden eliminar"
+                                : "Eliminar categoría"
+                            }
+                          >
                             <span>
                               <IconButton
                                 onClick={(e) => {
@@ -413,7 +481,11 @@ export default function CategoriasPage() {
                           </Tooltip>
                         </Box>
 
-                        <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.6875rem' }}>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ fontSize: "0.6875rem" }}
+                        >
                           Color: {categoria.color}
                         </Typography>
                       </Stack>
@@ -442,12 +514,14 @@ export default function CategoriasPage() {
                       key={categoria.id}
                       onClick={() => handleOpen(categoria)}
                       sx={{
-                        cursor: isGlobalReadOnly ? 'default' : 'pointer',
-                        '&:hover': {
-                          backgroundColor: isGlobalReadOnly ? undefined : 'action.hover',
+                        cursor: isGlobalReadOnly ? "default" : "pointer",
+                        "&:hover": {
+                          backgroundColor: isGlobalReadOnly
+                            ? undefined
+                            : "action.hover",
                         },
-                        '&:nth-of-type(odd)': {
-                          backgroundColor: 'rgba(0, 0, 0, 0.02)',
+                        "&:nth-of-type(odd)": {
+                          backgroundColor: "rgba(0, 0, 0, 0.02)",
                         },
                       }}
                     >
@@ -459,8 +533,8 @@ export default function CategoriasPage() {
                               height: 24,
                               borderRadius: 1,
                               bgcolor: categoria.color,
-                              border: '1px solid',
-                              borderColor: 'divider'
+                              border: "1px solid",
+                              borderColor: "divider",
                             }}
                           />
                           <Typography variant="body2" fontWeight="medium">
@@ -468,24 +542,42 @@ export default function CategoriasPage() {
                           </Typography>
                           {categoria.esGlobal && (
                             <Chip
-                              icon={<Public sx={{ fontSize: '0.75rem !important' }} />}
+                              icon={
+                                <Public
+                                  sx={{ fontSize: "0.75rem !important" }}
+                                />
+                              }
                               label="Global"
                               size="small"
                               color="info"
                               variant="outlined"
-                              sx={{ fontSize: '0.7rem' }}
+                              sx={{ fontSize: "0.7rem" }}
                             />
                           )}
                         </Box>
                       </TableCell>
                       <TableCell>
-                        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{ fontFamily: "monospace" }}
+                        >
                           {categoria.color}
                         </Typography>
                       </TableCell>
                       <TableCell align="center">
-                        <Stack direction="row" spacing={0.5} justifyContent="center">
-                          <Tooltip title={isGlobalReadOnly ? "Las categorías globales no se pueden modificar" : "Editar categoría"}>
+                        <Stack
+                          direction="row"
+                          spacing={0.5}
+                          justifyContent="center"
+                        >
+                          <Tooltip
+                            title={
+                              isGlobalReadOnly
+                                ? "Las categorías globales no se pueden modificar"
+                                : "Editar categoría"
+                            }
+                          >
                             <span>
                               <IconButton
                                 onClick={(e) => {
@@ -500,7 +592,13 @@ export default function CategoriasPage() {
                               </IconButton>
                             </span>
                           </Tooltip>
-                          <Tooltip title={isGlobalReadOnly ? "Las categorías globales no se pueden eliminar" : "Eliminar categoría"}>
+                          <Tooltip
+                            title={
+                              isGlobalReadOnly
+                                ? "Las categorías globales no se pueden eliminar"
+                                : "Eliminar categoría"
+                            }
+                          >
                             <span>
                               <IconButton
                                 onClick={(e) => {
@@ -528,7 +626,9 @@ export default function CategoriasPage() {
 
       {/* Dialog para crear/editar categoría */}
       <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-        <DialogTitle>{editingCategory ? "Editar Categoría" : "Nueva Categoría"}</DialogTitle>
+        <DialogTitle>
+          {editingCategory ? "Editar Categoría" : "Nueva Categoría"}
+        </DialogTitle>
         <DialogContent>
           <Stack spacing={3} sx={{ pt: 1 }}>
             <TextField
@@ -557,22 +657,22 @@ export default function CategoriasPage() {
                     height: 32,
                     borderRadius: 1,
                     bgcolor: color,
-                    border: '1px solid',
-                    borderColor: 'divider',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center'
+                    border: "1px solid",
+                    borderColor: "divider",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
                   }}
                 >
-                  <ColorLens sx={{ color: 'white', fontSize: 16 }} />
+                  <ColorLens sx={{ color: "white", fontSize: 16 }} />
                 </Box>
                 <Chip
                   label={nombre || "Vista previa"}
                   size="small"
                   sx={{
                     bgcolor: color,
-                    color: 'white',
-                    fontWeight: 'medium'
+                    color: "white",
+                    fontWeight: "medium",
                   }}
                 />
               </Box>
@@ -591,7 +691,8 @@ export default function CategoriasPage() {
                   <Box>
                     <Typography variant="body2">Categoría Global</Typography>
                     <Typography variant="caption" color="text.secondary">
-                      Disponible para todos los negocios, solo editable por superadmins
+                      Disponible para todos los negocios, solo editable por
+                      superadmins
                     </Typography>
                   </Box>
                 }

--- a/src/app/configuracion/destinos-transferencia/page.tsx
+++ b/src/app/configuracion/destinos-transferencia/page.tsx
@@ -30,10 +30,10 @@ import {
   Collapse,
   Divider,
   FormControlLabel,
-  Switch
+  Switch,
 } from "@mui/material";
-import { 
-  Delete, 
+import {
+  Delete,
   Add,
   AccountBalance,
   Description,
@@ -41,20 +41,27 @@ import {
   Search,
   Refresh,
   ExpandLess,
-  ExpandMore
+  ExpandMore,
 } from "@mui/icons-material";
-import { fetchTransferDestinations, createTransferDestination, updateTransferDestination, deleteTransferDestination } from "@/services/transferDestinationsService";
+import {
+  fetchTransferDestinations,
+  createTransferDestination,
+  updateTransferDestination,
+  deleteTransferDestination,
+} from "@/services/transferDestinationsService";
 import { useMessageContext } from "@/context/MessageContext";
 import useConfirmDialog from "@/components/confirmDialog";
 import { PageContainer } from "@/components/PageContainer";
 import { ContentCard } from "@/components/ContentCard";
+import SelectableTextField from "@/components/SelectableTextField";
 import { useAppContext } from "@/context/AppContext";
 import { ITransferDestination } from "@/schemas/transferDestination";
 
 export default function DestinosTransferenciaPage() {
   const [destinations, setDestinations] = useState<ITransferDestination[]>([]);
   const [open, setOpen] = useState(false);
-  const [editingDestination, setEditingDestination] = useState<ITransferDestination | null>(null);
+  const [editingDestination, setEditingDestination] =
+    useState<ITransferDestination | null>(null);
   const [nombre, setNombre] = useState("");
   const [descripcion, setDescripcion] = useState("");
   const [isDefault, setIsDefault] = useState(false);
@@ -63,9 +70,9 @@ export default function DestinosTransferenciaPage() {
   const { showMessage } = useMessageContext();
   const { ConfirmDialogComponent, confirmDialog } = useConfirmDialog();
   const { user } = useAppContext();
-  
+
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const [statsExpanded, setStatsExpanded] = useState(false);
 
@@ -77,7 +84,7 @@ export default function DestinosTransferenciaPage() {
 
   const loadDestinations = async () => {
     if (!user?.localActual?.id) return;
-    
+
     setLoading(true);
     try {
       const data = await fetchTransferDestinations(user.localActual.id);
@@ -114,49 +121,74 @@ export default function DestinosTransferenciaPage() {
 
     try {
       if (editingDestination) {
-        await updateTransferDestination(editingDestination.id, nombre, descripcion, isDefault);
-        showMessage('Destino de transferencia actualizado exitosamente', 'success');
+        await updateTransferDestination(
+          editingDestination.id,
+          nombre,
+          descripcion,
+          isDefault,
+        );
+        showMessage(
+          "Destino de transferencia actualizado exitosamente",
+          "success",
+        );
       } else {
-        await createTransferDestination(nombre, descripcion, isDefault, user.localActual.id);
-        showMessage('Destino de transferencia creado exitosamente', 'success');
+        await createTransferDestination(
+          nombre,
+          descripcion,
+          isDefault,
+          user.localActual.id,
+        );
+        showMessage("Destino de transferencia creado exitosamente", "success");
       }
       await loadDestinations();
       handleClose();
     } catch (error) {
       console.error("Error al guardar destino de transferencia:", error);
-      showMessage('Error al guardar el destino de transferencia', 'error');
+      showMessage("Error al guardar el destino de transferencia", "error");
     }
   };
 
   const handleDelete = async (id: string) => {
-    confirmDialog('¿Está seguro que desea eliminar el destino de transferencia?', async () => {
-      try {
-        await deleteTransferDestination(id);
-        showMessage('Destino de transferencia eliminado', 'success');
-      } catch (error) {
-        console.error(error);
-        showMessage('Error al intentar eliminar el destino de transferencia. Es probable que esté en uso!', 'error');
-      } finally {
-        await loadDestinations();
-      }
-    });
+    confirmDialog(
+      "¿Está seguro que desea eliminar el destino de transferencia?",
+      async () => {
+        try {
+          await deleteTransferDestination(id);
+          showMessage("Destino de transferencia eliminado", "success");
+        } catch (error) {
+          console.error(error);
+          showMessage(
+            "Error al intentar eliminar el destino de transferencia. Es probable que esté en uso!",
+            "error",
+          );
+        } finally {
+          await loadDestinations();
+        }
+      },
+    );
   };
 
-  const filteredDestinations = destinations.filter((destination) =>
-    destination.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (destination.descripcion && destination.descripcion.toLowerCase().includes(searchTerm.toLowerCase()))
+  const filteredDestinations = destinations.filter(
+    (destination) =>
+      destination.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (destination.descripcion &&
+        destination.descripcion
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase())),
   );
 
   // Cálculos para estadísticas
   const totalDestinations = destinations.length;
-  const defaultDestinations = destinations.filter(d => d.default).length;
-  const destinationsWithDescription = destinations.filter(d => d.descripcion).length;
+  const defaultDestinations = destinations.filter((d) => d.default).length;
+  const destinationsWithDescription = destinations.filter(
+    (d) => d.descripcion,
+  ).length;
   const destinationsVisible = filteredDestinations.length;
 
   const breadcrumbs = [
-    { label: 'Inicio', href: '/home' },
-    { label: 'Configuración', href: '/configuracion' },
-    { label: 'Destinos de Transferencia' }
+    { label: "Inicio", href: "/home" },
+    { label: "Configuración", href: "/configuracion" },
+    { label: "Destinos de Transferencia" },
   ];
 
   const headerActions = (
@@ -167,8 +199,15 @@ export default function DestinosTransferenciaPage() {
         </IconButton>
       </Tooltip>
       {isMobile && (
-        <Tooltip title={statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"}>
-          <IconButton onClick={() => setStatsExpanded(!statsExpanded)} size="small">
+        <Tooltip
+          title={
+            statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"
+          }
+        >
+          <IconButton
+            onClick={() => setStatsExpanded(!statsExpanded)}
+            size="small"
+          >
             {statsExpanded ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         </Tooltip>
@@ -186,8 +225,18 @@ export default function DestinosTransferenciaPage() {
   );
 
   // Componente de estadística móvil optimizado
-  const StatCard = ({ icon, value, label, color }: { icon: React.ReactNode, value: string, label: string, color: string }) => (
-    <Card sx={{ height: '100%' }}>
+  const StatCard = ({
+    icon,
+    value,
+    label,
+    color,
+  }: {
+    icon: React.ReactNode;
+    value: string;
+    label: string;
+    color: string;
+  }) => (
+    <Card sx={{ height: "100%" }}>
       <CardContent sx={{ p: isMobile ? 1.5 : 3 }}>
         <Stack direction="row" alignItems="center" spacing={isMobile ? 1 : 2}>
           <Box
@@ -195,39 +244,38 @@ export default function DestinosTransferenciaPage() {
               p: isMobile ? 0.75 : 1.5,
               borderRadius: 2,
               bgcolor: color,
-              color: 'white',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
+              color: "white",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
               minWidth: isMobile ? 32 : 48,
               minHeight: isMobile ? 32 : 48,
             }}
           >
-            {React.isValidElement(icon) 
-              ? React.cloneElement(icon, { 
-                  fontSize: isMobile ? "small" : "large" 
+            {React.isValidElement(icon)
+              ? React.cloneElement(icon, {
+                  fontSize: isMobile ? "small" : "large",
                 } as Record<string, unknown>)
-              : icon
-            }
+              : icon}
           </Box>
           <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Typography 
-              variant={isMobile ? "subtitle1" : "h4"} 
+            <Typography
+              variant={isMobile ? "subtitle1" : "h4"}
               fontWeight="bold"
-              sx={{ 
-                fontSize: isMobile ? '1rem' : '2rem',
+              sx={{
+                fontSize: isMobile ? "1rem" : "2rem",
                 lineHeight: 1.2,
-                wordBreak: 'break-all'
+                wordBreak: "break-all",
               }}
             >
               {value}
             </Typography>
-            <Typography 
-              variant="body2" 
+            <Typography
+              variant="body2"
               color="text.secondary"
-              sx={{ 
-                fontSize: isMobile ? '0.6875rem' : '0.875rem',
-                lineHeight: 1.2
+              sx={{
+                fontSize: isMobile ? "0.6875rem" : "0.875rem",
+                lineHeight: 1.2,
               }}
             >
               {label}
@@ -240,7 +288,12 @@ export default function DestinosTransferenciaPage() {
 
   if (!user?.localActual?.id) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="200px"
+      >
         <Typography variant="h6" color="text.secondary">
           Selecciona un local para gestionar los destinos de transferencia
         </Typography>
@@ -250,7 +303,12 @@ export default function DestinosTransferenciaPage() {
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="200px"
+      >
         <CircularProgress />
         <Typography variant="body2" sx={{ mt: 2, ml: 2 }}>
           Cargando destinos de transferencia...
@@ -262,7 +320,11 @@ export default function DestinosTransferenciaPage() {
   return (
     <PageContainer
       title="Gestión de Destinos de Transferencia"
-      subtitle={!isMobile ? "Configura los destinos para las transferencias de tu local" : undefined}
+      subtitle={
+        !isMobile
+          ? "Configura los destinos para las transferencias de tu local"
+          : undefined
+      }
       breadcrumbs={breadcrumbs}
       headerActions={headerActions}
       maxWidth="xl"
@@ -330,11 +392,13 @@ export default function DestinosTransferenciaPage() {
       )}
 
       {/* Lista de destinos */}
-      <ContentCard 
+      <ContentCard
         title="Lista de Destinos"
-        subtitle={!isMobile ? "Haz clic en cualquier destino para editarlo" : undefined}
+        subtitle={
+          !isMobile ? "Haz clic en cualquier destino para editarlo" : undefined
+        }
         headerActions={
-          <TextField
+          <SelectableTextField
             size="small"
             placeholder={isMobile ? "Buscar..." : "Buscar destino..."}
             value={searchTerm}
@@ -346,9 +410,9 @@ export default function DestinosTransferenciaPage() {
                 </InputAdornment>
               ),
             }}
-            sx={{ 
+            sx={{
               minWidth: isMobile ? 160 : 250,
-              maxWidth: isMobile ? 200 : 'none'
+              maxWidth: isMobile ? 200 : "none",
             }}
           />
         }
@@ -357,13 +421,19 @@ export default function DestinosTransferenciaPage() {
       >
         {filteredDestinations.length === 0 ? (
           <Box sx={{ p: 2 }}>
-            <Box sx={{ textAlign: 'center', py: 8 }}>
-              <AccountBalance sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }} />
+            <Box sx={{ textAlign: "center", py: 8 }}>
+              <AccountBalance
+                sx={{ fontSize: 48, color: "text.secondary", mb: 2 }}
+              />
               <Typography variant="h6" color="text.secondary">
-                {searchTerm ? 'No se encontraron destinos' : 'No hay destinos registrados'}
+                {searchTerm
+                  ? "No se encontraron destinos"
+                  : "No hay destinos registrados"}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                {searchTerm ? 'Intenta con otros términos de búsqueda' : 'Agrega destinos para configurar las transferencias'}
+                {searchTerm
+                  ? "Intenta con otros términos de búsqueda"
+                  : "Agrega destinos para configurar las transferencias"}
               </Typography>
             </Box>
           </Box>
@@ -372,22 +442,30 @@ export default function DestinosTransferenciaPage() {
           <Box sx={{ p: 1.5 }}>
             <Stack spacing={1.5}>
               {filteredDestinations.map((destination) => (
-                <Card 
+                <Card
                   key={destination.id}
                   onClick={() => handleOpen(destination)}
                   sx={{
-                    cursor: 'pointer',
-                    '&:hover': {
-                      backgroundColor: 'action.hover',
+                    cursor: "pointer",
+                    "&:hover": {
+                      backgroundColor: "action.hover",
                     },
                   }}
                 >
-                  <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
+                  <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
                     <Stack spacing={1.5}>
-                      <Box display="flex" justifyContent="space-between" alignItems="center">
+                      <Box
+                        display="flex"
+                        justifyContent="space-between"
+                        alignItems="center"
+                      >
                         <Box display="flex" alignItems="center" gap={1}>
                           <AccountBalance color="primary" />
-                          <Typography variant="subtitle2" fontWeight="medium" sx={{ fontSize: '0.875rem' }}>
+                          <Typography
+                            variant="subtitle2"
+                            fontWeight="medium"
+                            sx={{ fontSize: "0.875rem" }}
+                          >
                             {destination.nombre}
                           </Typography>
                           {destination.default && (
@@ -405,9 +483,13 @@ export default function DestinosTransferenciaPage() {
                           <Delete fontSize="small" />
                         </IconButton>
                       </Box>
-                      
+
                       {destination.descripcion && (
-                        <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.6875rem' }}>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ fontSize: "0.6875rem" }}
+                        >
                           {destination.descripcion}
                         </Typography>
                       )}
@@ -431,16 +513,16 @@ export default function DestinosTransferenciaPage() {
               </TableHead>
               <TableBody>
                 {filteredDestinations.map((destination) => (
-                  <TableRow 
+                  <TableRow
                     key={destination.id}
                     onClick={() => handleOpen(destination)}
                     sx={{
-                      cursor: 'pointer',
-                      '&:hover': {
-                        backgroundColor: 'action.hover',
+                      cursor: "pointer",
+                      "&:hover": {
+                        backgroundColor: "action.hover",
                       },
-                      '&:nth-of-type(odd)': {
-                        backgroundColor: 'rgba(0, 0, 0, 0.02)',
+                      "&:nth-of-type(odd)": {
+                        backgroundColor: "rgba(0, 0, 0, 0.02)",
                       },
                     }}
                   >
@@ -454,16 +536,16 @@ export default function DestinosTransferenciaPage() {
                     </TableCell>
                     <TableCell>
                       <Typography variant="body2" color="text.secondary">
-                        {destination.descripcion || '-'}
+                        {destination.descripcion || "-"}
                       </Typography>
                     </TableCell>
                     <TableCell align="center">
                       {destination.default ? (
-                        <Chip 
-                          icon={<Star />} 
-                          label="Por Defecto" 
-                          color="warning" 
-                          size="small" 
+                        <Chip
+                          icon={<Star />}
+                          label="Por Defecto"
+                          color="warning"
+                          size="small"
                         />
                       ) : (
                         <Typography variant="body2" color="text.secondary">
@@ -494,22 +576,24 @@ export default function DestinosTransferenciaPage() {
       {/* Modal de edición/creación */}
       <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
         <DialogTitle>
-          {editingDestination ? "Editar Destino de Transferencia" : "Nuevo Destino de Transferencia"}
+          {editingDestination
+            ? "Editar Destino de Transferencia"
+            : "Nuevo Destino de Transferencia"}
         </DialogTitle>
         <DialogContent>
           <Stack spacing={3} sx={{ pt: 1 }}>
-            <TextField 
-              fullWidth 
-              label="Nombre" 
+            <TextField
+              fullWidth
+              label="Nombre"
               value={nombre}
               onChange={(e) => setNombre(e.target.value)}
               required
               placeholder="Ej: Tarjeta Principal, Cuenta Bancaria..."
             />
-            
-            <TextField 
-              fullWidth 
-              label="Descripción" 
+
+            <TextField
+              fullWidth
+              label="Descripción"
               value={descripcion}
               onChange={(e) => setDescripcion(e.target.value)}
               multiline
@@ -531,9 +615,9 @@ export default function DestinosTransferenciaPage() {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancelar</Button>
-          <Button 
-            onClick={handleSave} 
-            variant="contained" 
+          <Button
+            onClick={handleSave}
+            variant="contained"
             disabled={!nombre.trim()}
           >
             {editingDestination ? "Actualizar" : "Crear"}
@@ -544,4 +628,4 @@ export default function DestinosTransferenciaPage() {
       {ConfirmDialogComponent}
     </PageContainer>
   );
-} 
+}

--- a/src/app/configuracion/locales/page.tsx
+++ b/src/app/configuracion/locales/page.tsx
@@ -35,9 +35,9 @@ import {
   Alert,
   Paper,
 } from "@mui/material";
-import { 
-  Delete, 
-  Edit, 
+import {
+  Delete,
+  Edit,
   Add,
   Store,
   Person,
@@ -50,16 +50,22 @@ import {
   Warehouse,
   Security,
   PersonAdd,
-  Close
+  Close,
 } from "@mui/icons-material";
 import { PageContainer } from "@/components/PageContainer";
 import { ContentCard } from "@/components/ContentCard";
+import SelectableTextField from "@/components/SelectableTextField";
 import { useMessageContext } from "@/context/MessageContext";
 import useConfirmDialog from "@/components/confirmDialog";
 import LimitDialog from "@/components/LimitDialog";
 import { ILocal, TipoLocal } from "@/schemas/tienda";
 import { IRol } from "@/schemas/rol";
-import { getLocales, createLocal, updateLocal, deleteLocal } from "@/services/localesService";
+import {
+  getLocales,
+  createLocal,
+  updateLocal,
+  deleteLocal,
+} from "@/services/localesService";
 import { getRoles } from "@/services/rolService";
 import { getUsuarios } from "@/services/usuarioService";
 
@@ -84,9 +90,9 @@ export default function Locales() {
   const [limitDialog, setLimitDialog] = useState(false);
   const { showMessage } = useMessageContext();
   const { ConfirmDialogComponent, confirmDialog } = useConfirmDialog();
-  
+
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {
     fetchLocales();
@@ -148,15 +154,17 @@ export default function Locales() {
       resetForm();
     } catch (error) {
       console.error("Error al guardar local:", error);
-      
+
       // Manejar específicamente el error de límite de locales
-      if (error.response?.status === 400 && 
-          error.response?.data?.error?.includes("Limite de locales")) {
+      if (
+        error.response?.status === 400 &&
+        error.response?.data?.error?.includes("Limite de locales")
+      ) {
         setLimitDialog(true);
       } else {
         showMessage(
-          error.response?.data?.error || "Error al guardar el local", 
-          "error"
+          error.response?.data?.error || "Error al guardar el local",
+          "error",
         );
       }
     } finally {
@@ -165,40 +173,41 @@ export default function Locales() {
   };
 
   const handleDelete = async (id) => {
-    confirmDialog(
-      "¿Está seguro que desea eliminar este local?",
-      async () => {
-        try {
-          await deleteLocal(id);
-          fetchLocales();
-          showMessage("Local eliminado exitosamente", "success");
-        } catch (error) {
-          console.error("Error al eliminar local:", error);
-          showMessage(
-            error.response?.data?.error || "Error al eliminar el local",
-            "error"
-          );
-        }
+    confirmDialog("¿Está seguro que desea eliminar este local?", async () => {
+      try {
+        await deleteLocal(id);
+        fetchLocales();
+        showMessage("Local eliminado exitosamente", "success");
+      } catch (error) {
+        console.error("Error al eliminar local:", error);
+        showMessage(
+          error.response?.data?.error || "Error al eliminar el local",
+          "error",
+        );
       }
-    );
+    });
   };
 
   const handleEdit = (local) => {
     setSelectedLocal(local);
     setNombre(local.nombre);
     setTipo(local.tipo || TipoLocal.TIENDA);
-    
+
     // Usar usuariosTiendas si está disponible, sino usar usuarios para compatibilidad
     if (local.usuariosTiendas) {
-      setUsuariosRoles(local.usuariosTiendas.map(ut => ({ 
-        usuarioId: ut.usuario.id, 
-        rolId: ut.rol?.id 
-      })));
+      setUsuariosRoles(
+        local.usuariosTiendas.map((ut) => ({
+          usuarioId: ut.usuario.id,
+          rolId: ut.rol?.id,
+        })),
+      );
     } else {
       // Fallback para compatibilidad con datos antiguos
-      setUsuariosRoles(local.usuarios.map(u => ({ usuarioId: u.id, rolId: undefined })));
+      setUsuariosRoles(
+        local.usuarios.map((u) => ({ usuarioId: u.id, rolId: undefined })),
+      );
     }
-    
+
     setOpen(true);
   };
 
@@ -218,20 +227,26 @@ export default function Locales() {
     setLimitDialog(false);
   };
 
-  const filteredLocales = locales.filter(local =>
-    local.nombre.toLowerCase().includes(searchTerm.toLowerCase())
+  const filteredLocales = locales.filter((local) =>
+    local.nombre.toLowerCase().includes(searchTerm.toLowerCase()),
   );
 
   // Cálculos para estadísticas
   const totalLocales = locales.length;
-  const totalUsuariosAsignados = [...new Set(locales.flatMap(t => t.usuarios.map(u => u.id)))].length;
-  const localesConUsuarios = locales.filter(t => t.usuarios.length > 0).length;
-  const localesSinUsuarios = locales.filter(t => t.usuarios.length === 0).length;
+  const totalUsuariosAsignados = [
+    ...new Set(locales.flatMap((t) => t.usuarios.map((u) => u.id))),
+  ].length;
+  const localesConUsuarios = locales.filter(
+    (t) => t.usuarios.length > 0,
+  ).length;
+  const localesSinUsuarios = locales.filter(
+    (t) => t.usuarios.length === 0,
+  ).length;
 
   const breadcrumbs = [
-    { label: 'Inicio', href: '/home' },
-    { label: 'Configuración', href: '/configuracion' },
-    { label: 'Locales' }
+    { label: "Inicio", href: "/home" },
+    { label: "Configuración", href: "/configuracion" },
+    { label: "Locales" },
   ];
 
   const headerActions = (
@@ -242,8 +257,15 @@ export default function Locales() {
         </IconButton>
       </Tooltip>
       {isMobile && (
-        <Tooltip title={statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"}>
-          <IconButton onClick={() => setStatsExpanded(!statsExpanded)} size="small">
+        <Tooltip
+          title={
+            statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"
+          }
+        >
+          <IconButton
+            onClick={() => setStatsExpanded(!statsExpanded)}
+            size="small"
+          >
             {statsExpanded ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         </Tooltip>
@@ -261,7 +283,11 @@ export default function Locales() {
 
   // Función para obtener el icono según el tipo
   const getTipoIcon = (tipoLocal: string) => {
-    return tipoLocal === TipoLocal.ALMACEN ? <Warehouse fontSize="small" /> : <Store fontSize="small" />;
+    return tipoLocal === TipoLocal.ALMACEN ? (
+      <Warehouse fontSize="small" />
+    ) : (
+      <Store fontSize="small" />
+    );
   };
 
   // Función para obtener el color según el tipo
@@ -270,8 +296,18 @@ export default function Locales() {
   };
 
   // Componente de estadística móvil optimizado
-  const StatCard = ({ icon, value, label, color }: { icon: React.ReactNode, value: string, label: string, color: string }) => (
-    <Card sx={{ height: '100%' }}>
+  const StatCard = ({
+    icon,
+    value,
+    label,
+    color,
+  }: {
+    icon: React.ReactNode;
+    value: string;
+    label: string;
+    color: string;
+  }) => (
+    <Card sx={{ height: "100%" }}>
       <CardContent sx={{ p: isMobile ? 1.5 : 3 }}>
         <Stack direction="row" alignItems="center" spacing={isMobile ? 1 : 2}>
           <Box
@@ -279,39 +315,38 @@ export default function Locales() {
               p: isMobile ? 0.75 : 1.5,
               borderRadius: 2,
               bgcolor: color,
-              color: 'white',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
+              color: "white",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
               minWidth: isMobile ? 32 : 48,
               minHeight: isMobile ? 32 : 48,
             }}
           >
-            {React.isValidElement(icon) 
-              ? React.cloneElement(icon, { 
-                  fontSize: isMobile ? "small" : "large" 
+            {React.isValidElement(icon)
+              ? React.cloneElement(icon, {
+                  fontSize: isMobile ? "small" : "large",
                 } as Record<string, unknown>)
-              : icon
-            }
+              : icon}
           </Box>
           <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Typography 
-              variant={isMobile ? "subtitle1" : "h4"} 
+            <Typography
+              variant={isMobile ? "subtitle1" : "h4"}
               fontWeight="bold"
-              sx={{ 
-                fontSize: isMobile ? '1rem' : '2rem',
+              sx={{
+                fontSize: isMobile ? "1rem" : "2rem",
                 lineHeight: 1.2,
-                wordBreak: 'break-all'
+                wordBreak: "break-all",
               }}
             >
               {value}
             </Typography>
-            <Typography 
-              variant="body2" 
+            <Typography
+              variant="body2"
               color="text.secondary"
-              sx={{ 
-                fontSize: isMobile ? '0.6875rem' : '0.875rem',
-                lineHeight: 1.2
+              sx={{
+                fontSize: isMobile ? "0.6875rem" : "0.875rem",
+                lineHeight: 1.2,
               }}
             >
               {label}
@@ -324,7 +359,12 @@ export default function Locales() {
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="200px"
+      >
         <CircularProgress />
         <Typography variant="body2" sx={{ mt: 2, ml: 2 }}>
           Cargando locales...
@@ -334,8 +374,8 @@ export default function Locales() {
   }
 
   return (
-    <PageContainer 
-      title="Gestión de Locales" 
+    <PageContainer
+      title="Gestión de Locales"
       breadcrumbs={breadcrumbs}
       headerActions={headerActions}
     >
@@ -380,7 +420,7 @@ export default function Locales() {
       <ContentCard
         title={`Locales (${filteredLocales.length})`}
         headerActions={
-          <TextField
+          <SelectableTextField
             size="small"
             placeholder="Buscar locales..."
             value={searchTerm}
@@ -392,9 +432,9 @@ export default function Locales() {
                 </InputAdornment>
               ),
             }}
-            sx={{ 
+            sx={{
               minWidth: isMobile ? 160 : 250,
-              maxWidth: isMobile ? 200 : 'none'
+              maxWidth: isMobile ? 200 : "none",
             }}
           />
         }
@@ -405,10 +445,14 @@ export default function Locales() {
           <Box sx={{ p: 2 }}>
             <Alert severity="info" sx={{ mt: 2 }}>
               <Typography variant="h6" gutterBottom>
-                {searchTerm ? 'No se encontraron locales' : 'No hay locales registradas'}
+                {searchTerm
+                  ? "No se encontraron locales"
+                  : "No hay locales registradas"}
               </Typography>
               <Typography variant="body1" gutterBottom>
-                {searchTerm ? 'Intenta con otros términos de búsqueda' : 'Comienza creando tu primera locales para gestionar tu negocio'}
+                {searchTerm
+                  ? "Intenta con otros términos de búsqueda"
+                  : "Comienza creando tu primera locales para gestionar tu negocio"}
               </Typography>
               {!searchTerm && (
                 <Button
@@ -427,30 +471,43 @@ export default function Locales() {
           <Box sx={{ p: 1.5 }}>
             <Stack spacing={1.5}>
               {filteredLocales.map((local) => (
-                <Card 
+                <Card
                   key={local.id}
                   onClick={() => handleEdit(local)}
                   sx={{
-                    cursor: 'pointer',
-                    '&:hover': {
-                      backgroundColor: 'action.hover',
+                    cursor: "pointer",
+                    "&:hover": {
+                      backgroundColor: "action.hover",
                     },
                   }}
                 >
-                  <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
+                  <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
                     <Stack spacing={1.5}>
-                      <Box display="flex" justifyContent="space-between" alignItems="center">
-                        <Box display="flex" alignItems="center" gap={1} sx={{ flex: 1 }}>
-                          <Typography variant="subtitle2" fontWeight="medium" sx={{ fontSize: '0.875rem' }}>
+                      <Box
+                        display="flex"
+                        justifyContent="space-between"
+                        alignItems="center"
+                      >
+                        <Box
+                          display="flex"
+                          alignItems="center"
+                          gap={1}
+                          sx={{ flex: 1 }}
+                        >
+                          <Typography
+                            variant="subtitle2"
+                            fontWeight="medium"
+                            sx={{ fontSize: "0.875rem" }}
+                          >
                             {local.nombre}
                           </Typography>
-                          <Chip 
+                          <Chip
                             icon={getTipoIcon(local.tipo)}
                             label={local.tipo}
                             size="small"
                             color={getTipoColor(local.tipo)}
                             variant="outlined"
-                            sx={{ fontSize: '0.6875rem', height: 20 }}
+                            sx={{ fontSize: "0.6875rem", height: 20 }}
                           />
                         </Box>
                         <IconButton
@@ -464,33 +521,44 @@ export default function Locales() {
                           <Delete fontSize="small" />
                         </IconButton>
                       </Box>
-                      
+
                       <Box display="flex" flexWrap="wrap" gap={0.5}>
-                        {local.usuariosTiendas && local.usuariosTiendas.length > 0 ? (
+                        {local.usuariosTiendas &&
+                        local.usuariosTiendas.length > 0 ? (
                           local.usuariosTiendas.map((usuarioTienda) => (
-                            <Chip 
+                            <Chip
                               key={usuarioTienda.usuario.id}
-                              label={`${usuarioTienda.usuario.nombre}${usuarioTienda.rol ? ` (${usuarioTienda.rol.nombre})` : ''}`}
+                              label={`${usuarioTienda.usuario.nombre}${usuarioTienda.rol ? ` (${usuarioTienda.rol.nombre})` : ""}`}
                               size="small"
                               variant="outlined"
-                              icon={usuarioTienda.rol ? <Security fontSize="small" /> : <Person fontSize="small" />}
-                              sx={{ fontSize: '0.6875rem', height: 24 }}
+                              icon={
+                                usuarioTienda.rol ? (
+                                  <Security fontSize="small" />
+                                ) : (
+                                  <Person fontSize="small" />
+                                )
+                              }
+                              sx={{ fontSize: "0.6875rem", height: 24 }}
                             />
                           ))
                         ) : local.usuarios && local.usuarios.length > 0 ? (
                           // Fallback para compatibilidad
                           local.usuarios.map((user) => (
-                            <Chip 
+                            <Chip
                               key={user.id}
                               label={user.nombre}
                               size="small"
                               variant="outlined"
                               icon={<Person fontSize="small" />}
-                              sx={{ fontSize: '0.6875rem', height: 24 }}
+                              sx={{ fontSize: "0.6875rem", height: 24 }}
                             />
                           ))
                         ) : (
-                          <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.6875rem' }}>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ fontSize: "0.6875rem" }}
+                          >
                             Sin usuarios asignados
                           </Typography>
                         )}
@@ -515,16 +583,16 @@ export default function Locales() {
               </TableHead>
               <TableBody>
                 {filteredLocales.map((local) => (
-                  <TableRow 
+                  <TableRow
                     key={local.id}
                     onClick={() => handleEdit(local)}
                     sx={{
-                      cursor: 'pointer',
-                      '&:hover': {
-                        backgroundColor: 'action.hover',
+                      cursor: "pointer",
+                      "&:hover": {
+                        backgroundColor: "action.hover",
                       },
-                      '&:nth-of-type(odd)': {
-                        backgroundColor: 'rgba(0, 0, 0, 0.02)',
+                      "&:nth-of-type(odd)": {
+                        backgroundColor: "rgba(0, 0, 0, 0.02)",
                       },
                     }}
                   >
@@ -534,7 +602,7 @@ export default function Locales() {
                       </Typography>
                     </TableCell>
                     <TableCell>
-                      <Chip 
+                      <Chip
                         icon={getTipoIcon(local.tipo)}
                         label={local.tipo}
                         size="small"
@@ -544,20 +612,27 @@ export default function Locales() {
                     </TableCell>
                     <TableCell>
                       <Box display="flex" flexWrap="wrap" gap={0.5}>
-                        {local.usuariosTiendas && local.usuariosTiendas.length > 0 ? (
+                        {local.usuariosTiendas &&
+                        local.usuariosTiendas.length > 0 ? (
                           local.usuariosTiendas.map((usuarioTienda) => (
-                            <Chip 
+                            <Chip
                               key={usuarioTienda.usuario.id}
-                              label={`${usuarioTienda.usuario.nombre}${usuarioTienda.rol ? ` (${usuarioTienda.rol.nombre})` : ''}`}
+                              label={`${usuarioTienda.usuario.nombre}${usuarioTienda.rol ? ` (${usuarioTienda.rol.nombre})` : ""}`}
                               size="small"
                               variant="outlined"
-                              icon={usuarioTienda.rol ? <Security fontSize="small" /> : <Person fontSize="small" />}
+                              icon={
+                                usuarioTienda.rol ? (
+                                  <Security fontSize="small" />
+                                ) : (
+                                  <Person fontSize="small" />
+                                )
+                              }
                             />
                           ))
                         ) : local.usuarios && local.usuarios.length > 0 ? (
                           // Fallback para compatibilidad
                           local.usuarios.map((user) => (
-                            <Chip 
+                            <Chip
                               key={user.id}
                               label={user.nombre}
                               size="small"
@@ -573,7 +648,11 @@ export default function Locales() {
                       </Box>
                     </TableCell>
                     <TableCell align="center">
-                      <Stack direction="row" spacing={0.5} justifyContent="center">
+                      <Stack
+                        direction="row"
+                        spacing={0.5}
+                        justifyContent="center"
+                      >
                         <Tooltip title="Editar local">
                           <IconButton
                             onClick={(e) => {
@@ -610,12 +689,14 @@ export default function Locales() {
 
       {/* Dialog para crear/editar local */}
       <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-        <DialogTitle>{selectedLocal ? "Editar Local" : "Nuevo Local"}</DialogTitle>
+        <DialogTitle>
+          {selectedLocal ? "Editar Local" : "Nuevo Local"}
+        </DialogTitle>
         <DialogContent>
           <Stack spacing={3} sx={{ pt: 1 }}>
-            <TextField 
-              fullWidth 
-              label="Nombre del local" 
+            <TextField
+              fullWidth
+              label="Nombre del local"
               value={nombre}
               onChange={(e) => setNombre(e.target.value)}
               required
@@ -649,49 +730,55 @@ export default function Locales() {
               <Typography variant="subtitle2" gutterBottom sx={{ mt: 2 }}>
                 Usuarios y Roles Asignados
               </Typography>
-              
+
               {/* Lista de usuarios asignados con roles */}
               {usuariosRoles.length > 0 && (
                 <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
                   <Stack spacing={1}>
                     {usuariosRoles.map((usuarioRol, index) => {
-                      const usuario = usuarios.find(u => u.id === usuarioRol.usuarioId);
+                      const usuario = usuarios.find(
+                        (u) => u.id === usuarioRol.usuarioId,
+                      );
                       // const rol = roles.find(r => r.id === usuarioRol.rolId);
-                      
+
                       if (!usuario) return null;
-                      
+
                       return (
-                        <Box 
-                          key={usuario.id} 
-                          display="flex" 
-                          alignItems="center" 
+                        <Box
+                          key={usuario.id}
+                          display="flex"
+                          alignItems="center"
                           gap={2}
-                          sx={{ 
-                            p: 1, 
-                            border: '1px solid', 
-                            borderColor: 'divider', 
+                          sx={{
+                            p: 1,
+                            border: "1px solid",
+                            borderColor: "divider",
                             borderRadius: 1,
-                            bgcolor: 'background.paper'
+                            bgcolor: "background.paper",
                           }}
                         >
                           <Person fontSize="small" color="primary" />
-                          
+
                           <Box flex={1}>
                             <Typography variant="body2" fontWeight="medium">
                               {usuario.nombre}
                             </Typography>
-                            <Typography variant="caption" color="text.secondary">
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
                               {usuario.usuario}
                             </Typography>
                           </Box>
-                          
+
                           <FormControl size="small" sx={{ minWidth: 150 }}>
                             <InputLabel>Rol</InputLabel>
                             <Select
-                              value={usuarioRol.rolId || ''}
+                              value={usuarioRol.rolId || ""}
                               onChange={(e) => {
                                 const newUsuariosRoles = [...usuariosRoles];
-                                newUsuariosRoles[index].rolId = e.target.value || undefined;
+                                newUsuariosRoles[index].rolId =
+                                  e.target.value || undefined;
                                 setUsuariosRoles(newUsuariosRoles);
                               }}
                               label="Rol"
@@ -701,7 +788,11 @@ export default function Locales() {
                               </MenuItem>
                               {roles.map((rol) => (
                                 <MenuItem key={rol.id} value={rol.id}>
-                                  <Box display="flex" alignItems="center" gap={1}>
+                                  <Box
+                                    display="flex"
+                                    alignItems="center"
+                                    gap={1}
+                                  >
                                     <Security fontSize="small" />
                                     {rol.nombre}
                                   </Box>
@@ -709,13 +800,15 @@ export default function Locales() {
                               ))}
                             </Select>
                           </FormControl>
-                          
+
                           <Tooltip title="Remover usuario">
-                            <IconButton 
-                              size="small" 
+                            <IconButton
+                              size="small"
                               color="error"
                               onClick={() => {
-                                setUsuariosRoles(usuariosRoles.filter((_, i) => i !== index));
+                                setUsuariosRoles(
+                                  usuariosRoles.filter((_, i) => i !== index),
+                                );
                               }}
                             >
                               <Close fontSize="small" />
@@ -727,15 +820,21 @@ export default function Locales() {
                   </Stack>
                 </Paper>
               )}
-              
+
               {/* Selector para agregar nuevos usuarios */}
               <FormControl fullWidth>
                 <Select
                   value=""
                   onChange={(e) => {
                     const userId = e.target.value as string;
-                    if (userId && !usuariosRoles.some(ur => ur.usuarioId === userId)) {
-                      setUsuariosRoles([...usuariosRoles, { usuarioId: userId, rolId: undefined }]);
+                    if (
+                      userId &&
+                      !usuariosRoles.some((ur) => ur.usuarioId === userId)
+                    ) {
+                      setUsuariosRoles([
+                        ...usuariosRoles,
+                        { usuarioId: userId, rolId: undefined },
+                      ]);
                     }
                   }}
                   displayEmpty
@@ -744,7 +843,9 @@ export default function Locales() {
                     <em>Seleccionar usuario para agregar...</em>
                   </MenuItem>
                   {usuarios
-                    .filter(u => !usuariosRoles.some(ur => ur.usuarioId === u.id))
+                    .filter(
+                      (u) => !usuariosRoles.some((ur) => ur.usuarioId === u.id),
+                    )
                     .map((user) => (
                       <MenuItem key={user.id} value={user.id}>
                         <Box display="flex" alignItems="center" gap={1}>
@@ -755,10 +856,11 @@ export default function Locales() {
                     ))}
                 </Select>
               </FormControl>
-              
+
               {usuariosRoles.length === 0 && (
                 <Alert severity="info" sx={{ mt: 1 }}>
-                  No hay usuarios asignados a este local. Agregue al menos un usuario.
+                  No hay usuarios asignados a este local. Agregue al menos un
+                  usuario.
                 </Alert>
               )}
             </FormControl>
@@ -768,9 +870,9 @@ export default function Locales() {
           <Button onClick={handleClose} color="secondary" disabled={saving}>
             Cancelar
           </Button>
-          <Button 
-            onClick={handleSave} 
-            variant="contained" 
+          <Button
+            onClick={handleSave}
+            variant="contained"
             color="primary"
             disabled={!nombre.trim() || saving}
             startIcon={saving ? <CircularProgress size={16} /> : undefined}
@@ -790,4 +892,4 @@ export default function Locales() {
       {ConfirmDialogComponent}
     </PageContainer>
   );
-} 
+}

--- a/src/app/configuracion/negocios/page.tsx
+++ b/src/app/configuracion/negocios/page.tsx
@@ -37,13 +37,13 @@ import {
   FormControlLabel,
   Switch,
 } from "@mui/material";
-import { 
-  Delete, 
-  Edit, 
-  Add, 
-  Business, 
-  Store, 
-  Person, 
+import {
+  Delete,
+  Edit,
+  Add,
+  Business,
+  Store,
+  Person,
   Inventory,
   Search,
   ExpandMore,
@@ -54,20 +54,27 @@ import {
   Refresh,
 } from "@mui/icons-material";
 import Payments from "@mui/icons-material/Payments";
-import { createNegocio, getNegocios, updateNegocio, deleteNegocio, getNegocioStatsById } from "@/services/negocioServce";
+import {
+  createNegocio,
+  getNegocios,
+  updateNegocio,
+  deleteNegocio,
+  getNegocioStatsById,
+} from "@/services/negocioServce";
 import { getPlanes } from "@/services/planService";
 import type { IPlan } from "@/schemas/plan";
 import { useMessageContext } from "@/context/MessageContext";
 import { useAppContext } from "@/context/AppContext";
 import { INegocio } from "@/schemas/negocio";
-import { 
-  formatDate, 
-  formatDaysRemaining, 
+import {
+  formatDate,
+  formatDaysRemaining,
   getDaysRemainingColor,
-  formatPercentage 
+  formatPercentage,
 } from "@/utils/formatters";
 import { PageContainer } from "@/components/PageContainer";
 import { ContentCard } from "@/components/ContentCard";
+import SelectableTextField from "@/components/SelectableTextField";
 import { useRouter } from "next/navigation";
 import { registerFirstPaymentForNegocio } from "@/services/referralAdminService";
 
@@ -93,8 +100,8 @@ interface NegocioStats {
 
 export default function Negocios() {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-  
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
   const [negocios, setNegocios] = useState<INegocio[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -104,7 +111,9 @@ export default function Negocios() {
   /** Solo negocios creados vía activación desde la landing */
   const [soloActivacionLanding, setSoloActivacionLanding] = useState(false);
   const [expandedNegocio, setExpandedNegocio] = useState<string | null>(null);
-  const [negocioStats, setNegocioStats] = useState<Record<string, NegocioStats>>({});
+  const [negocioStats, setNegocioStats] = useState<
+    Record<string, NegocioStats>
+  >({});
   const [statsExpanded, setStatsExpanded] = useState(false);
   const { showMessage } = useMessageContext();
   const { user, loadingContext } = useAppContext();
@@ -130,7 +139,7 @@ export default function Negocios() {
       setNegocios(data);
     } catch (error) {
       console.error(error);
-      setError('Error al cargar los negocios');
+      setError("Error al cargar los negocios");
     } finally {
       setLoading(false);
     }
@@ -140,7 +149,10 @@ export default function Negocios() {
   useEffect(() => {
     if (!loadingContext && user) {
       if (user.rol !== "SUPER_ADMIN") {
-        showMessage("No tienes permisos para acceder a la gestión de negocios", "error");
+        showMessage(
+          "No tienes permisos para acceder a la gestión de negocios",
+          "error",
+        );
         router.push("/home");
         return;
       }
@@ -150,20 +162,22 @@ export default function Negocios() {
   useEffect(() => {
     if (user && user.rol === "SUPER_ADMIN") {
       fetchNegocios();
-      getPlanes().then(setPlanes).catch(() => showMessage('Error al cargar los planes', 'error'));
+      getPlanes()
+        .then(setPlanes)
+        .catch(() => showMessage("Error al cargar los planes", "error"));
     }
   }, [user, soloActivacionLanding]);
 
   const fetchNegocioStats = async (negocioId: string) => {
     try {
       const data = await getNegocioStatsById(negocioId);
-      setNegocioStats(prev => ({
+      setNegocioStats((prev) => ({
         ...prev,
-        [negocioId]: data
+        [negocioId]: data,
       }));
     } catch (error) {
-      console.error('Error al cargar estadísticas del negocio:', error);
-      showMessage('Error al cargar estadísticas del negocio', 'error');
+      console.error("Error al cargar estadísticas del negocio:", error);
+      showMessage("Error al cargar estadísticas del negocio", "error");
     }
   };
 
@@ -180,32 +194,24 @@ export default function Negocios() {
 
   const handleSave = async () => {
     if (!selectedPlan) return;
-    
+
     setLoading(true);
     try {
       if (selectedNegocio) {
-        await updateNegocio(
-          selectedNegocio.id,
-          nombre,
-          selectedPlan.id,
-        );
-        showMessage('Negocio actualizado satisfactoriamente', 'success');
+        await updateNegocio(selectedNegocio.id, nombre, selectedPlan.id);
+        showMessage("Negocio actualizado satisfactoriamente", "success");
       } else {
-        await createNegocio(
-          nombre,
-          selectedPlan.duracion,
-          selectedPlan.id,
-        );
-        showMessage('Negocio creado satisfactoriamente', 'success');
+        await createNegocio(nombre, selectedPlan.duracion, selectedPlan.id);
+        showMessage("Negocio creado satisfactoriamente", "success");
       }
-      
+
       const negocioId = selectedNegocio?.id;
       await fetchNegocios();
       if (negocioId) {
         if (expandedNegocio === negocioId) {
           fetchNegocioStats(negocioId);
         } else {
-          setNegocioStats(prev => {
+          setNegocioStats((prev) => {
             const updated = { ...prev };
             delete updated[negocioId];
             return updated;
@@ -215,26 +221,35 @@ export default function Negocios() {
       handleCloseDialog();
     } catch (error) {
       console.error(error);
-      showMessage(`Ocurrió un error al ${selectedNegocio ? 'actualizar' : 'crear'} el negocio`, 'error');
+      showMessage(
+        `Ocurrió un error al ${selectedNegocio ? "actualizar" : "crear"} el negocio`,
+        "error",
+      );
     } finally {
       setLoading(false);
     }
   };
 
   const handleDelete = async (negocio: INegocio) => {
-    if (!confirm(`¿Estás seguro de que deseas eliminar el negocio "${negocio.nombre}"? Esta acción no se puede deshacer.`)) {
+    if (
+      !confirm(
+        `¿Estás seguro de que deseas eliminar el negocio "${negocio.nombre}"? Esta acción no se puede deshacer.`,
+      )
+    ) {
       return;
     }
-    
+
     setLoading(true);
     try {
       await deleteNegocio(negocio.id);
-      showMessage('Negocio eliminado satisfactoriamente', 'success');
+      showMessage("Negocio eliminado satisfactoriamente", "success");
       await fetchNegocios();
     } catch (error) {
       console.error(error);
-      const errorMessage = error.response?.data?.error || 'Ocurrió un error al eliminar el negocio';
-      showMessage(errorMessage, 'error');
+      const errorMessage =
+        error.response?.data?.error ||
+        "Ocurrió un error al eliminar el negocio";
+      showMessage(errorMessage, "error");
     } finally {
       setLoading(false);
     }
@@ -244,17 +259,17 @@ export default function Negocios() {
     setSelectedNegocio(negocio);
     setNombre(negocio.nombre);
 
-    const matched = planes.find(p => p.id === negocio.planId);
+    const matched = planes.find((p) => p.id === negocio.planId);
     if (matched) setSelectedPlan(matched);
     setOpen(true);
   };
 
   const handleSetSelectedPlan = (planId: string) => {
-    setSelectedPlan(planes.find(p => p.id === planId));
+    setSelectedPlan(planes.find((p) => p.id === planId));
   };
 
   const handleCloseDialog = () => {
-    setNombre('');
+    setNombre("");
     setSelectedNegocio(null);
     setSelectedPlan(undefined);
     setOpen(false);
@@ -263,13 +278,16 @@ export default function Negocios() {
   const toLocalDatetimeInput = (d: Date) => {
     const pad = (n: number) => String(n).padStart(2, "0");
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(
-      d.getMinutes()
+      d.getMinutes(),
     )}`;
   };
 
   const openFirstPaymentDialog = (negocio: INegocio) => {
     if (!puedeMostrarBotonPrimerPago(negocio)) {
-      showMessage('Este negocio ya está en un plan de pago. No aplica registrar primer pago desde aquí.', 'info');
+      showMessage(
+        "Este negocio ya está en un plan de pago. No aplica registrar primer pago desde aquí.",
+        "info",
+      );
       return;
     }
     setFpNegocio(negocio);
@@ -298,20 +316,22 @@ export default function Negocios() {
       const res = await registerFirstPaymentForNegocio(fpNegocio.id, {
         planId: fpPlanId,
         paidAt: fpPaidAt ? new Date(fpPaidAt).toISOString() : undefined,
-        paymentAmount: fpAmount.trim() ? Number.parseFloat(fpAmount) : undefined,
+        paymentAmount: fpAmount.trim()
+          ? Number.parseFloat(fpAmount)
+          : undefined,
       });
       const r = res.result;
       if (r?.alreadyQualified) {
         showMessage(
           "Este negocio ya tenía registrado el primer pago. No se aplicaron cambios nuevos.",
-          "info"
+          "info",
         );
       } else if (r?.qualifiedNow) {
         showMessage(
           r.hasReferral
             ? "Primer pago registrado. Referido calificado y pendiente de liquidación si aplica."
             : "Primer pago registrado. Este negocio no tenía código de referido asociado.",
-          "success"
+          "success",
         );
       } else {
         showMessage(res.message ?? "Operación completada.", "success");
@@ -319,9 +339,14 @@ export default function Negocios() {
       closeFirstPaymentDialog();
       await fetchNegocios();
     } catch (e: unknown) {
-      const err = e as { response?: { data?: { error?: string } }; message?: string };
+      const err = e as {
+        response?: { data?: { error?: string } };
+        message?: string;
+      };
       const msg =
-        err.response?.data?.error ?? err.message ?? "No se pudo registrar el primer pago.";
+        err.response?.data?.error ??
+        err.message ??
+        "No se pudo registrar el primer pago.";
       showMessage(msg, "error");
     } finally {
       setFpSubmitting(false);
@@ -329,7 +354,7 @@ export default function Negocios() {
   };
 
   const getPlanForNegocio = (negocio: INegocio): IPlan | undefined =>
-    planes.find(p => p.id === negocio.planId);
+    planes.find((p) => p.id === negocio.planId);
 
   /** Solo negocios aún en plan gratuito/freemium (precio 0 o sin plan): ya en plan de pago no aplica registrar “primer pago” desde aquí. */
   const puedeMostrarBotonPrimerPago = (negocio: INegocio): boolean => {
@@ -339,7 +364,7 @@ export default function Negocios() {
   };
 
   const getPlanName = (negocio: INegocio): string =>
-    getPlanForNegocio(negocio)?.nombre ?? 'Sin plan';
+    getPlanForNegocio(negocio)?.nombre ?? "Sin plan";
 
   const getDaysRemaining = (limitTime: Date): number => {
     const now = new Date();
@@ -351,7 +376,10 @@ export default function Negocios() {
 
   const getPlanColor = (negocio: INegocio) => {
     const color = getPlanForNegocio(negocio)?.color;
-    return (color as 'default' | 'primary' | 'secondary' | 'success' | 'warning') || 'default';
+    return (
+      (color as "default" | "primary" | "secondary" | "success" | "warning") ||
+      "default"
+    );
   };
 
   const filteredNegocios = negocios.filter((negocio) => {
@@ -365,12 +393,22 @@ export default function Negocios() {
 
   // Cálculos para estadísticas
   const totalNegocios = negocios.length;
-  const negociosActivos = negocios.filter(n => getDaysRemaining(n.limitTime) > 0).length;
+  const negociosActivos = negocios.filter(
+    (n) => getDaysRemaining(n.limitTime) > 0,
+  ).length;
   const negociosExpirados = totalNegocios - negociosActivos;
   const negociosVisibles = filteredNegocios.length;
 
   // Componente para mostrar estadísticas de uso
-  const UsageStatsCard = ({ icon, title, actual, limite, porcentaje, color, compact = false }: {
+  const UsageStatsCard = ({
+    icon,
+    title,
+    actual,
+    limite,
+    porcentaje,
+    color,
+    compact = false,
+  }: {
     icon: React.ReactNode;
     title: string;
     actual: number;
@@ -384,7 +422,7 @@ export default function Negocios() {
     const isOverLimit = porcentaje >= 100 && !isUnlimited;
 
     return (
-      <Card variant="outlined" sx={{ height: '100%' }}>
+      <Card variant="outlined" sx={{ height: "100%" }}>
         <CardContent sx={{ p: compact ? 1.5 : 2 }}>
           <Stack spacing={compact ? 1 : 1.5}>
             {/* Header con icono y título */}
@@ -395,21 +433,21 @@ export default function Negocios() {
                   borderRadius: 1.5,
                   bgcolor: `${color}.light`,
                   color: `${color}.main`,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
                   minWidth: compact ? 24 : 32,
                   minHeight: compact ? 24 : 32,
                 }}
               >
                 {icon}
               </Box>
-              <Typography 
-                variant={compact ? "caption" : "body2"} 
+              <Typography
+                variant={compact ? "caption" : "body2"}
                 fontWeight="medium"
-                sx={{ 
-                  fontSize: compact ? '0.6875rem' : '0.875rem',
-                  lineHeight: 1.2
+                sx={{
+                  fontSize: compact ? "0.6875rem" : "0.875rem",
+                  lineHeight: 1.2,
                 }}
               >
                 {title}
@@ -418,36 +456,47 @@ export default function Negocios() {
 
             {/* Números principales */}
             <Box>
-              <Stack direction="row" alignItems="baseline" spacing={0.5} sx={{ mb: 0.5 }}>
-                <Typography 
-                  variant={compact ? "h6" : "h5"} 
+              <Stack
+                direction="row"
+                alignItems="baseline"
+                spacing={0.5}
+                sx={{ mb: 0.5 }}
+              >
+                <Typography
+                  variant={compact ? "h6" : "h5"}
                   fontWeight="bold"
-                  sx={{ 
-                    fontSize: compact ? '1rem' : '1.25rem',
-                    lineHeight: 1.2
+                  sx={{
+                    fontSize: compact ? "1rem" : "1.25rem",
+                    lineHeight: 1.2,
                   }}
                 >
                   {actual}
                 </Typography>
-                <Typography 
-                  variant="caption" 
+                <Typography
+                  variant="caption"
                   color="text.secondary"
-                  sx={{ fontSize: compact ? '0.625rem' : '0.75rem' }}
+                  sx={{ fontSize: compact ? "0.625rem" : "0.75rem" }}
                 >
-                  / {isUnlimited ? '∞' : limite}
+                  / {isUnlimited ? "∞" : limite}
                 </Typography>
                 {!isUnlimited && (
                   <Chip
                     label={formatPercentage(porcentaje)}
                     size="small"
-                    color={isOverLimit ? 'error' : isNearLimit ? 'warning' : 'success'}
+                    color={
+                      isOverLimit
+                        ? "error"
+                        : isNearLimit
+                          ? "warning"
+                          : "success"
+                    }
                     variant="outlined"
-                    sx={{ 
+                    sx={{
                       height: compact ? 16 : 20,
-                      fontSize: compact ? '0.625rem' : '0.75rem',
-                      '& .MuiChip-label': {
-                        px: compact ? 0.5 : 1
-                      }
+                      fontSize: compact ? "0.625rem" : "0.75rem",
+                      "& .MuiChip-label": {
+                        px: compact ? 0.5 : 1,
+                      },
                     }}
                   />
                 )}
@@ -461,11 +510,15 @@ export default function Negocios() {
                   sx={{
                     height: compact ? 4 : 6,
                     borderRadius: 2,
-                    backgroundColor: 'grey.200',
-                    '& .MuiLinearProgress-bar': {
-                      backgroundColor: isOverLimit ? 'error.main' : isNearLimit ? 'warning.main' : 'success.main',
+                    backgroundColor: "grey.200",
+                    "& .MuiLinearProgress-bar": {
+                      backgroundColor: isOverLimit
+                        ? "error.main"
+                        : isNearLimit
+                          ? "warning.main"
+                          : "success.main",
                       borderRadius: 2,
-                    }
+                    },
                   }}
                 />
               )}
@@ -477,13 +530,18 @@ export default function Negocios() {
   };
 
   // Componente de estadística general
-  const StatCard = ({ icon, value, label, color }: { 
-    icon: React.ReactNode, 
-    value: string, 
-    label: string, 
-    color: string 
+  const StatCard = ({
+    icon,
+    value,
+    label,
+    color,
+  }: {
+    icon: React.ReactNode;
+    value: string;
+    label: string;
+    color: string;
   }) => (
-    <Card sx={{ height: '100%' }}>
+    <Card sx={{ height: "100%" }}>
       <CardContent sx={{ p: isMobile ? 1 : 3 }}>
         <Stack direction="row" alignItems="center" spacing={isMobile ? 1 : 2}>
           <Box
@@ -491,10 +549,10 @@ export default function Negocios() {
               p: isMobile ? 1 : 1.5,
               borderRadius: 2,
               bgcolor: color,
-              color: 'white',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
+              color: "white",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
               minWidth: isMobile ? 40 : 48,
               minHeight: isMobile ? 40 : 48,
             }}
@@ -502,23 +560,23 @@ export default function Negocios() {
             {icon}
           </Box>
           <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Typography 
-              variant={isMobile ? "h5" : "h4"} 
+            <Typography
+              variant={isMobile ? "h5" : "h4"}
               fontWeight="bold"
-              sx={{ 
-                fontSize: isMobile ? '1.25rem' : '2rem',
+              sx={{
+                fontSize: isMobile ? "1.25rem" : "2rem",
                 lineHeight: 1.2,
-                wordBreak: 'break-all'
+                wordBreak: "break-all",
               }}
             >
               {value}
             </Typography>
-            <Typography 
-              variant="body2" 
+            <Typography
+              variant="body2"
               color="text.secondary"
-              sx={{ 
-                fontSize: isMobile ? '0.75rem' : '0.875rem',
-                lineHeight: 1.2
+              sx={{
+                fontSize: isMobile ? "0.75rem" : "0.875rem",
+                lineHeight: 1.2,
               }}
             >
               {label}
@@ -547,12 +605,23 @@ export default function Negocios() {
               <Typography variant="h6" fontWeight="bold" noWrap>
                 {negocio.nombre}
               </Typography>
-              <Stack direction="row" alignItems="center" gap={0.5} flexWrap="wrap" sx={{ mt: 0.25 }}>
+              <Stack
+                direction="row"
+                alignItems="center"
+                gap={0.5}
+                flexWrap="wrap"
+                sx={{ mt: 0.25 }}
+              >
                 <Typography variant="caption" color="text.secondary">
                   ID: {negocio.id.slice(0, 8)}...
                 </Typography>
                 {negocio.creadoPorActivacionLanding ? (
-                  <Chip label="Activación landing" size="small" color="info" variant="outlined" />
+                  <Chip
+                    label="Activación landing"
+                    size="small"
+                    color="info"
+                    variant="outlined"
+                  />
                 ) : null}
               </Stack>
             </Box>
@@ -567,7 +636,7 @@ export default function Negocios() {
               variant="filled"
             />
             <Chip
-              label={days > 0 ? 'Activo' : 'Expirado'}
+              label={days > 0 ? "Activo" : "Expirado"}
               size="small"
               color={getDaysRemainingColor(days)}
               variant="filled"
@@ -590,7 +659,12 @@ export default function Negocios() {
           </Box>
 
           {/* Botones de acción */}
-          <Stack direction="row" spacing={1} justifyContent="space-between" alignItems="center">
+          <Stack
+            direction="row"
+            spacing={1}
+            justifyContent="space-between"
+            alignItems="center"
+          >
             <Stack direction="row" spacing={0.5}>
               {puedeMostrarBotonPrimerPago(negocio) && (
                 <Tooltip title="Registrar primer pago (módulo referidos)">
@@ -622,14 +696,24 @@ export default function Negocios() {
                 </IconButton>
               </Tooltip>
             </Stack>
-            
-            <Tooltip title={isExpanded ? "Ocultar estadísticas" : "Ver estadísticas detalladas"}>
+
+            <Tooltip
+              title={
+                isExpanded
+                  ? "Ocultar estadísticas"
+                  : "Ver estadísticas detalladas"
+              }
+            >
               <IconButton
                 onClick={() => handleExpandNegocio(negocio.id)}
                 size="small"
                 color="info"
               >
-                {isExpanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+                {isExpanded ? (
+                  <ExpandLess fontSize="small" />
+                ) : (
+                  <ExpandMore fontSize="small" />
+                )}
               </IconButton>
             </Tooltip>
           </Stack>
@@ -637,11 +721,15 @@ export default function Negocios() {
           {/* Estadísticas expandidas */}
           <Collapse in={isExpanded} timeout="auto" unmountOnExit>
             <Divider sx={{ my: 2 }} />
-            <Typography variant="subtitle2" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="subtitle2"
+              gutterBottom
+              sx={{ display: "flex", alignItems: "center", gap: 1 }}
+            >
               <TrendingUp color="primary" fontSize="small" />
               Estadísticas de Uso
             </Typography>
-            
+
             {stats ? (
               <Grid container spacing={2}>
                 <Grid item xs={12}>
@@ -681,12 +769,15 @@ export default function Negocios() {
                     </Grid>
                   </Grid>
                 </Grid>
-                
+
                 <Grid item xs={12}>
                   <Card variant="outlined">
-                    <CardContent sx={{ p: 2, textAlign: 'center' }}>
+                    <CardContent sx={{ p: 2, textAlign: "center" }}>
                       <Stack alignItems="center" spacing={1}>
-                        <Schedule color={getDaysRemainingColor(stats.diasRestantes)} sx={{ fontSize: 24 }} />
+                        <Schedule
+                          color={getDaysRemainingColor(stats.diasRestantes)}
+                          sx={{ fontSize: 24 }}
+                        />
                         <Typography variant="body2" fontWeight="bold">
                           {formatDaysRemaining(stats.diasRestantes)}
                         </Typography>
@@ -699,9 +790,11 @@ export default function Negocios() {
                 </Grid>
               </Grid>
             ) : (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, p: 2 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 2, p: 2 }}>
                 <CircularProgress size={20} />
-                <Typography variant="body2">Cargando estadísticas...</Typography>
+                <Typography variant="body2">
+                  Cargando estadísticas...
+                </Typography>
               </Box>
             )}
           </Collapse>
@@ -711,9 +804,9 @@ export default function Negocios() {
   };
 
   const breadcrumbs = [
-    { label: 'Inicio', href: '/home' },
-    { label: 'Configuración', href: '/configuracion' },
-    { label: 'Negocios' }
+    { label: "Inicio", href: "/home" },
+    { label: "Configuración", href: "/configuracion" },
+    { label: "Negocios" },
   ];
 
   const headerActions = (
@@ -724,8 +817,15 @@ export default function Negocios() {
         </IconButton>
       </Tooltip>
       {isMobile && (
-        <Tooltip title={statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"}>
-          <IconButton onClick={() => setStatsExpanded(!statsExpanded)} size="small">
+        <Tooltip
+          title={
+            statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"
+          }
+        >
+          <IconButton
+            onClick={() => setStatsExpanded(!statsExpanded)}
+            size="small"
+          >
             {statsExpanded ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         </Tooltip>
@@ -748,7 +848,12 @@ export default function Negocios() {
         subtitle="Administra los negocios del sistema"
         breadcrumbs={breadcrumbs}
       >
-        <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          minHeight="200px"
+        >
           <CircularProgress />
           <Typography variant="body2" sx={{ mt: 2, ml: 2 }}>
             Cargando negocios...
@@ -766,7 +871,12 @@ export default function Negocios() {
         subtitle="Administra los negocios del sistema"
         breadcrumbs={breadcrumbs}
       >
-        <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          minHeight="200px"
+        >
           <CircularProgress />
           <Typography variant="body2" sx={{ mt: 2, ml: 2 }}>
             Verificando permisos...
@@ -784,7 +894,11 @@ export default function Negocios() {
   return (
     <PageContainer
       title="Gestión de Negocios"
-      subtitle={!isMobile ? "Administra los negocios del sistema y sus planes de suscripción" : undefined}
+      subtitle={
+        !isMobile
+          ? "Administra los negocios del sistema y sus planes de suscripción"
+          : undefined
+      }
       breadcrumbs={breadcrumbs}
       headerActions={headerActions}
       maxWidth="xl"
@@ -875,9 +989,15 @@ export default function Negocios() {
 
       <ContentCard
         title="Lista de Negocios"
-        subtitle={`${filteredNegocios.length} negocio${filteredNegocios.length !== 1 ? 's' : ''} encontrado${filteredNegocios.length !== 1 ? 's' : ''}`}
+        subtitle={`${filteredNegocios.length} negocio${filteredNegocios.length !== 1 ? "s" : ""} encontrado${filteredNegocios.length !== 1 ? "s" : ""}`}
         headerActions={
-          <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
+          <Stack
+            direction="row"
+            spacing={2}
+            alignItems="center"
+            flexWrap="wrap"
+            useFlexGap
+          >
             <FormControlLabel
               control={
                 <Switch
@@ -888,9 +1008,14 @@ export default function Negocios() {
                 />
               }
               label="Solo registro por landing"
-              sx={{ '& .MuiFormControlLabel-label': { fontSize: '0.875rem', whiteSpace: 'nowrap' } }}
+              sx={{
+                "& .MuiFormControlLabel-label": {
+                  fontSize: "0.875rem",
+                  whiteSpace: "nowrap",
+                },
+              }}
             />
-            <TextField
+            <SelectableTextField
               size="small"
               placeholder={isMobile ? "Buscar..." : "Buscar negocio..."}
               value={searchTerm}
@@ -904,7 +1029,7 @@ export default function Negocios() {
               }}
               sx={{
                 minWidth: isMobile ? 160 : 250,
-                maxWidth: isMobile ? 200 : 'none',
+                maxWidth: isMobile ? 200 : "none",
               }}
             />
           </Stack>
@@ -918,7 +1043,9 @@ export default function Negocios() {
             {filteredNegocios.length === 0 ? (
               <Box textAlign="center" py={4}>
                 <Typography variant="h6" color="text.secondary">
-                  {searchTerm ? 'No se encontraron negocios' : 'No hay negocios registrados'}
+                  {searchTerm
+                    ? "No se encontraron negocios"
+                    : "No hay negocios registrados"}
                 </Typography>
               </Box>
             ) : (
@@ -947,10 +1074,15 @@ export default function Negocios() {
                   const planData = getPlanForNegocio(negocio);
                   const stats = negocioStats[negocio.id];
                   const isExpanded = expandedNegocio === negocio.id;
-                  
+
                   return (
                     <>
-                      <TableRow key={negocio.id} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
+                      <TableRow
+                        key={negocio.id}
+                        sx={{
+                          "&:last-child td, &:last-child th": { border: 0 },
+                        }}
+                      >
                         <TableCell>
                           <Box display="flex" alignItems="center" gap={1}>
                             <Business color="primary" />
@@ -958,12 +1090,26 @@ export default function Negocios() {
                               <Typography variant="body2" fontWeight="medium">
                                 {negocio.nombre}
                               </Typography>
-                              <Stack direction="row" alignItems="center" gap={0.5} flexWrap="wrap" sx={{ mt: 0.25 }}>
-                                <Typography variant="caption" color="text.secondary">
+                              <Stack
+                                direction="row"
+                                alignItems="center"
+                                gap={0.5}
+                                flexWrap="wrap"
+                                sx={{ mt: 0.25 }}
+                              >
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                >
                                   ID: {negocio.id.slice(0, 8)}...
                                 </Typography>
                                 {negocio.creadoPorActivacionLanding ? (
-                                  <Chip label="Activación landing" size="small" color="info" variant="outlined" />
+                                  <Chip
+                                    label="Activación landing"
+                                    size="small"
+                                    color="info"
+                                    variant="outlined"
+                                  />
                                 ) : null}
                               </Stack>
                             </Box>
@@ -978,7 +1124,10 @@ export default function Negocios() {
                               variant="filled"
                             />
                             {planData && planData.precio > 0 && (
-                              <Typography variant="caption" color="success.main">
+                              <Typography
+                                variant="caption"
+                                color="success.main"
+                              >
                                 ${planData.precio}/mes
                               </Typography>
                             )}
@@ -986,7 +1135,7 @@ export default function Negocios() {
                         </TableCell>
                         <TableCell align="center">
                           <Chip
-                            label={days > 0 ? 'Activo' : 'Expirado'}
+                            label={days > 0 ? "Activo" : "Expirado"}
                             size="small"
                             color={getDaysRemainingColor(days)}
                             variant="filled"
@@ -997,26 +1146,45 @@ export default function Negocios() {
                             <Typography variant="body2" fontWeight="medium">
                               {formatDaysRemaining(days)}
                             </Typography>
-                            <Typography variant="caption" color="text.secondary">
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
                               {formatDate(negocio.limitTime)}
                             </Typography>
                           </Stack>
                         </TableCell>
                         <TableCell align="center">
-                          <Stack direction="row" spacing={0.5} justifyContent="center">
-                            <Tooltip title={isExpanded ? "Ocultar estadísticas" : "Ver estadísticas detalladas"}>
+                          <Stack
+                            direction="row"
+                            spacing={0.5}
+                            justifyContent="center"
+                          >
+                            <Tooltip
+                              title={
+                                isExpanded
+                                  ? "Ocultar estadísticas"
+                                  : "Ver estadísticas detalladas"
+                              }
+                            >
                               <IconButton
                                 onClick={() => handleExpandNegocio(negocio.id)}
                                 size="small"
                                 color="info"
                               >
-                                {isExpanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+                                {isExpanded ? (
+                                  <ExpandLess fontSize="small" />
+                                ) : (
+                                  <ExpandMore fontSize="small" />
+                                )}
                               </IconButton>
                             </Tooltip>
                             {puedeMostrarBotonPrimerPago(negocio) && (
                               <Tooltip title="Registrar primer pago (referidos)">
                                 <IconButton
-                                  onClick={() => openFirstPaymentDialog(negocio)}
+                                  onClick={() =>
+                                    openFirstPaymentDialog(negocio)
+                                  }
                                   size="small"
                                   color="success"
                                 >
@@ -1046,14 +1214,30 @@ export default function Negocios() {
                         </TableCell>
                       </TableRow>
                       <TableRow>
-                        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={5}>
-                          <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+                        <TableCell
+                          style={{ paddingBottom: 0, paddingTop: 0 }}
+                          colSpan={5}
+                        >
+                          <Collapse
+                            in={isExpanded}
+                            timeout="auto"
+                            unmountOnExit
+                          >
                             <Box sx={{ margin: 2 }}>
-                              <Typography variant="h6" gutterBottom component="div" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                              <Typography
+                                variant="h6"
+                                gutterBottom
+                                component="div"
+                                sx={{
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: 1,
+                                }}
+                              >
                                 <TrendingUp color="primary" />
                                 Estadísticas de Uso - {negocio.nombre}
                               </Typography>
-                              
+
                               {stats ? (
                                 <Grid container spacing={3}>
                                   <Grid item xs={12} md={9}>
@@ -1084,27 +1268,54 @@ export default function Negocios() {
                                           title="Productos"
                                           actual={stats.productos.actual}
                                           limite={stats.productos.limite}
-                                          porcentaje={stats.productos.porcentaje}
+                                          porcentaje={
+                                            stats.productos.porcentaje
+                                          }
                                           color="info"
                                         />
                                       </Grid>
                                     </Grid>
                                   </Grid>
-                                  
+
                                   <Grid item xs={12} md={3}>
-                                    <Card variant="outlined" sx={{ height: '100%' }}>
-                                      <CardContent sx={{ p: 2, textAlign: 'center' }}>
+                                    <Card
+                                      variant="outlined"
+                                      sx={{ height: "100%" }}
+                                    >
+                                      <CardContent
+                                        sx={{ p: 2, textAlign: "center" }}
+                                      >
                                         <Stack alignItems="center" spacing={1}>
-                                          <Schedule color={getDaysRemainingColor(stats.diasRestantes)} sx={{ fontSize: 32 }} />
-                                          <Typography variant="h6" fontWeight="bold">
-                                            {formatDaysRemaining(stats.diasRestantes)}
+                                          <Schedule
+                                            color={getDaysRemainingColor(
+                                              stats.diasRestantes,
+                                            )}
+                                            sx={{ fontSize: 32 }}
+                                          />
+                                          <Typography
+                                            variant="h6"
+                                            fontWeight="bold"
+                                          >
+                                            {formatDaysRemaining(
+                                              stats.diasRestantes,
+                                            )}
                                           </Typography>
-                                          <Typography variant="body2" color="text.secondary">
-                                            Vence el {formatDate(stats.fechaVencimiento)}
+                                          <Typography
+                                            variant="body2"
+                                            color="text.secondary"
+                                          >
+                                            Vence el{" "}
+                                            {formatDate(stats.fechaVencimiento)}
                                           </Typography>
                                           <Chip
-                                            label={stats.diasRestantes <= 0 ? 'Expirado' : 'Activo'}
-                                            color={getDaysRemainingColor(stats.diasRestantes)}
+                                            label={
+                                              stats.diasRestantes <= 0
+                                                ? "Expirado"
+                                                : "Activo"
+                                            }
+                                            color={getDaysRemainingColor(
+                                              stats.diasRestantes,
+                                            )}
                                             variant="filled"
                                             size="small"
                                           />
@@ -1114,9 +1325,18 @@ export default function Negocios() {
                                   </Grid>
                                 </Grid>
                               ) : (
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, p: 2 }}>
+                                <Box
+                                  sx={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: 2,
+                                    p: 2,
+                                  }}
+                                >
                                   <CircularProgress size={20} />
-                                  <Typography variant="body2">Cargando estadísticas...</Typography>
+                                  <Typography variant="body2">
+                                    Cargando estadísticas...
+                                  </Typography>
                                 </Box>
                               )}
                             </Box>
@@ -1128,11 +1348,13 @@ export default function Negocios() {
                 })}
               </TableBody>
             </Table>
-            
+
             {filteredNegocios.length === 0 && (
               <Box textAlign="center" py={4}>
                 <Typography variant="h6" color="text.secondary">
-                  {searchTerm ? 'No se encontraron negocios' : 'No hay negocios registrados'}
+                  {searchTerm
+                    ? "No se encontraron negocios"
+                    : "No hay negocios registrados"}
                 </Typography>
               </Box>
             )}
@@ -1141,17 +1363,17 @@ export default function Negocios() {
       </ContentCard>
 
       {/* Dialog para crear/editar negocio */}
-      <Dialog 
-        open={open} 
-        onClose={handleCloseDialog} 
-        fullWidth 
+      <Dialog
+        open={open}
+        onClose={handleCloseDialog}
+        fullWidth
         maxWidth="sm"
         fullScreen={isMobile}
         PaperProps={{
           sx: {
             borderRadius: isMobile ? 0 : 3,
-            m: isMobile ? 0 : 2
-          }
+            m: isMobile ? 0 : 2,
+          },
         }}
       >
         <DialogTitle sx={{ pb: 1 }}>
@@ -1173,15 +1395,17 @@ export default function Negocios() {
               required
               size={isMobile ? "small" : "medium"}
             />
-            
+
             <Box>
               <Typography variant="subtitle2" gutterBottom>
                 Plan de Suscripción
               </Typography>
               <Select
                 fullWidth
-                value={selectedPlan?.id ?? ''}
-                onChange={(e) => handleSetSelectedPlan(e.target.value as string)}
+                value={selectedPlan?.id ?? ""}
+                onChange={(e) =>
+                  handleSetSelectedPlan(e.target.value as string)
+                }
                 displayEmpty
                 size={isMobile ? "small" : "medium"}
               >
@@ -1204,25 +1428,29 @@ export default function Negocios() {
                           />
                         )}
                       </Box>
-                      <Typography variant="caption" color="text.secondary" display="block">
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        display="block"
+                      >
                         {planData.descripcion}
                       </Typography>
                       <Box display="flex" gap={1} mt={0.5}>
                         <Chip
                           icon={<Store />}
-                          label={`${planData.limiteLocales === -1 ? '∞' : planData.limiteLocales} tiendas`}
+                          label={`${planData.limiteLocales === -1 ? "∞" : planData.limiteLocales} tiendas`}
                           size="small"
                           variant="outlined"
                         />
                         <Chip
                           icon={<Person />}
-                          label={`${planData.limiteUsuarios === -1 ? '∞' : planData.limiteUsuarios} usuarios`}
+                          label={`${planData.limiteUsuarios === -1 ? "∞" : planData.limiteUsuarios} usuarios`}
                           size="small"
                           variant="outlined"
                         />
                         <Chip
                           icon={<Inventory />}
-                          label={`${planData.limiteProductos === -1 ? '∞' : planData.limiteProductos} productos`}
+                          label={`${planData.limiteProductos === -1 ? "∞" : planData.limiteProductos} productos`}
                           size="small"
                           variant="outlined"
                         />
@@ -1242,26 +1470,36 @@ export default function Negocios() {
                   {selectedPlan.descripcion}
                 </Typography>
                 <Typography variant="body2" sx={{ mt: 0.5 }}>
-                  <strong>Validez:</strong> {selectedPlan.duracion > 0 ? selectedPlan.duracion : 'Cantidad personalizable de'} días desde la activación
+                  <strong>Validez:</strong>{" "}
+                  {selectedPlan.duracion > 0
+                    ? selectedPlan.duracion
+                    : "Cantidad personalizable de"}{" "}
+                  días desde la activación
                 </Typography>
               </Alert>
             )}
           </Stack>
         </DialogContent>
         <DialogActions sx={{ p: isMobile ? 1.5 : 3, gap: 1 }}>
-          <Button onClick={handleCloseDialog} color="secondary" size={isMobile ? "medium" : "large"}>
+          <Button
+            onClick={handleCloseDialog}
+            color="secondary"
+            size={isMobile ? "medium" : "large"}
+          >
             Cancelar
           </Button>
-          <Button 
-            onClick={handleSave} 
-            variant="contained" 
+          <Button
+            onClick={handleSave}
+            variant="contained"
             disabled={!nombre || !selectedPlan || loading}
             size={isMobile ? "medium" : "large"}
           >
             {loading ? (
               <CircularProgress size={20} />
+            ) : selectedNegocio ? (
+              "Actualizar"
             ) : (
-              selectedNegocio ? "Actualizar" : "Crear"
+              "Crear"
             )}
           </Button>
         </DialogActions>
@@ -1294,8 +1532,9 @@ export default function Negocios() {
               Negocio: <strong>{fpNegocio?.nombre ?? "—"}</strong>
             </Typography>
             <Alert severity="info" icon={<Info />}>
-              Marca el plan que contrató el cliente al pagar en efectivo. Si había referido, se califica y se
-              generan los montos según la tabla de reglas. Requiere una regla activa por plan en base de datos.
+              Marca el plan que contrató el cliente al pagar en efectivo. Si
+              había referido, se califica y se generan los montos según la tabla
+              de reglas. Requiere una regla activa por plan en base de datos.
             </Alert>
             <Box>
               <Typography variant="subtitle2" gutterBottom>
@@ -1342,7 +1581,11 @@ export default function Negocios() {
           </Stack>
         </DialogContent>
         <DialogActions sx={{ p: isMobile ? 1.5 : 3, gap: 1 }}>
-          <Button onClick={closeFirstPaymentDialog} color="secondary" disabled={fpSubmitting}>
+          <Button
+            onClick={closeFirstPaymentDialog}
+            color="secondary"
+            disabled={fpSubmitting}
+          >
             Cancelar
           </Button>
           <Button
@@ -1351,7 +1594,11 @@ export default function Negocios() {
             color="success"
             disabled={!fpPlanId || fpSubmitting}
           >
-            {fpSubmitting ? <CircularProgress size={22} /> : "Confirmar primer pago"}
+            {fpSubmitting ? (
+              <CircularProgress size={22} />
+            ) : (
+              "Confirmar primer pago"
+            )}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/app/configuracion/notificaciones/page.tsx
+++ b/src/app/configuracion/notificaciones/page.tsx
@@ -1,21 +1,21 @@
-"use client"
+"use client";
 
 import React, { useEffect, useState } from "react";
-import { 
-  Typography, 
-  Button, 
-  Table, 
-  TableBody, 
-  TableCell, 
-  TableContainer, 
-  TableHead, 
-  TableRow, 
-  IconButton, 
-  Dialog, 
-  DialogTitle, 
-  DialogContent, 
-  DialogActions, 
-  TextField, 
+import {
+  Typography,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
   Box,
   CircularProgress,
   InputAdornment,
@@ -32,11 +32,11 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  Autocomplete
+  Autocomplete,
 } from "@mui/material";
-import { 
-  Edit, 
-  Delete, 
+import {
+  Edit,
+  Delete,
   Add,
   Search,
   Refresh,
@@ -45,21 +45,29 @@ import {
   Warning,
   Info,
   Campaign,
-  Message
+  Message,
 } from "@mui/icons-material";
 import { NotificationApiService } from "@/services/notificationApiService";
-import { INotificacion, INotificacionFormData, INotificacionStats, NivelImportancia, TipoNotificacion } from "@/schemas/notificacion";
+import {
+  INotificacion,
+  INotificacionFormData,
+  INotificacionStats,
+  NivelImportancia,
+  TipoNotificacion,
+} from "@/schemas/notificacion";
 import useConfirmDialog from "@/components/confirmDialog";
 import { PageContainer } from "@/components/PageContainer";
 import { ContentCard } from "@/components/ContentCard";
+import SelectableTextField from "@/components/SelectableTextField";
 import { useMessageContext } from "@/context/MessageContext";
-import dayjs from 'dayjs';
+import dayjs from "dayjs";
 import { INegocio } from "@/schemas/negocio";
 
 export default function NotificacionesPage() {
   const [notificaciones, setNotificaciones] = useState<INotificacion[]>([]);
   const [open, setOpen] = useState(false);
-  const [selectedNotificacion, setSelectedNotificacion] = useState<INotificacion | null>(null);
+  const [selectedNotificacion, setSelectedNotificacion] =
+    useState<INotificacion | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
@@ -68,24 +76,24 @@ export default function NotificacionesPage() {
   const [negocios, setNegocios] = useState<INegocio[]>([]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [usuarios, setUsuarios] = useState<any[]>([]);
-  
+
   // Form data
   const [formData, setFormData] = useState<INotificacionFormData>({
     titulo: "",
     descripcion: "",
-    fechaInicio: dayjs().format('YYYY-MM-DDTHH:mm'),
-    fechaFin: dayjs().add(7, 'day').format('YYYY-MM-DDTHH:mm'),
-    nivelImportancia: 'MEDIA',
-    tipo: 'NOTIFICACION',
+    fechaInicio: dayjs().format("YYYY-MM-DDTHH:mm"),
+    fechaFin: dayjs().add(7, "day").format("YYYY-MM-DDTHH:mm"),
+    nivelImportancia: "MEDIA",
+    tipo: "NOTIFICACION",
     negociosDestino: [],
-    usuariosDestino: []
+    usuariosDestino: [],
   });
 
   const { ConfirmDialogComponent, confirmDialog } = useConfirmDialog();
   const { showMessage } = useMessageContext();
-  
+
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {
     fetchNotificaciones();
@@ -118,7 +126,7 @@ export default function NotificacionesPage() {
 
   const fetchNegocios = async () => {
     try {
-      const response = await fetch('/api/negocio');
+      const response = await fetch("/api/negocio");
       const data = await response.json();
       setNegocios(data);
     } catch (error) {
@@ -128,7 +136,7 @@ export default function NotificacionesPage() {
 
   const fetchUsuarios = async () => {
     try {
-      const response = await fetch('/api/usuarios');
+      const response = await fetch("/api/usuarios");
       const data = await response.json();
       setUsuarios(data);
     } catch (error) {
@@ -142,24 +150,28 @@ export default function NotificacionesPage() {
       setFormData({
         titulo: notificacion.titulo,
         descripcion: notificacion.descripcion,
-        fechaInicio: dayjs(notificacion.fechaInicio).format('YYYY-MM-DDTHH:mm'),
-        fechaFin: dayjs(notificacion.fechaFin).format('YYYY-MM-DDTHH:mm'),
+        fechaInicio: dayjs(notificacion.fechaInicio).format("YYYY-MM-DDTHH:mm"),
+        fechaFin: dayjs(notificacion.fechaFin).format("YYYY-MM-DDTHH:mm"),
         nivelImportancia: notificacion.nivelImportancia,
         tipo: notificacion.tipo,
-        negociosDestino: NotificationApiService.stringToArray(notificacion.negociosDestino),
-        usuariosDestino: NotificationApiService.stringToArray(notificacion.usuariosDestino)
+        negociosDestino: NotificationApiService.stringToArray(
+          notificacion.negociosDestino,
+        ),
+        usuariosDestino: NotificationApiService.stringToArray(
+          notificacion.usuariosDestino,
+        ),
       });
     } else {
       setSelectedNotificacion(null);
       setFormData({
         titulo: "",
         descripcion: "",
-        fechaInicio: dayjs().format('YYYY-MM-DDTHH:mm'),
-        fechaFin: dayjs().add(7, 'day').format('YYYY-MM-DDTHH:mm'),
-        nivelImportancia: 'MEDIA',
-        tipo: 'NOTIFICACION',
+        fechaInicio: dayjs().format("YYYY-MM-DDTHH:mm"),
+        fechaFin: dayjs().add(7, "day").format("YYYY-MM-DDTHH:mm"),
+        nivelImportancia: "MEDIA",
+        tipo: "NOTIFICACION",
         negociosDestino: [],
-        usuariosDestino: []
+        usuariosDestino: [],
       });
     }
     setOpen(true);
@@ -191,14 +203,20 @@ export default function NotificacionesPage() {
     }
 
     if (new Date(formData.fechaInicio) >= new Date(formData.fechaFin)) {
-      showMessage("La fecha de inicio debe ser anterior a la fecha de fin", "warning");
+      showMessage(
+        "La fecha de inicio debe ser anterior a la fecha de fin",
+        "warning",
+      );
       return;
     }
 
     setSaving(true);
     try {
       if (selectedNotificacion) {
-        await NotificationApiService.updateNotification(selectedNotificacion.id, formData);
+        await NotificationApiService.updateNotification(
+          selectedNotificacion.id,
+          formData,
+        );
         showMessage("Notificación actualizada exitosamente", "success");
       } else {
         await NotificationApiService.createNotification(formData);
@@ -218,7 +236,10 @@ export default function NotificacionesPage() {
   const handleRunAutoCheck = async () => {
     try {
       await NotificationApiService.runAutomaticChecks();
-      showMessage("Verificaciones automáticas ejecutadas exitosamente", "success");
+      showMessage(
+        "Verificaciones automáticas ejecutadas exitosamente",
+        "success",
+      );
       fetchNotificaciones();
       fetchStats();
     } catch (error) {
@@ -227,19 +248,20 @@ export default function NotificacionesPage() {
     }
   };
 
-  const filteredNotificaciones = notificaciones.filter((notif) =>
-    notif.titulo.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    notif.descripcion.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    notif.tipo.toLowerCase().includes(searchTerm.toLowerCase())
+  const filteredNotificaciones = notificaciones.filter(
+    (notif) =>
+      notif.titulo.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      notif.descripcion.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      notif.tipo.toLowerCase().includes(searchTerm.toLowerCase()),
   );
 
   const getTipoIcon = (tipo: TipoNotificacion) => {
     switch (tipo) {
-      case 'ALERTA':
+      case "ALERTA":
         return <Warning color="error" />;
-      case 'PROMOCION':
+      case "PROMOCION":
         return <Campaign color="secondary" />;
-      case 'MENSAJE':
+      case "MENSAJE":
         return <Message color="primary" />;
       default:
         return <Info color="info" />;
@@ -248,43 +270,61 @@ export default function NotificacionesPage() {
 
   const getImportanceColor = (nivel: NivelImportancia) => {
     switch (nivel) {
-      case 'CRITICA':
-        return 'error';
-      case 'ALTA':
-        return 'warning';
-      case 'MEDIA':
-        return 'info';
+      case "CRITICA":
+        return "error";
+      case "ALTA":
+        return "warning";
+      case "MEDIA":
+        return "info";
       default:
-        return 'success';
+        return "success";
     }
   };
 
   const isActive = (notificacion: INotificacion) => {
     const ahora = new Date();
-    return ahora >= new Date(notificacion.fechaInicio) && ahora <= new Date(notificacion.fechaFin);
+    return (
+      ahora >= new Date(notificacion.fechaInicio) &&
+      ahora <= new Date(notificacion.fechaFin)
+    );
   };
 
   const breadcrumbs = [
-    { label: 'Inicio', href: '/home' },
-    { label: 'Configuración', href: '/configuracion' },
-    { label: 'Notificaciones' }
+    { label: "Inicio", href: "/home" },
+    { label: "Configuración", href: "/configuracion" },
+    { label: "Notificaciones" },
   ];
 
   const headerActions = (
     <Stack direction="row" spacing={0.5} alignItems="center">
       <Tooltip title="Ejecutar verificaciones automáticas">
-        <IconButton onClick={handleRunAutoCheck} disabled={loading} size="small">
+        <IconButton
+          onClick={handleRunAutoCheck}
+          disabled={loading}
+          size="small"
+        >
           <Refresh />
         </IconButton>
       </Tooltip>
       <Tooltip title="Actualizar notificaciones">
-        <IconButton onClick={fetchNotificaciones} disabled={loading} size="small">
+        <IconButton
+          onClick={fetchNotificaciones}
+          disabled={loading}
+          size="small"
+        >
           <Refresh />
         </IconButton>
       </Tooltip>
       {isMobile && (
-        <Tooltip title={statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"}>
-          <IconButton onClick={() => setStatsExpanded(!statsExpanded)} size="small">
+        <Tooltip
+          title={
+            statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"
+          }
+        >
+          <IconButton
+            onClick={() => setStatsExpanded(!statsExpanded)}
+            size="small"
+          >
             {statsExpanded ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         </Tooltip>
@@ -369,7 +409,7 @@ export default function NotificacionesPage() {
       {/* Tabla de Notificaciones */}
       <ContentCard>
         <Box sx={{ mb: 2 }}>
-          <TextField
+          <SelectableTextField
             fullWidth
             variant="outlined"
             placeholder="Buscar notificaciones..."
@@ -425,7 +465,9 @@ export default function NotificacionesPage() {
                     <TableCell>
                       <Chip
                         label={notificacion.nivelImportancia}
-                        color={getImportanceColor(notificacion.nivelImportancia)}
+                        color={getImportanceColor(
+                          notificacion.nivelImportancia,
+                        )}
                         size="small"
                       />
                     </TableCell>
@@ -438,12 +480,16 @@ export default function NotificacionesPage() {
                     </TableCell>
                     <TableCell>
                       <Typography variant="body2">
-                        {dayjs(notificacion.fechaInicio).format('DD/MM/YYYY HH:mm')}
+                        {dayjs(notificacion.fechaInicio).format(
+                          "DD/MM/YYYY HH:mm",
+                        )}
                       </Typography>
                     </TableCell>
                     <TableCell>
                       <Typography variant="body2">
-                        {dayjs(notificacion.fechaFin).format('DD/MM/YYYY HH:mm')}
+                        {dayjs(notificacion.fechaFin).format(
+                          "DD/MM/YYYY HH:mm",
+                        )}
                       </Typography>
                     </TableCell>
                     <TableCell>
@@ -478,7 +524,9 @@ export default function NotificacionesPage() {
       {/* Dialog para crear/editar notificación */}
       <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
         <DialogTitle>
-          {selectedNotificacion ? "Editar Notificación" : "Crear Nueva Notificación"}
+          {selectedNotificacion
+            ? "Editar Notificación"
+            : "Crear Nueva Notificación"}
         </DialogTitle>
         <DialogContent>
           <Grid container spacing={2} sx={{ mt: 1 }}>
@@ -487,7 +535,9 @@ export default function NotificacionesPage() {
                 fullWidth
                 label="Título"
                 value={formData.titulo}
-                onChange={(e) => setFormData({ ...formData, titulo: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, titulo: e.target.value })
+                }
                 required
               />
             </Grid>
@@ -496,7 +546,9 @@ export default function NotificacionesPage() {
                 fullWidth
                 label="Descripción"
                 value={formData.descripcion}
-                onChange={(e) => setFormData({ ...formData, descripcion: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, descripcion: e.target.value })
+                }
                 multiline
                 rows={3}
                 required
@@ -508,7 +560,9 @@ export default function NotificacionesPage() {
                 label="Fecha de Inicio"
                 type="datetime-local"
                 value={formData.fechaInicio}
-                onChange={(e) => setFormData({ ...formData, fechaInicio: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, fechaInicio: e.target.value })
+                }
                 InputLabelProps={{ shrink: true }}
                 required
               />
@@ -519,7 +573,9 @@ export default function NotificacionesPage() {
                 label="Fecha de Fin"
                 type="datetime-local"
                 value={formData.fechaFin}
-                onChange={(e) => setFormData({ ...formData, fechaFin: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, fechaFin: e.target.value })
+                }
                 InputLabelProps={{ shrink: true }}
                 required
               />
@@ -529,7 +585,12 @@ export default function NotificacionesPage() {
                 <InputLabel>Tipo</InputLabel>
                 <Select
                   value={formData.tipo}
-                  onChange={(e) => setFormData({ ...formData, tipo: e.target.value as TipoNotificacion })}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      tipo: e.target.value as TipoNotificacion,
+                    })
+                  }
                   label="Tipo"
                 >
                   <MenuItem value="ALERTA">Alerta</MenuItem>
@@ -544,7 +605,12 @@ export default function NotificacionesPage() {
                 <InputLabel>Nivel de Importancia</InputLabel>
                 <Select
                   value={formData.nivelImportancia}
-                  onChange={(e) => setFormData({ ...formData, nivelImportancia: e.target.value as NivelImportancia })}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      nivelImportancia: e.target.value as NivelImportancia,
+                    })
+                  }
                   label="Nivel de Importancia"
                 >
                   <MenuItem value="BAJA">Baja</MenuItem>
@@ -559,11 +625,13 @@ export default function NotificacionesPage() {
                 multiple
                 options={negocios}
                 getOptionLabel={(option) => option.nombre}
-                value={negocios.filter(n => formData.negociosDestino.includes(n.id))}
+                value={negocios.filter((n) =>
+                  formData.negociosDestino.includes(n.id),
+                )}
                 onChange={(_, newValue) => {
                   setFormData({
                     ...formData,
-                    negociosDestino: newValue.map(n => n.id)
+                    negociosDestino: newValue.map((n) => n.id),
                   });
                 }}
                 renderInput={(params) => (
@@ -580,11 +648,13 @@ export default function NotificacionesPage() {
                 multiple
                 options={usuarios}
                 getOptionLabel={(option) => option.nombre}
-                value={usuarios.filter(u => formData.usuariosDestino.includes(u.id))}
+                value={usuarios.filter((u) =>
+                  formData.usuariosDestino.includes(u.id),
+                )}
                 onChange={(_, newValue) => {
                   setFormData({
                     ...formData,
-                    usuariosDestino: newValue.map(u => u.id)
+                    usuariosDestino: newValue.map((u) => u.id),
                   });
                 }}
                 renderInput={(params) => (

--- a/src/app/configuracion/proveedores/page.tsx
+++ b/src/app/configuracion/proveedores/page.tsx
@@ -34,9 +34,9 @@ import {
   MenuItem,
   Avatar,
 } from "@mui/material";
-import { 
-  Delete, 
-  Edit, 
+import {
+  Delete,
+  Edit,
   Add,
   Business,
   Phone,
@@ -51,17 +51,29 @@ import {
 } from "@mui/icons-material";
 import { PageContainer } from "@/components/PageContainer";
 import { ContentCard } from "@/components/ContentCard";
+import SelectableTextField from "@/components/SelectableTextField";
 import { useMessageContext } from "@/context/MessageContext";
 import useConfirmDialog from "@/components/confirmDialog";
-import { getProveedores, createProveedor, updateProveedor, deleteProveedor } from "@/services/proveedorService";
-import { IProveedor, IProveedorCreate, IProveedorUpdate } from "@/schemas/proveedor";
+import {
+  getProveedores,
+  createProveedor,
+  updateProveedor,
+  deleteProveedor,
+} from "@/services/proveedorService";
+import {
+  IProveedor,
+  IProveedorCreate,
+  IProveedorUpdate,
+} from "@/schemas/proveedor";
 import { getUsuarios, IUsuarioBasico } from "@/services/usuarioService";
 
 export default function Proveedores() {
   const [proveedores, setProveedores] = useState<IProveedor[]>([]);
   const [usuarios, setUsuarios] = useState<IUsuarioBasico[]>([]);
   const [open, setOpen] = useState(false);
-  const [selectedProveedor, setSelectedProveedor] = useState<IProveedor | null>(null);
+  const [selectedProveedor, setSelectedProveedor] = useState<IProveedor | null>(
+    null,
+  );
   const [nombre, setNombre] = useState("");
   const [descripcion, setDescripcion] = useState("");
   const [direccion, setDireccion] = useState("");
@@ -73,9 +85,9 @@ export default function Proveedores() {
   const [statsExpanded, setStatsExpanded] = useState(false);
   const { showMessage } = useMessageContext();
   const { ConfirmDialogComponent, confirmDialog } = useConfirmDialog();
-  
+
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {
     fetchProveedores();
@@ -122,7 +134,10 @@ export default function Proveedores() {
       };
 
       if (selectedProveedor) {
-        await updateProveedor(selectedProveedor.id, proveedorData as IProveedorUpdate);
+        await updateProveedor(
+          selectedProveedor.id,
+          proveedorData as IProveedorUpdate,
+        );
         showMessage("Proveedor actualizado exitosamente", "success");
       } else {
         await createProveedor(proveedorData as IProveedorCreate);
@@ -133,7 +148,8 @@ export default function Proveedores() {
       handleClose();
     } catch (error) {
       console.error("Error al guardar proveedor:", error);
-      const errorMessage = error.response?.data?.error || "Error al guardar el proveedor";
+      const errorMessage =
+        error.response?.data?.error || "Error al guardar el proveedor";
       showMessage(errorMessage, "error");
     } finally {
       setSaving(false);
@@ -141,7 +157,7 @@ export default function Proveedores() {
   };
 
   const handleDelete = async (id: string) => {
-    const proveedor = proveedores.find(p => p.id === id);
+    const proveedor = proveedores.find((p) => p.id === id);
     if (!proveedor) return;
 
     confirmDialog(
@@ -153,10 +169,11 @@ export default function Proveedores() {
           await fetchProveedores();
         } catch (error) {
           console.error("Error al eliminar proveedor:", error);
-          const errorMessage = error.response?.data?.error || "Error al eliminar el proveedor";
+          const errorMessage =
+            error.response?.data?.error || "Error al eliminar el proveedor";
           showMessage(errorMessage, "error");
         }
-      }
+      },
     );
   };
 
@@ -184,21 +201,23 @@ export default function Proveedores() {
     resetForm();
   };
 
-  const filteredProveedores = proveedores.filter(proveedor =>
-    proveedor.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (proveedor.descripcion && proveedor.descripcion.toLowerCase().includes(searchTerm.toLowerCase()))
+  const filteredProveedores = proveedores.filter(
+    (proveedor) =>
+      proveedor.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (proveedor.descripcion &&
+        proveedor.descripcion.toLowerCase().includes(searchTerm.toLowerCase())),
   );
 
   // Cálculos para estadísticas
   const totalProveedores = proveedores.length;
-  const proveedoresConTelefono = proveedores.filter(p => p.telefono).length;
-  const proveedoresConDireccion = proveedores.filter(p => p.direccion).length;
-  const proveedoresConUsuario = proveedores.filter(p => p.usuarioId).length;
+  const proveedoresConTelefono = proveedores.filter((p) => p.telefono).length;
+  const proveedoresConDireccion = proveedores.filter((p) => p.direccion).length;
+  const proveedoresConUsuario = proveedores.filter((p) => p.usuarioId).length;
 
   const breadcrumbs = [
-    { label: 'Inicio', href: '/home' },
-    { label: 'Configuración', href: '/configuracion' },
-    { label: 'Proveedores' }
+    { label: "Inicio", href: "/home" },
+    { label: "Configuración", href: "/configuracion" },
+    { label: "Proveedores" },
   ];
 
   const headerActions = (
@@ -209,8 +228,15 @@ export default function Proveedores() {
         </IconButton>
       </Tooltip>
       {isMobile && (
-        <Tooltip title={statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"}>
-          <IconButton onClick={() => setStatsExpanded(!statsExpanded)} size="small">
+        <Tooltip
+          title={
+            statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"
+          }
+        >
+          <IconButton
+            onClick={() => setStatsExpanded(!statsExpanded)}
+            size="small"
+          >
             {statsExpanded ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         </Tooltip>
@@ -238,7 +264,7 @@ export default function Proveedores() {
           <Grid container spacing={2}>
             <Grid item xs={12} sm={6} md={3}>
               <Card>
-                <CardContent sx={{ textAlign: 'center', py: 2 }}>
+                <CardContent sx={{ textAlign: "center", py: 2 }}>
                   <Typography variant="h4" color="primary" fontWeight="bold">
                     {totalProveedores}
                   </Typography>
@@ -250,8 +276,12 @@ export default function Proveedores() {
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
               <Card>
-                <CardContent sx={{ textAlign: 'center', py: 2 }}>
-                  <Typography variant="h4" color="success.main" fontWeight="bold">
+                <CardContent sx={{ textAlign: "center", py: 2 }}>
+                  <Typography
+                    variant="h4"
+                    color="success.main"
+                    fontWeight="bold"
+                  >
                     {proveedoresConTelefono}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
@@ -262,7 +292,7 @@ export default function Proveedores() {
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
               <Card>
-                <CardContent sx={{ textAlign: 'center', py: 2 }}>
+                <CardContent sx={{ textAlign: "center", py: 2 }}>
                   <Typography variant="h4" color="info.main" fontWeight="bold">
                     {proveedoresConDireccion}
                   </Typography>
@@ -274,8 +304,12 @@ export default function Proveedores() {
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
               <Card>
-                <CardContent sx={{ textAlign: 'center', py: 2 }}>
-                  <Typography variant="h4" color="secondary.main" fontWeight="bold">
+                <CardContent sx={{ textAlign: "center", py: 2 }}>
+                  <Typography
+                    variant="h4"
+                    color="secondary.main"
+                    fontWeight="bold"
+                  >
                     {proveedoresConUsuario}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
@@ -291,9 +325,9 @@ export default function Proveedores() {
       {/* Contenido principal */}
       <ContentCard
         title="Lista de Proveedores"
-        subtitle={`${filteredProveedores.length} proveedor${filteredProveedores.length !== 1 ? 'es' : ''} encontrado${filteredProveedores.length !== 1 ? 's' : ''}`}
+        subtitle={`${filteredProveedores.length} proveedor${filteredProveedores.length !== 1 ? "es" : ""} encontrado${filteredProveedores.length !== 1 ? "s" : ""}`}
         headerActions={
-          <TextField
+          <SelectableTextField
             size="small"
             placeholder="Buscar proveedores..."
             value={searchTerm}
@@ -310,20 +344,23 @@ export default function Proveedores() {
         }
       >
         {loading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
             <CircularProgress />
           </Box>
         ) : filteredProveedores.length === 0 ? (
-          <Box sx={{ textAlign: 'center', py: 4 }}>
-            <LocalShipping sx={{ fontSize: 64, color: 'text.secondary', mb: 2 }} />
+          <Box sx={{ textAlign: "center", py: 4 }}>
+            <LocalShipping
+              sx={{ fontSize: 64, color: "text.secondary", mb: 2 }}
+            />
             <Typography variant="h6" color="text.secondary" gutterBottom>
-              {searchTerm ? 'No se encontraron proveedores' : 'No hay proveedores registrados'}
+              {searchTerm
+                ? "No se encontraron proveedores"
+                : "No hay proveedores registrados"}
             </Typography>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-              {searchTerm 
-                ? 'Intenta con otros términos de búsqueda' 
-                : 'Comienza agregando tu primer proveedor'
-              }
+              {searchTerm
+                ? "Intenta con otros términos de búsqueda"
+                : "Comienza agregando tu primer proveedor"}
             </Typography>
             {!searchTerm && (
               <Button
@@ -340,25 +377,37 @@ export default function Proveedores() {
           <Box sx={{ p: 1.5 }}>
             <Stack spacing={1.5}>
               {filteredProveedores.map((proveedor) => (
-                <Card 
+                <Card
                   key={proveedor.id}
                   onClick={() => handleEdit(proveedor)}
                   sx={{
-                    cursor: 'pointer',
-                    '&:hover': {
-                      backgroundColor: 'action.hover',
+                    cursor: "pointer",
+                    "&:hover": {
+                      backgroundColor: "action.hover",
                     },
                   }}
                 >
-                  <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
+                  <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
                     <Stack spacing={1.5}>
-                      <Box display="flex" justifyContent="space-between" alignItems="center">
+                      <Box
+                        display="flex"
+                        justifyContent="space-between"
+                        alignItems="center"
+                      >
                         <Box sx={{ flex: 1 }}>
-                          <Typography variant="subtitle2" fontWeight="medium" sx={{ fontSize: '0.875rem' }}>
+                          <Typography
+                            variant="subtitle2"
+                            fontWeight="medium"
+                            sx={{ fontSize: "0.875rem" }}
+                          >
                             {proveedor.nombre}
                           </Typography>
                           {proveedor.descripcion && (
-                            <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.75rem' }}>
+                            <Typography
+                              variant="body2"
+                              color="text.secondary"
+                              sx={{ fontSize: "0.75rem" }}
+                            >
                               {proveedor.descripcion}
                             </Typography>
                           )}
@@ -374,16 +423,19 @@ export default function Proveedores() {
                           <Delete fontSize="small" />
                         </IconButton>
                       </Box>
-                      
+
                       <Box display="flex" gap={1} flexWrap="wrap">
                         {proveedor.usuarioId && (
                           <Chip
                             icon={<Person fontSize="small" />}
-                            label={usuarios.find(u => u.id === proveedor.usuarioId)?.nombre || 'Usuario'}
+                            label={
+                              usuarios.find((u) => u.id === proveedor.usuarioId)
+                                ?.nombre || "Usuario"
+                            }
                             size="small"
                             variant="outlined"
                             color="primary"
-                            sx={{ fontSize: '0.6875rem', height: 20 }}
+                            sx={{ fontSize: "0.6875rem", height: 20 }}
                           />
                         )}
                         {proveedor.telefono && (
@@ -393,7 +445,7 @@ export default function Proveedores() {
                             size="small"
                             variant="outlined"
                             color="success"
-                            sx={{ fontSize: '0.6875rem', height: 20 }}
+                            sx={{ fontSize: "0.6875rem", height: 20 }}
                           />
                         )}
                         {proveedor.direccion && (
@@ -403,7 +455,7 @@ export default function Proveedores() {
                             size="small"
                             variant="outlined"
                             color="info"
-                            sx={{ fontSize: '0.6875rem', height: 20 }}
+                            sx={{ fontSize: "0.6875rem", height: 20 }}
                           />
                         )}
                       </Box>
@@ -429,16 +481,16 @@ export default function Proveedores() {
               </TableHead>
               <TableBody>
                 {filteredProveedores.map((proveedor) => (
-                  <TableRow 
+                  <TableRow
                     key={proveedor.id}
                     onClick={() => handleEdit(proveedor)}
                     sx={{
-                      cursor: 'pointer',
-                      '&:hover': {
-                        backgroundColor: 'action.hover',
+                      cursor: "pointer",
+                      "&:hover": {
+                        backgroundColor: "action.hover",
                       },
-                      '&:nth-of-type(odd)': {
-                        backgroundColor: 'rgba(0, 0, 0, 0.02)',
+                      "&:nth-of-type(odd)": {
+                        backgroundColor: "rgba(0, 0, 0, 0.02)",
                       },
                     }}
                   >
@@ -449,21 +501,32 @@ export default function Proveedores() {
                     </TableCell>
                     <TableCell>
                       <Typography variant="body2" color="text.secondary">
-                        {proveedor.descripcion || '-'}
+                        {proveedor.descripcion || "-"}
                       </Typography>
                     </TableCell>
                     <TableCell>
                       {proveedor.usuarioId ? (
-                        <Stack direction="row" alignItems="center" spacing={0.5}>
+                        <Stack
+                          direction="row"
+                          alignItems="center"
+                          spacing={0.5}
+                        >
                           <Avatar sx={{ width: 24, height: 24 }}>
-                            {usuarios.find(u => u.id === proveedor.usuarioId)?.nombre.charAt(0)}
+                            {usuarios
+                              .find((u) => u.id === proveedor.usuarioId)
+                              ?.nombre.charAt(0)}
                           </Avatar>
                           <Typography variant="body2" fontWeight="medium">
-                            {usuarios.find(u => u.id === proveedor.usuarioId)?.nombre}
+                            {
+                              usuarios.find((u) => u.id === proveedor.usuarioId)
+                                ?.nombre
+                            }
                           </Typography>
                         </Stack>
                       ) : (
-                        <Typography variant="body2" color="text.secondary">-</Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          -
+                        </Typography>
                       )}
                     </TableCell>
                     <TableCell>
@@ -476,7 +539,9 @@ export default function Proveedores() {
                           color="success"
                         />
                       ) : (
-                        <Typography variant="body2" color="text.secondary">-</Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          -
+                        </Typography>
                       )}
                     </TableCell>
                     <TableCell>
@@ -489,11 +554,17 @@ export default function Proveedores() {
                           color="info"
                         />
                       ) : (
-                        <Typography variant="body2" color="text.secondary">-</Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          -
+                        </Typography>
                       )}
                     </TableCell>
                     <TableCell align="center">
-                      <Stack direction="row" spacing={0.5} justifyContent="center">
+                      <Stack
+                        direction="row"
+                        spacing={0.5}
+                        justifyContent="center"
+                      >
                         <Tooltip title="Editar proveedor">
                           <IconButton
                             onClick={(e) => {
@@ -530,12 +601,14 @@ export default function Proveedores() {
 
       {/* Dialog para crear/editar proveedor */}
       <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-        <DialogTitle>{selectedProveedor ? "Editar Proveedor" : "Nuevo Proveedor"}</DialogTitle>
+        <DialogTitle>
+          {selectedProveedor ? "Editar Proveedor" : "Nuevo Proveedor"}
+        </DialogTitle>
         <DialogContent>
           <Stack spacing={3} sx={{ pt: 1 }}>
-            <TextField 
-              fullWidth 
-              label="Nombre del proveedor" 
+            <TextField
+              fullWidth
+              label="Nombre del proveedor"
               value={nombre}
               onChange={(e) => setNombre(e.target.value)}
               required
@@ -550,9 +623,9 @@ export default function Proveedores() {
               }}
             />
 
-            <TextField 
-              fullWidth 
-              label="Descripción" 
+            <TextField
+              fullWidth
+              label="Descripción"
               value={descripcion}
               onChange={(e) => setDescripcion(e.target.value)}
               placeholder="Descripción opcional del proveedor..."
@@ -561,9 +634,9 @@ export default function Proveedores() {
               rows={2}
             />
 
-            <TextField 
-              fullWidth 
-              label="Teléfono" 
+            <TextField
+              fullWidth
+              label="Teléfono"
               value={telefono}
               onChange={(e) => setTelefono(e.target.value)}
               placeholder="Ej: +1234567890"
@@ -577,9 +650,9 @@ export default function Proveedores() {
               }}
             />
 
-            <TextField 
-              fullWidth 
-              label="Dirección" 
+            <TextField
+              fullWidth
+              label="Dirección"
               value={direccion}
               onChange={(e) => setDireccion(e.target.value)}
               placeholder="Dirección del proveedor..."
@@ -596,7 +669,9 @@ export default function Proveedores() {
             />
 
             <FormControl fullWidth disabled={saving}>
-              <InputLabel id="usuario-label">Usuario Asociado (Opcional)</InputLabel>
+              <InputLabel id="usuario-label">
+                Usuario Asociado (Opcional)
+              </InputLabel>
               <Select
                 labelId="usuario-label"
                 value={usuarioId}
@@ -619,7 +694,9 @@ export default function Proveedores() {
                         {usuario.nombre.charAt(0)}
                       </Avatar>
                       <Box>
-                        <Typography variant="body2">{usuario.nombre}</Typography>
+                        <Typography variant="body2">
+                          {usuario.nombre}
+                        </Typography>
                         <Typography variant="caption" color="text.secondary">
                           @{usuario.usuario}
                         </Typography>
@@ -635,9 +712,9 @@ export default function Proveedores() {
           <Button onClick={handleClose} color="secondary" disabled={saving}>
             Cancelar
           </Button>
-          <Button 
-            onClick={handleSave} 
-            variant="contained" 
+          <Button
+            onClick={handleSave}
+            variant="contained"
             color="primary"
             disabled={!nombre.trim() || saving}
             startIcon={saving ? <CircularProgress size={16} /> : undefined}
@@ -650,4 +727,4 @@ export default function Proveedores() {
       {ConfirmDialogComponent}
     </PageContainer>
   );
-} 
+}

--- a/src/app/configuracion/usuarios/page.tsx
+++ b/src/app/configuracion/usuarios/page.tsx
@@ -1,21 +1,21 @@
-"use client"
+"use client";
 
 import React, { useEffect, useState } from "react";
-import { 
-  Typography, 
-  Button, 
-  Table, 
-  TableBody, 
-  TableCell, 
-  TableContainer, 
-  TableHead, 
-  TableRow, 
-  IconButton, 
-  Dialog, 
-  DialogTitle, 
-  DialogContent, 
-  DialogActions, 
-  TextField, 
+import {
+  Typography,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
   Box,
   CircularProgress,
   InputAdornment,
@@ -28,11 +28,11 @@ import {
   useTheme,
   useMediaQuery,
   Collapse,
-  Divider
+  Divider,
 } from "@mui/material";
-import { 
-  Edit, 
-  Delete, 
+import {
+  Edit,
+  Delete,
   Add,
   Person,
   Search,
@@ -45,6 +45,7 @@ import {
 import useConfirmDialog from "@/components/confirmDialog";
 import { PageContainer } from "@/components/PageContainer";
 import { ContentCard } from "@/components/ContentCard";
+import SelectableTextField from "@/components/SelectableTextField";
 import LimitDialog from "@/components/LimitDialog";
 import { useMessageContext } from "@/context/MessageContext";
 import { usePermisos } from "@/utils/permisos_front";
@@ -65,9 +66,12 @@ const PENDIENTE_VERIFICACION = "PENDIENTE_VERIFICACION" as const;
 
 export default function UsuariosPage() {
   const [usuarios, setUsuarios] = useState<IUsuarioListItem[]>([]);
-  const [resetPasswordSent, setResetPasswordSent] = useState<Record<string, boolean>>({});
+  const [resetPasswordSent, setResetPasswordSent] = useState<
+    Record<string, boolean>
+  >({});
   const [open, setOpen] = useState(false);
-  const [selectedUsuario, setSelectedUsuario] = useState<IUsuarioListItem | null>(null);
+  const [selectedUsuario, setSelectedUsuario] =
+    useState<IUsuarioListItem | null>(null);
   const [nombre, setNombre] = useState("");
   const [usuario, setUsuario] = useState("");
   const [loading, setLoading] = useState(true);
@@ -82,9 +86,9 @@ export default function UsuariosPage() {
   const { showMessage } = useMessageContext();
   const { verificarPermiso } = usePermisos();
   const canManageUsers = verificarPermiso("configuracion.usuarios.acceder");
-  
+
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {
     fetchUsuarios();
@@ -129,7 +133,7 @@ export default function UsuariosPage() {
       const info = await getUsuarioDeleteInfo(id);
       setDeleteInfo(info);
       setDeleteDialogOpen(true);
-    } catch(e) {
+    } catch (e) {
       showMessage("Error al obtener información del usuario", "error");
       console.error("Error al eliminar el usuario", e);
     } finally {
@@ -150,8 +154,10 @@ export default function UsuariosPage() {
         typeof error === "object" &&
         error !== null &&
         "response" in error &&
-        typeof (error as { response?: { data?: { error?: string } } }).response?.data?.error === "string"
-          ? (error as { response: { data: { error: string } } }).response.data.error
+        typeof (error as { response?: { data?: { error?: string } } }).response
+          ?.data?.error === "string"
+          ? (error as { response: { data: { error: string } } }).response.data
+              .error
           : "Error al eliminar el usuario";
       showMessage(msg, "error");
     }
@@ -167,9 +173,10 @@ export default function UsuariosPage() {
         typeof error === "object" &&
         error !== null &&
         "response" in error &&
-        typeof (error as { response?: { data?: { error?: string } } }).response?.data?.error ===
-          "string"
-          ? (error as { response: { data: { error: string } } }).response.data.error
+        typeof (error as { response?: { data?: { error?: string } } }).response
+          ?.data?.error === "string"
+          ? (error as { response: { data: { error: string } } }).response.data
+              .error
           : "No se pudo reenviar la invitación";
       showMessage(msg, "error");
     }
@@ -183,7 +190,10 @@ export default function UsuariosPage() {
 
     const emailNormalizado = usuario.trim().toLowerCase();
     if (!EMAIL_REGEX.test(emailNormalizado)) {
-      showMessage("El campo usuario debe ser un correo electrónico válido.", "warning");
+      showMessage(
+        "El campo usuario debe ser un correo electrónico válido.",
+        "warning",
+      );
       return;
     }
 
@@ -202,34 +212,42 @@ export default function UsuariosPage() {
           emailCambiado
             ? "Datos guardados. Se envió un correo de activación para confirmar el nuevo email."
             : "Usuario actualizado exitosamente",
-          "success"
+          "success",
         );
       } else {
         await createUsuario(data);
         showMessage(
           "Usuario creado. Se envió una invitación por correo para que defina su contraseña.",
-          "success"
+          "success",
         );
       }
       fetchUsuarios();
       handleClose();
     } catch (error: unknown) {
       console.error("Error al guardar el usuario", error);
-      const err = error as { response?: { status?: number; data?: { error?: string } } };
+      const err = error as {
+        response?: { status?: number; data?: { error?: string } };
+      };
       if (
         err.response?.status === 400 &&
         err.response?.data?.error?.includes("Limite de usuarios exedido")
       ) {
         setLimitDialog(true);
       } else {
-        showMessage(err.response?.data?.error || "Error al guardar el usuario", "error");
+        showMessage(
+          err.response?.data?.error || "Error al guardar el usuario",
+          "error",
+        );
       }
     } finally {
       setSaving(false);
     }
   };
 
-  const handleResetPassword = async (e: React.MouseEvent, user: IUsuarioListItem) => {
+  const handleResetPassword = async (
+    e: React.MouseEvent,
+    user: IUsuarioListItem,
+  ) => {
     e.stopPropagation();
     confirmDialog(
       `Se enviará un correo de restablecimiento a ${user.usuario}. ¿Deseas continuar?`,
@@ -243,13 +261,14 @@ export default function UsuariosPage() {
             typeof error === "object" &&
             error !== null &&
             "response" in error &&
-            typeof (error as { response?: { data?: { error?: string } } }).response?.data?.error ===
-              "string"
-              ? (error as { response: { data: { error: string } } }).response.data.error
+            typeof (error as { response?: { data?: { error?: string } } })
+              .response?.data?.error === "string"
+              ? (error as { response: { data: { error: string } } }).response
+                  .data.error
               : "No se pudo enviar el restablecimiento";
           showMessage(msg, "error");
         }
-      }
+      },
     );
   };
 
@@ -260,16 +279,16 @@ export default function UsuariosPage() {
   const filteredUsuarios = usuarios.filter(
     (user) =>
       user.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      user.usuario.toLowerCase().includes(searchTerm.toLowerCase())
+      user.usuario.toLowerCase().includes(searchTerm.toLowerCase()),
   );
 
   // Cálculos para estadísticas
   const totalUsuarios = usuarios.length;
 
   const breadcrumbs = [
-    { label: 'Inicio', href: '/home' },
-    { label: 'Configuración', href: '/configuracion' },
-    { label: 'Usuarios' }
+    { label: "Inicio", href: "/home" },
+    { label: "Configuración", href: "/configuracion" },
+    { label: "Usuarios" },
   ];
 
   const headerActions = (
@@ -280,8 +299,15 @@ export default function UsuariosPage() {
         </IconButton>
       </Tooltip>
       {isMobile && (
-        <Tooltip title={statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"}>
-          <IconButton onClick={() => setStatsExpanded(!statsExpanded)} size="small">
+        <Tooltip
+          title={
+            statsExpanded ? "Ocultar estadísticas" : "Mostrar estadísticas"
+          }
+        >
+          <IconButton
+            onClick={() => setStatsExpanded(!statsExpanded)}
+            size="small"
+          >
             {statsExpanded ? <ExpandLess /> : <ExpandMore />}
           </IconButton>
         </Tooltip>
@@ -300,8 +326,18 @@ export default function UsuariosPage() {
   );
 
   // Componente de estadística móvil optimizado
-  const StatCard = ({ icon, value, label, color }: { icon: React.ReactNode, value: string, label: string, color: string }) => (
-    <Card sx={{ height: '100%' }}>
+  const StatCard = ({
+    icon,
+    value,
+    label,
+    color,
+  }: {
+    icon: React.ReactNode;
+    value: string;
+    label: string;
+    color: string;
+  }) => (
+    <Card sx={{ height: "100%" }}>
       <CardContent sx={{ p: isMobile ? 1.5 : 3 }}>
         <Stack direction="row" alignItems="center" spacing={isMobile ? 1 : 2}>
           <Box
@@ -309,39 +345,38 @@ export default function UsuariosPage() {
               p: isMobile ? 0.75 : 1.5,
               borderRadius: 2,
               bgcolor: color,
-              color: 'white',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
+              color: "white",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
               minWidth: isMobile ? 32 : 48,
               minHeight: isMobile ? 32 : 48,
             }}
           >
-            {React.isValidElement(icon) 
-              ? React.cloneElement(icon, { 
-                  fontSize: isMobile ? "small" : "large" 
+            {React.isValidElement(icon)
+              ? React.cloneElement(icon, {
+                  fontSize: isMobile ? "small" : "large",
                 } as Record<string, unknown>)
-              : icon
-            }
+              : icon}
           </Box>
           <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Typography 
-              variant={isMobile ? "subtitle1" : "h4"} 
+            <Typography
+              variant={isMobile ? "subtitle1" : "h4"}
               fontWeight="bold"
-              sx={{ 
-                fontSize: isMobile ? '1rem' : '2rem',
+              sx={{
+                fontSize: isMobile ? "1rem" : "2rem",
                 lineHeight: 1.2,
-                wordBreak: 'break-all'
+                wordBreak: "break-all",
               }}
             >
               {value}
             </Typography>
-            <Typography 
-              variant="body2" 
+            <Typography
+              variant="body2"
               color="text.secondary"
-              sx={{ 
-                fontSize: isMobile ? '0.6875rem' : '0.875rem',
-                lineHeight: 1.2
+              sx={{
+                fontSize: isMobile ? "0.6875rem" : "0.875rem",
+                lineHeight: 1.2,
               }}
             >
               {label}
@@ -354,7 +389,12 @@ export default function UsuariosPage() {
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="200px"
+      >
         <CircularProgress />
         <Typography variant="body2" sx={{ mt: 2, ml: 2 }}>
           Cargando usuarios...
@@ -434,11 +474,13 @@ export default function UsuariosPage() {
       )}
 
       {/* Lista de usuarios */}
-      <ContentCard 
+      <ContentCard
         title="Lista de Usuarios"
-        subtitle={!isMobile ? "Haz clic en cualquier usuario para editarlo" : undefined}
+        subtitle={
+          !isMobile ? "Haz clic en cualquier usuario para editarlo" : undefined
+        }
         headerActions={
-          <TextField
+          <SelectableTextField
             size="small"
             placeholder={isMobile ? "Buscar..." : "Buscar usuario..."}
             value={searchTerm}
@@ -450,9 +492,9 @@ export default function UsuariosPage() {
                 </InputAdornment>
               ),
             }}
-            sx={{ 
+            sx={{
               minWidth: isMobile ? 160 : 250,
-              maxWidth: isMobile ? 200 : 'none'
+              maxWidth: isMobile ? 200 : "none",
             }}
           />
         }
@@ -461,13 +503,17 @@ export default function UsuariosPage() {
       >
         {filteredUsuarios.length === 0 ? (
           <Box sx={{ p: 2 }}>
-            <Box sx={{ textAlign: 'center', py: 8 }}>
-              <Person sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }} />
+            <Box sx={{ textAlign: "center", py: 8 }}>
+              <Person sx={{ fontSize: 48, color: "text.secondary", mb: 2 }} />
               <Typography variant="h6" color="text.secondary">
-                {searchTerm ? 'No se encontraron usuarios' : 'No hay usuarios registrados'}
+                {searchTerm
+                  ? "No se encontraron usuarios"
+                  : "No hay usuarios registrados"}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                {searchTerm ? 'Intenta con otros términos de búsqueda' : 'Agrega usuarios para comenzar a gestionar el acceso al sistema'}
+                {searchTerm
+                  ? "Intenta con otros términos de búsqueda"
+                  : "Agrega usuarios para comenzar a gestionar el acceso al sistema"}
               </Typography>
             </Box>
           </Box>
@@ -476,35 +522,63 @@ export default function UsuariosPage() {
           <Box sx={{ p: 1.5 }}>
             <Stack spacing={1.5}>
               {filteredUsuarios.map((user) => (
-                <Card 
+                <Card
                   key={user.id}
                   onClick={() => handleOpen(user)}
                   sx={{
-                    cursor: 'pointer',
-                    '&:hover': {
-                      backgroundColor: 'action.hover',
+                    cursor: "pointer",
+                    "&:hover": {
+                      backgroundColor: "action.hover",
                     },
                   }}
                 >
-                  <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
+                  <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 } }}>
                     <Stack spacing={1.5}>
-                      <Box display="flex" justifyContent="space-between" alignItems="center">
-                        <Typography variant="subtitle2" fontWeight="medium" sx={{ fontSize: '0.875rem' }}>
+                      <Box
+                        display="flex"
+                        justifyContent="space-between"
+                        alignItems="center"
+                      >
+                        <Typography
+                          variant="subtitle2"
+                          fontWeight="medium"
+                          sx={{ fontSize: "0.875rem" }}
+                        >
                           {user.nombre}
                         </Typography>
-                        <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                        <Stack
+                          direction="row"
+                          spacing={0.5}
+                          flexWrap="wrap"
+                          useFlexGap
+                        >
                           {user.estadoCuenta === PENDIENTE_VERIFICACION ? (
-                            <Chip label="Pendiente" color="warning" size="small" sx={{ height: 20 }} />
+                            <Chip
+                              label="Pendiente"
+                              color="warning"
+                              size="small"
+                              sx={{ height: 20 }}
+                            />
                           ) : null}
                           {user.rol === "SUPER_ADMIN" ? (
-                            <Chip label={user.rol} color="info" size="small" sx={{ height: 20 }} />
+                            <Chip
+                              label={user.rol}
+                              color="info"
+                              size="small"
+                              sx={{ height: 20 }}
+                            />
                           ) : null}
                           {resetPasswordSent[user.id] ? (
-                            <Chip label="Reset enviado" color="info" size="small" sx={{ height: 20 }} />
+                            <Chip
+                              label="Reset enviado"
+                              color="info"
+                              size="small"
+                              sx={{ height: 20 }}
+                            />
                           ) : null}
                         </Stack>
                       </Box>
-                      
+
                       <Box
                         display="flex"
                         flexDirection="row"
@@ -549,7 +623,8 @@ export default function UsuariosPage() {
                               <MailOutline sx={{ fontSize: 20 }} />
                             </IconButton>
                           ) : null}
-                          {canManageUsers && user.estadoCuenta !== PENDIENTE_VERIFICACION ? (
+                          {canManageUsers &&
+                          user.estadoCuenta !== PENDIENTE_VERIFICACION ? (
                             <IconButton
                               onClick={(e) => handleResetPassword(e, user)}
                               size="small"
@@ -567,7 +642,11 @@ export default function UsuariosPage() {
                             }}
                             size="small"
                             color="error"
-                            disabled={!verificarPermiso("configuracion.usuarios.deleteOrDisable") || deleteLoading}
+                            disabled={
+                              !verificarPermiso(
+                                "configuracion.usuarios.deleteOrDisable",
+                              ) || deleteLoading
+                            }
                             aria-label="Eliminar usuario"
                           >
                             <Delete sx={{ fontSize: 20 }} />
@@ -594,16 +673,16 @@ export default function UsuariosPage() {
               </TableHead>
               <TableBody>
                 {filteredUsuarios.map((user) => (
-                  <TableRow 
+                  <TableRow
                     key={user.id}
                     onClick={() => handleOpen(user)}
                     sx={{
-                      cursor: 'pointer',
-                      '&:hover': {
-                        backgroundColor: 'action.hover',
+                      cursor: "pointer",
+                      "&:hover": {
+                        backgroundColor: "action.hover",
                       },
-                      '&:nth-of-type(odd)': {
-                        backgroundColor: 'rgba(0, 0, 0, 0.02)',
+                      "&:nth-of-type(odd)": {
+                        backgroundColor: "rgba(0, 0, 0, 0.02)",
                       },
                     }}
                   >
@@ -618,20 +697,43 @@ export default function UsuariosPage() {
                       </Typography>
                     </TableCell>
                     <TableCell>
-                      <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="flex-start">
+                      <Stack
+                        direction="row"
+                        spacing={0.5}
+                        alignItems="center"
+                        justifyContent="flex-start"
+                      >
                         {user.estadoCuenta === PENDIENTE_VERIFICACION ? (
-                          <Chip label="Pendiente" color="warning" size="small" />
+                          <Chip
+                            label="Pendiente"
+                            color="warning"
+                            size="small"
+                          />
                         ) : (
-                          <Chip label="Activo" color="success" size="small" variant="outlined" />
+                          <Chip
+                            label="Activo"
+                            color="success"
+                            size="small"
+                            variant="outlined"
+                          />
                         )}
                         {resetPasswordSent[user.id] ? (
-                          <Chip label="Reset enviado" color="info" size="small" variant="outlined" />
+                          <Chip
+                            label="Reset enviado"
+                            color="info"
+                            size="small"
+                            variant="outlined"
+                          />
                         ) : null}
                       </Stack>
                     </TableCell>
 
                     <TableCell align="center">
-                      <Stack direction="row" spacing={0.5} justifyContent="center">
+                      <Stack
+                        direction="row"
+                        spacing={0.5}
+                        justifyContent="center"
+                      >
                         {user.estadoCuenta === PENDIENTE_VERIFICACION &&
                         verificarPermiso("configuracion.usuarios.acceder") ? (
                           <Tooltip title="Reenviar invitación">
@@ -644,7 +746,8 @@ export default function UsuariosPage() {
                             </IconButton>
                           </Tooltip>
                         ) : null}
-                        {canManageUsers && user.estadoCuenta !== PENDIENTE_VERIFICACION ? (
+                        {canManageUsers &&
+                        user.estadoCuenta !== PENDIENTE_VERIFICACION ? (
                           <Tooltip title="Enviar restablecimiento de contraseña">
                             <IconButton
                               onClick={(e) => handleResetPassword(e, user)}
@@ -676,7 +779,11 @@ export default function UsuariosPage() {
                               }}
                               size="small"
                               color="error"
-                              disabled={!verificarPermiso('configuracion.usuarios.deleteOrDisable') || deleteLoading}
+                              disabled={
+                                !verificarPermiso(
+                                  "configuracion.usuarios.deleteOrDisable",
+                                ) || deleteLoading
+                              }
                             >
                               <Delete fontSize="small" />
                             </IconButton>
@@ -701,24 +808,24 @@ export default function UsuariosPage() {
           <Stack spacing={3} sx={{ pt: 1 }}>
             {!selectedUsuario ? (
               <Typography variant="body2" color="text.secondary">
-                Se enviará un correo con un enlace para que la persona defina su contraseña y active
-                su cuenta (válido varias horas).
+                Se enviará un correo con un enlace para que la persona defina su
+                contraseña y active su cuenta (válido varias horas).
               </Typography>
             ) : null}
 
-            <TextField 
-              fullWidth 
-              label="Nombre completo" 
+            <TextField
+              fullWidth
+              label="Nombre completo"
               value={nombre}
               onChange={(e) => setNombre(e.target.value)}
               required
               placeholder="Ej: Juan Pérez, María García..."
             />
-            
-            <TextField 
-              fullWidth 
+
+            <TextField
+              fullWidth
               type="email"
-              label="Correo electrónico (usuario)" 
+              label="Correo electrónico (usuario)"
               value={usuario}
               onChange={(e) => setUsuario(e.target.value)}
               required
@@ -727,7 +834,8 @@ export default function UsuariosPage() {
 
             {selectedUsuario ? (
               <Typography variant="caption" color="text.secondary">
-                La contraseña se gestiona por flujo de restablecimiento enviado por correo.
+                La contraseña se gestiona por flujo de restablecimiento enviado
+                por correo.
               </Typography>
             ) : null}
           </Stack>
@@ -736,9 +844,9 @@ export default function UsuariosPage() {
           <Button onClick={handleClose} color="secondary" disabled={saving}>
             Cancelar
           </Button>
-          <Button 
-            onClick={handleSave} 
-            variant="contained" 
+          <Button
+            onClick={handleSave}
+            variant="contained"
             color="primary"
             disabled={
               !nombre.trim() ||
@@ -756,7 +864,10 @@ export default function UsuariosPage() {
       <DeleteUsuarioDialog
         open={deleteDialogOpen}
         info={deleteInfo}
-        onClose={() => { setDeleteDialogOpen(false); setDeleteInfo(null); }}
+        onClose={() => {
+          setDeleteDialogOpen(false);
+          setDeleteInfo(null);
+        }}
         onConfirm={handleConfirmDelete}
       />
 

--- a/src/app/gastos/components/AssignPlantillaDialog.tsx
+++ b/src/app/gastos/components/AssignPlantillaDialog.tsx
@@ -12,15 +12,17 @@ import {
   Divider,
   FormControl,
   FormHelperText,
-  InputAdornment,
   InputLabel,
   MenuItem,
   Select,
   Stack,
-  TextField,
   Typography,
 } from "@mui/material";
-import { IGastoPlantilla, IAssignPlantilla, assignPlantillaSchema } from "@/schemas/gastos";
+import {
+  IGastoPlantilla,
+  IAssignPlantilla,
+  assignPlantillaSchema,
+} from "@/schemas/gastos";
 import {
   TIPO_CALCULO_LABELS,
   TIPO_CALCULO_COLORS,
@@ -30,6 +32,8 @@ import {
   DIAS_MES,
 } from "@/constants/gastos";
 import { formatearCuandoAplica } from "@/utils/gastos";
+import MoneyField from "@/components/MoneyField";
+import PercentageField from "@/components/PercentageField";
 
 interface Props {
   open: boolean;
@@ -38,7 +42,12 @@ interface Props {
   onAssign: (data: IAssignPlantilla) => Promise<void>;
 }
 
-export default function AssignPlantillaDialog({ open, plantillas, onClose, onAssign }: Props) {
+export default function AssignPlantillaDialog({
+  open,
+  plantillas,
+  onClose,
+  onAssign,
+}: Props) {
   const [step, setStep] = useState<1 | 2>(1);
   const [selected, setSelected] = useState<IGastoPlantilla | null>(null);
   const [monto, setMonto] = useState("");
@@ -111,14 +120,17 @@ export default function AssignPlantillaDialog({ open, plantillas, onClose, onAss
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>
-        {step === 1 ? "Seleccionar plantilla" : `Configurar: ${selected?.nombre}`}
+        {step === 1
+          ? "Seleccionar plantilla"
+          : `Configurar: ${selected?.nombre}`}
       </DialogTitle>
       <DialogContent>
         {step === 1 && (
           <Stack spacing={1.5} mt={0.5}>
             {plantillas.length === 0 && (
               <Typography color="text.secondary" textAlign="center" py={2}>
-                No hay plantillas disponibles. Crea una desde Configuración → Plantillas de Gastos.
+                No hay plantillas disponibles. Crea una desde Configuración →
+                Plantillas de Gastos.
               </Typography>
             )}
             {plantillas.map((p) => (
@@ -135,21 +147,35 @@ export default function AssignPlantillaDialog({ open, plantillas, onClose, onAss
                   opacity: p.activo ? 1 : 0.5,
                 }}
               >
-                <Box display="flex" justifyContent="space-between" alignItems="flex-start">
+                <Box
+                  display="flex"
+                  justifyContent="space-between"
+                  alignItems="flex-start"
+                >
                   <Typography variant="subtitle2">{p.nombre}</Typography>
                   <Chip
                     label={RECURRENCIA_LABELS[p.recurrencia]}
                     size="small"
-                    sx={{ backgroundColor: RECURRENCIA_COLORS[p.recurrencia], color: "#fff", fontSize: "0.6875rem" }}
+                    sx={{
+                      backgroundColor: RECURRENCIA_COLORS[p.recurrencia],
+                      color: "#fff",
+                      fontSize: "0.6875rem",
+                    }}
                   />
                 </Box>
                 <Box display="flex" gap={1} mt={0.5} alignItems="center">
                   <Chip
                     label={TIPO_CALCULO_LABELS[p.tipoCalculo]}
                     size="small"
-                    sx={{ backgroundColor: TIPO_CALCULO_COLORS[p.tipoCalculo], color: "#fff", fontSize: "0.6875rem" }}
+                    sx={{
+                      backgroundColor: TIPO_CALCULO_COLORS[p.tipoCalculo],
+                      color: "#fff",
+                      fontSize: "0.6875rem",
+                    }}
                   />
-                  <Typography variant="caption" color="text.secondary">{p.categoria}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {p.categoria}
+                  </Typography>
                 </Box>
                 <Typography variant="caption" color="text.secondary">
                   {formatearCuandoAplica(p)}
@@ -163,7 +189,8 @@ export default function AssignPlantillaDialog({ open, plantillas, onClose, onAss
           <Stack spacing={2} mt={0.5}>
             <Box p={1.5} bgcolor="action.hover" borderRadius={1}>
               <Typography variant="body2" color="text.secondary">
-                Plantilla: <strong>{selected.nombre}</strong> · {selected.categoria}
+                Plantilla: <strong>{selected.nombre}</strong> ·{" "}
+                {selected.categoria}
               </Typography>
               <Typography variant="caption" color="text.secondary">
                 {formatearCuandoAplica(selected)}
@@ -173,30 +200,24 @@ export default function AssignPlantillaDialog({ open, plantillas, onClose, onAss
             <Divider />
 
             {showMonto && (
-              <TextField
+              <MoneyField
                 label="Monto para esta tienda"
-                type="number"
                 value={monto}
                 onChange={(e) => setMonto(e.target.value)}
                 error={!!errors.monto}
                 helperText={errors.monto}
-                InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
-                inputProps={{ min: 0, step: "0.01" }}
                 fullWidth
                 required
               />
             )}
 
             {showPorcentaje && (
-              <TextField
+              <PercentageField
                 label="Porcentaje para esta tienda"
-                type="number"
                 value={porcentaje}
                 onChange={(e) => setPorcentaje(e.target.value)}
                 error={!!errors.porcentaje}
                 helperText={errors.porcentaje}
-                InputProps={{ endAdornment: <InputAdornment position="end">%</InputAdornment> }}
-                inputProps={{ min: 0, max: 100, step: "0.01" }}
                 fullWidth
                 required
               />
@@ -210,9 +231,15 @@ export default function AssignPlantillaDialog({ open, plantillas, onClose, onAss
                   label="Día del mes"
                   onChange={(e) => setDiaMes(Number(e.target.value))}
                 >
-                  {DIAS_MES.map((d) => <MenuItem key={d.value} value={d.value}>{d.label}</MenuItem>)}
+                  {DIAS_MES.map((d) => (
+                    <MenuItem key={d.value} value={d.value}>
+                      {d.label}
+                    </MenuItem>
+                  ))}
                 </Select>
-                {errors.diaMes && <FormHelperText>{errors.diaMes}</FormHelperText>}
+                {errors.diaMes && (
+                  <FormHelperText>{errors.diaMes}</FormHelperText>
+                )}
               </FormControl>
             )}
 
@@ -220,17 +247,37 @@ export default function AssignPlantillaDialog({ open, plantillas, onClose, onAss
               <Stack direction="row" spacing={2}>
                 <FormControl fullWidth error={!!errors.mesAnio}>
                   <InputLabel>Mes</InputLabel>
-                  <Select value={mesAnio} label="Mes" onChange={(e) => setMesAnio(Number(e.target.value))}>
-                    {MESES.map((m) => <MenuItem key={m.value} value={m.value}>{m.label}</MenuItem>)}
+                  <Select
+                    value={mesAnio}
+                    label="Mes"
+                    onChange={(e) => setMesAnio(Number(e.target.value))}
+                  >
+                    {MESES.map((m) => (
+                      <MenuItem key={m.value} value={m.value}>
+                        {m.label}
+                      </MenuItem>
+                    ))}
                   </Select>
-                  {errors.mesAnio && <FormHelperText>{errors.mesAnio}</FormHelperText>}
+                  {errors.mesAnio && (
+                    <FormHelperText>{errors.mesAnio}</FormHelperText>
+                  )}
                 </FormControl>
                 <FormControl fullWidth error={!!errors.diaAnio}>
                   <InputLabel>Día</InputLabel>
-                  <Select value={diaAnio} label="Día" onChange={(e) => setDiaAnio(Number(e.target.value))}>
-                    {DIAS_MES.map((d) => <MenuItem key={d.value} value={d.value}>{d.label}</MenuItem>)}
+                  <Select
+                    value={diaAnio}
+                    label="Día"
+                    onChange={(e) => setDiaAnio(Number(e.target.value))}
+                  >
+                    {DIAS_MES.map((d) => (
+                      <MenuItem key={d.value} value={d.value}>
+                        {d.label}
+                      </MenuItem>
+                    ))}
                   </Select>
-                  {errors.diaAnio && <FormHelperText>{errors.diaAnio}</FormHelperText>}
+                  {errors.diaAnio && (
+                    <FormHelperText>{errors.diaAnio}</FormHelperText>
+                  )}
                 </FormControl>
               </Stack>
             )}
@@ -238,8 +285,14 @@ export default function AssignPlantillaDialog({ open, plantillas, onClose, onAss
         )}
       </DialogContent>
       <DialogActions>
-        {step === 2 && <Button onClick={() => setStep(1)} disabled={loading}>Atrás</Button>}
-        <Button onClick={onClose} disabled={loading}>Cancelar</Button>
+        {step === 2 && (
+          <Button onClick={() => setStep(1)} disabled={loading}>
+            Atrás
+          </Button>
+        )}
+        <Button onClick={onClose} disabled={loading}>
+          Cancelar
+        </Button>
         {step === 2 && (
           <Button variant="contained" onClick={handleAssign} disabled={loading}>
             {loading ? "Asignando..." : "Asignar"}

--- a/src/app/gastos/components/GastoAdHocDialog.tsx
+++ b/src/app/gastos/components/GastoAdHocDialog.tsx
@@ -10,7 +10,6 @@ import {
   DialogContent,
   DialogTitle,
   FormControl,
-  InputAdornment,
   InputLabel,
   MenuItem,
   Select,
@@ -30,6 +29,8 @@ import {
   NATURALEZA_GASTO_LABELS,
   NATURALEZA_GASTO_DESCRIPTIONS,
 } from "@/constants/gastos";
+import MoneyField from "@/components/MoneyField";
+import PercentageField from "@/components/PercentageField";
 
 interface Props {
   open: boolean;
@@ -225,41 +226,28 @@ export default function GastoAdHocDialog({
                   </Select>
                 </FormControl>
               )}
-              <TextField
+              <MoneyField
                 label="Monto"
-                type="number"
                 value={monto}
                 onChange={(e) => setMonto(e.target.value)}
                 error={!!errors.monto || !!errors.montoCalculado}
                 helperText={errors.monto ?? errors.montoCalculado}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      {monedasActivas?.find(
-                        (m) => m.monedaCode === (monedaCode ?? monedaBase),
-                      )?.moneda?.simbolo ?? "$"}
-                    </InputAdornment>
-                  ),
-                }}
-                inputProps={{ min: 0, step: "0.01" }}
+                currencySymbol={
+                  monedasActivas?.find(
+                    (m) => m.monedaCode === (monedaCode ?? monedaBase),
+                  )?.moneda?.simbolo ?? "$"
+                }
                 fullWidth
               />
             </>
           ) : (
             <>
-              <TextField
+              <PercentageField
                 label="Porcentaje"
-                type="number"
                 value={porcentaje}
                 onChange={(e) => setPorcentaje(e.target.value)}
                 error={!!errors.porcentaje}
                 helperText={errors.porcentaje}
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position="end">%</InputAdornment>
-                  ),
-                }}
-                inputProps={{ min: 0, max: 100, step: "0.01" }}
                 fullWidth
               />
               {calculado > 0 && (

--- a/src/app/gastos/components/GastoFormDialog.tsx
+++ b/src/app/gastos/components/GastoFormDialog.tsx
@@ -12,7 +12,6 @@ import {
   FormControl,
   FormControlLabel,
   FormHelperText,
-  InputAdornment,
   InputLabel,
   MenuItem,
   Select,
@@ -42,6 +41,8 @@ import {
   MESES,
   DIAS_MES,
 } from "@/constants/gastos";
+import MoneyField from "@/components/MoneyField";
+import PercentageField from "@/components/PercentageField";
 
 type Mode = "tienda" | "plantilla";
 
@@ -241,35 +242,23 @@ export default function GastoFormDialog({
           </FormControl>
 
           {showMonto && (
-            <TextField
+            <MoneyField
               label="Monto"
-              type="number"
               value={form.monto}
               onChange={(e) => set("monto", e.target.value)}
               error={!!errors.monto}
               helperText={errors.monto}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">$</InputAdornment>
-                ),
-              }}
-              inputProps={{ min: 0, step: "0.01" }}
               fullWidth
             />
           )}
 
           {showPorcentaje && (
-            <TextField
+            <PercentageField
               label="Porcentaje"
-              type="number"
               value={form.porcentaje}
               onChange={(e) => set("porcentaje", e.target.value)}
               error={!!errors.porcentaje}
               helperText={errors.porcentaje}
-              InputProps={{
-                endAdornment: <InputAdornment position="end">%</InputAdornment>,
-              }}
-              inputProps={{ min: 0, max: 100, step: "0.01" }}
               fullWidth
             />
           )}

--- a/src/app/pos/components/AsociarCodigoDialog.tsx
+++ b/src/app/pos/components/AsociarCodigoDialog.tsx
@@ -7,7 +7,6 @@ import {
   DialogContent,
   DialogActions,
   Button,
-  TextField,
   List,
   ListItemButton,
   ListItemText,
@@ -26,6 +25,7 @@ import { normalizeSearch } from "@/utils/formatters";
 import { MultiCurrencyAmount } from "@/components/MultiCurrencyAmount";
 import { useAppContext } from "@/context/AppContext";
 import { convertToBase } from "@/lib/currency";
+import SelectableTextField from "@/components/SelectableTextField";
 
 interface AsociarCodigoDialogProps {
   open: boolean;
@@ -113,7 +113,7 @@ export function AsociarCodigoDialog({
           />
         </Box>
 
-        <TextField
+        <SelectableTextField
           fullWidth
           autoFocus
           label="Buscar producto"

--- a/src/app/pos/components/CajaResumenCards.tsx
+++ b/src/app/pos/components/CajaResumenCards.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { IResumenCajaMoneda } from "@/schemas/resumenCaja";
+import { formatMontoEnMoneda } from "@/utils/formatters";
+
+interface IProps {
+  resumen: IResumenCajaMoneda[];
+}
+
+function CajaResumenMonedaCard({ item }: { item: IResumenCajaMoneda }) {
+  return (
+    <Card elevation={2}>
+      <CardContent sx={{ py: 1.5 }}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          mb={0.5}
+        >
+          <Chip label={item.monedaCode} size="small" />
+          <Typography variant="h6" fontWeight="bold">
+            {formatMontoEnMoneda(item.totalEsperado, item.monedaCode)}
+          </Typography>
+        </Stack>
+        <Divider sx={{ my: 1 }} />
+        <Box display="flex" justifyContent="space-between">
+          <Typography variant="caption" color="textSecondary">
+            Fondo inicial
+          </Typography>
+          <Typography variant="caption">
+            {formatMontoEnMoneda(item.fondoInicial, item.monedaCode)}
+          </Typography>
+        </Box>
+        <Box display="flex" justifyContent="space-between">
+          <Typography variant="caption" color="textSecondary">
+            Ventas reales
+          </Typography>
+          <Typography variant="caption">
+            {formatMontoEnMoneda(item.ventasEfectivo, item.monedaCode)}
+          </Typography>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}
+
+// Fondo inicial y efectivo real de caja, por moneda, del período abierto —
+// usado en el resumen de "Mis Ventas" del POS.
+export default function CajaResumenCards({ resumen }: IProps) {
+  if (resumen.length === 0) return null;
+
+  return (
+    <Box mb={3}>
+      <Typography variant="body2" color="textSecondary" mb={1}>
+        Caja
+      </Typography>
+      <Grid container spacing={2}>
+        {resumen.map((item) => (
+          <Grid item xs={12} sm={4} key={item.monedaCode}>
+            <CajaResumenMonedaCard item={item} />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+}

--- a/src/app/pos/components/PaymentModal.tsx
+++ b/src/app/pos/components/PaymentModal.tsx
@@ -7,7 +7,6 @@ import {
   FormControl,
   InputLabel,
   InputAdornment,
-  OutlinedInput,
   Select,
   MenuItem,
   TextField,
@@ -41,6 +40,8 @@ import { useAppContext } from "@/context/AppContext";
 import type { IPagoLinea, IVueltoLinea } from "@/schemas/pago";
 import type { ITasaSnapshot } from "@/schemas/tasaCambio";
 import { convertToBase, convertFromBase } from "@/lib/currency";
+import MoneyField from "@/components/MoneyField";
+import SelectableTextField from "@/components/SelectableTextField";
 
 export interface IMultimonedaExtras {
   monedaCobro: string;
@@ -610,70 +611,55 @@ const PaymentModal: FC<IProps> = ({
               {/* Efectivo */}
               {admiteEfectivo && (
                 <>
-                  <FormControl fullWidth>
-                    <InputLabel>Efectivo</InputLabel>
-                    <OutlinedInput
-                      startAdornment={
-                        <InputAdornment position="start">
-                          <AttachMoneyIcon />
+                  <MoneyField
+                    fullWidth
+                    label="Efectivo"
+                    currencySymbol={<AttachMoneyIcon />}
+                    InputProps={{
+                      endAdornment: admiteTransfer ? (
+                        <InputAdornment position="end">
+                          <IconButton
+                            edge="end"
+                            size="small"
+                            onClick={() => toggleTransfer(moneda)}
+                            title={
+                              (showTransfer[moneda] ?? false)
+                                ? "Ocultar transferencia"
+                                : "Mostrar transferencia"
+                            }
+                          >
+                            <CreditCardIcon fontSize="small" />
+                          </IconButton>
                         </InputAdornment>
-                      }
-                      endAdornment={
-                        admiteTransfer ? (
-                          <InputAdornment position="end">
-                            <IconButton
-                              edge="end"
-                              size="small"
-                              onClick={() => toggleTransfer(moneda)}
-                              title={
-                                (showTransfer[moneda] ?? false)
-                                  ? "Ocultar transferencia"
-                                  : "Mostrar transferencia"
-                              }
-                            >
-                              <CreditCardIcon fontSize="small" />
-                            </IconButton>
-                          </InputAdornment>
-                        ) : undefined
-                      }
-                      label="Efectivo"
-                      value={pago.cash || ""}
-                      type="number"
-                      onChange={(e) => {
-                        const bdActive = isBase
-                          ? showBreakdown
-                          : (showPayBreakdown[moneda] ?? false);
-                        if (bdActive) return;
+                      ) : undefined,
+                    }}
+                    value={pago.cash || ""}
+                    onChange={(e) => {
+                      const bdActive = isBase
+                        ? showBreakdown
+                        : (showPayBreakdown[moneda] ?? false);
+                      if (bdActive) return;
 
-                        const v = e.target.value;
-                        if (moneyRegex.test(v))
-                          updatePago(moneda, { cash: Number(v) });
-                        else if (v === "") updatePago(moneda, { cash: 0 });
-                      }}
-                      onMouseDown={(e) => {
-                        if (e.button !== 0) return;
-                        const inp = (
-                          e.currentTarget as HTMLElement
-                        ).querySelector("input");
-                        if (inp) setTimeout(() => inp.select(), 0);
-                      }}
-                      inputProps={{
-                        inputMode: "decimal",
-                        readOnly: isBase
+                      const v = e.target.value;
+                      if (moneyRegex.test(v))
+                        updatePago(moneda, { cash: Number(v) });
+                      else if (v === "") updatePago(moneda, { cash: 0 });
+                    }}
+                    inputProps={{
+                      readOnly: isBase
+                        ? showBreakdown
+                        : (showPayBreakdown[moneda] ?? false),
+                    }}
+                    sx={
+                      (
+                        isBase
                           ? showBreakdown
-                          : (showPayBreakdown[moneda] ?? false),
-                      }}
-                      sx={
-                        (
-                          isBase
-                            ? showBreakdown
-                            : (showPayBreakdown[moneda] ?? false)
-                        )
-                          ? { bgcolor: "action.hover" }
-                          : {}
-                      }
-                    />
-                  </FormControl>
+                          : (showPayBreakdown[moneda] ?? false)
+                      )
+                        ? { bgcolor: "action.hover" }
+                        : {}
+                    }
+                  />
 
                   {isBase ? (
                     <>
@@ -779,63 +765,48 @@ const PaymentModal: FC<IProps> = ({
               {admiteTransfer && (
                 <Collapse in={showTransfer[moneda] ?? false}>
                   <Box sx={{ mt: 1 }}>
-                    <FormControl fullWidth>
-                      <InputLabel>Transferencia</InputLabel>
-                      <OutlinedInput
-                        startAdornment={
-                          <InputAdornment position="start">
-                            <CreditCardIcon />
-                          </InputAdornment>
-                        }
-                        label="Transferencia"
-                        value={pago.transfer || ""}
-                        type={"number"}
-                        onMouseDown={(e) => {
-                          if (e.button !== 0) return;
-                          const inp = (
-                            e.currentTarget as HTMLElement
-                          ).querySelector("input");
-                          if (inp) setTimeout(() => inp.select(), 0);
-                        }}
-                        onChange={(e) => {
-                          if (isBase) {
-                            const v = e.target.value;
-                            if (moneyRegex.test(v)) {
-                              const newTransfer = Number(v);
-                              const newCash = parseFloat(
-                                Math.max(
-                                  0,
-                                  pago.cash + pago.transfer - newTransfer,
-                                ).toFixed(2),
-                              );
-                              updatePago(moneda, {
-                                transfer: newTransfer,
-                                cash: newCash,
-                              });
-                            } else if (v === "") {
-                              const total = parseFloat(
-                                (pago.cash + pago.transfer).toFixed(2),
-                              );
-                              updatePago(moneda, {
-                                transfer: 0,
-                                cash: total,
-                              });
-                            }
-                          } else {
-                            const newTransfer = parseFloat(e.target.value) || 0;
-                            const newCash = Math.max(
-                              0,
-                              pago.cash + pago.transfer - newTransfer,
+                    <MoneyField
+                      fullWidth
+                      label="Transferencia"
+                      currencySymbol={<CreditCardIcon />}
+                      value={pago.transfer || ""}
+                      onChange={(e) => {
+                        if (isBase) {
+                          const v = e.target.value;
+                          if (moneyRegex.test(v)) {
+                            const newTransfer = Number(v);
+                            const newCash = parseFloat(
+                              Math.max(
+                                0,
+                                pago.cash + pago.transfer - newTransfer,
+                              ).toFixed(2),
                             );
                             updatePago(moneda, {
                               transfer: newTransfer,
                               cash: newCash,
                             });
+                          } else if (v === "") {
+                            const total = parseFloat(
+                              (pago.cash + pago.transfer).toFixed(2),
+                            );
+                            updatePago(moneda, {
+                              transfer: 0,
+                              cash: total,
+                            });
                           }
-                        }}
-                        inputProps={{ inputMode: "decimal" }}
-                      />
-                    </FormControl>
+                        } else {
+                          const newTransfer = parseFloat(e.target.value) || 0;
+                          const newCash = Math.max(
+                            0,
+                            pago.cash + pago.transfer - newTransfer,
+                          );
+                          updatePago(moneda, {
+                            transfer: newTransfer,
+                            cash: newCash,
+                          });
+                        }
+                      }}
+                    />
 
                     {/* Transfer destination */}
                     {pago.transfer > 0 && transferDestinations.length > 0 && (
@@ -930,21 +901,13 @@ const PaymentModal: FC<IProps> = ({
                 <Box key={moneda} sx={{ mt: idx > 0 ? 1.5 : 0 }}>
                   <Stack direction="row" gap={1} alignItems="center">
                     <Chip label={moneda} size="small" variant="outlined" />
-                    <OutlinedInput
+                    <SelectableTextField
                       size="small"
-                      type="number"
                       value={monto || ""}
-                      onMouseDown={(e) => {
-                        if (e.button !== 0) return;
-                        const inp = (
-                          e.currentTarget as HTMLElement
-                        ).querySelector("input");
-                        if (inp) setTimeout(() => inp.select(), 0);
-                      }}
                       onChange={(e) =>
                         updateVuelto(moneda, parseFloat(e.target.value) || 0)
                       }
-                      inputProps={{ min: 0, step: 0.01, inputMode: "decimal" }}
+                      inputProps={{ inputMode: "decimal" }}
                       sx={{ flex: 1 }}
                       error={!!err}
                     />

--- a/src/app/pos/components/SearchInput.tsx
+++ b/src/app/pos/components/SearchInput.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { IconButton, InputAdornment, TextField } from "@mui/material";
+import { IconButton, InputAdornment } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material";
 import ClearIcon from "@mui/icons-material/Clear";
 import SearchIcon from "@mui/icons-material/Search";
 import { normalizeSearch } from "@/utils/formatters";
+import SelectableTextField from "@/components/SelectableTextField";
 
 interface IProps {
   onSearch: (normalizedTerm: string) => void;
@@ -15,7 +16,11 @@ interface IProps {
 
 // Llama a onSearch solo cuando el texto esté vacío o tenga al menos 3 caracteres.
 // El término que recibe el padre ya está normalizado (sin tildes, minúsculas, espacios colapsados).
-export default function SearchInput({ onSearch, placeholder = "Buscar...", sx }: IProps) {
+export default function SearchInput({
+  onSearch,
+  placeholder = "Buscar...",
+  sx,
+}: IProps) {
   const [value, setValue] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -41,7 +46,7 @@ export default function SearchInput({ onSearch, placeholder = "Buscar...", sx }:
   };
 
   return (
-    <TextField
+    <SelectableTextField
       size="small"
       placeholder={placeholder}
       value={value}

--- a/src/app/pos/components/UserSalesDrawer.tsx
+++ b/src/app/pos/components/UserSalesDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   Box,
   Collapse,
@@ -36,11 +36,14 @@ import { usePermisos } from "@/utils/permisos_front";
 import useConfirmDialog from "@/components/confirmDialog";
 import { useMessageContext } from "@/context/MessageContext";
 import { removeProductFromSale, removeSell } from "@/services/sellService";
+import { getResumenCaja } from "@/services/movimientoService";
 import { ICierrePeriodo } from "@/schemas/cierre";
 import { ITransferDestination } from "@/schemas/transferDestination";
 import { IProductoTiendaV2 } from "@/schemas/producto";
+import { IResumenCajaMoneda } from "@/schemas/resumenCaja";
 import { formatDateTime } from "@/utils/formatters";
 import { convertToBase, pagadaConUnSoloPago } from "@/lib/currency";
+import CajaResumenCards from "./CajaResumenCards";
 
 interface IProps {
   showUserSales: boolean;
@@ -140,6 +143,25 @@ export const UserSalesDrawer: React.FC<IProps> = ({
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
   const [deletingSaleId, setDeletingSaleId] = useState<string | null>(null);
   const [transferExpanded, setTransferExpanded] = useState(false);
+  const [cajaResumen, setCajaResumen] = useState<IResumenCajaMoneda[]>([]);
+
+  const puedeVerCaja = verificarPermiso("operaciones.cierre.acceder");
+  const tiendaId = user?.localActual?.id;
+
+  // Fondo inicial y efectivo real de caja — se carga junto con el resto del
+  // resumen cada vez que se abre el drawer, mismo endpoint que ya usa el
+  // widget de caja del cierre (única fuente de verdad, ver src/lib/movimiento/caja.ts).
+  useEffect(() => {
+    if (!showUserSales || !puedeVerCaja || !tiendaId) return;
+    getResumenCaja(tiendaId)
+      .then((result) => setCajaResumen(result.resumen))
+      .catch((error) => {
+        console.error(
+          "[UserSalesDrawer] Error al cargar el resumen de caja",
+          error,
+        );
+      });
+  }, [showUserSales, puedeVerCaja, tiendaId]);
 
   const canDeleteProducts =
     viewMode === "historical" &&
@@ -414,6 +436,9 @@ export const UserSalesDrawer: React.FC<IProps> = ({
 
         {/* Contenido Scrollable */}
         <Box sx={{ flexGrow: 1, overflowY: "auto", pr: 0.5 }}>
+          {/* Caja: fondo inicial y efectivo real, por moneda */}
+          <CajaResumenCards resumen={cajaResumen} />
+
           {/* Totales generales */}
           <Grid container spacing={2} mb={3}>
             <Grid item xs={12} sm={4}>

--- a/src/app/pos/page.tsx
+++ b/src/app/pos/page.tsx
@@ -12,7 +12,6 @@ import {
   Typography,
   CircularProgress,
   Box,
-  TextField,
   Paper as MuiPaper,
   Portal,
   InputAdornment,
@@ -55,6 +54,7 @@ import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import { useBlockBackNavigation } from "@/hooks/useBlockBackNavigation";
 import { useCartTotal } from "@/hooks/useCartTotal";
 import { convertToBase } from "@/lib/currency";
+import SelectableTextField from "@/components/SelectableTextField";
 
 import ProductProcessorData from "@/components/ProductProcessorData/ProductProcessorData";
 
@@ -177,7 +177,7 @@ export default function POSInterface() {
   const editCartInputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
     if (editingCartId) {
-      // Forzar foco de forma robusta tras renderizar el TextField
+      // Forzar foco de forma robusta tras renderizar el campo
       const focusLater = () => {
         const el = editCartInputRef.current;
         if (el) {
@@ -188,10 +188,7 @@ export default function POSInterface() {
               el.focus();
             } catch {}
           }
-          // Seleccionar el texto para facilitar la edición
-          try {
-            el.select();
-          } catch {}
+          // SelectableTextField selecciona el texto en su propio onFocus.
         }
       };
       const raf = requestAnimationFrame(() => setTimeout(focusLater, 0));
@@ -720,8 +717,7 @@ export default function POSInterface() {
       // un total fraccionado podía dar `false` por diferencias ~1e-13 y la venta
       // se descartaba en silencio.
       if (
-        Math.round(total * 100) <=
-        Math.round((totalCash + totalTransfer) * 100)
+        Math.round(total * 100) <= Math.round((totalCash + totalTransfer) * 100)
       ) {
         const tiendaId = user.localActual.id;
         const cierreId = periodo.id;
@@ -947,10 +943,7 @@ export default function POSInterface() {
           );
         }
       } else {
-        showMessage(
-          "❌ El pago no cubre el total de la venta",
-          "error",
-        );
+        showMessage("❌ El pago no cubre el total de la venta", "error");
       }
     } catch (error) {
       console.error(error);
@@ -1583,6 +1576,11 @@ export default function POSInterface() {
           cierreId={periodo?.id ?? ""}
         />
 
+        {/* Modal de resumen de caja (fondo inicial vs. ventas reales) */}
+          <ResumenCajaModal
+            onClose={() => setResumenCajaOpen(false)}
+          />
+        )}
         {/* Diálogo de devolución de venta */}
         {puedeDevolucionVenta && (
           <DevolucionVentaDialog
@@ -1652,11 +1650,11 @@ export default function POSInterface() {
             {carts.map((c) => (
               <Box key={c.id} sx={{ display: "flex", alignItems: "center" }}>
                 {editingCartId === c.id ? (
-                  <TextField
+                  <SelectableTextField
                     size="small"
                     value={editingCartName}
                     autoFocus
-                    inputRef={editCartInputRef}
+                    ref={editCartInputRef}
                     onChange={(e) => setEditingCartName(e.target.value)}
                     onBlur={() => {
                       if (editingCartId) {
@@ -1794,8 +1792,8 @@ export default function POSInterface() {
           }}
         >
           <Stack direction="row" spacing={1}>
-            <TextField
-              inputRef={searchInputRef}
+            <SelectableTextField
+              ref={searchInputRef}
               fullWidth
               variant="outlined"
               placeholder="Buscar productos..."
@@ -1804,11 +1802,7 @@ export default function POSInterface() {
               // onFocus={() => searchQuery.length > 0 && setShowSearchResults(true)}
               onFocus={() => handleSearchFocus()}
               onBlur={() => handleSearchBlur()}
-              onMouseDown={(e) => {
-                handleSearchMouseDown();
-                if (e.button === 0 && searchInputRef.current)
-                  setTimeout(() => searchInputRef.current?.select(), 0);
-              }}
+              onMouseDown={() => handleSearchMouseDown()}
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">

--- a/src/app/pos/page.tsx
+++ b/src/app/pos/page.tsx
@@ -1151,7 +1151,7 @@ export default function POSInterface() {
         onOnboardingPeriodPrompt,
       );
     };
-  }, [periodo, user.localActual?.id]);
+  }, [periodo, user?.localActual?.id]);
 
   // Activar audio context cuando se carga la página
   useEffect(() => {
@@ -1576,11 +1576,6 @@ export default function POSInterface() {
           cierreId={periodo?.id ?? ""}
         />
 
-        {/* Modal de resumen de caja (fondo inicial vs. ventas reales) */}
-          <ResumenCajaModal
-            onClose={() => setResumenCajaOpen(false)}
-          />
-        )}
         {/* Diálogo de devolución de venta */}
         {puedeDevolucionVenta && (
           <DevolucionVentaDialog

--- a/src/app/ventas/page.tsx
+++ b/src/app/ventas/page.tsx
@@ -14,7 +14,6 @@ import {
   IconButton,
   Alert,
   Button,
-  TextField,
   InputAdornment,
   Grid,
   Card,
@@ -49,6 +48,7 @@ import {
 } from "@/services/sellService";
 import { PageContainer } from "@/components/PageContainer";
 import { ContentCard } from "@/components/ContentCard";
+import SelectableTextField from "@/components/SelectableTextField";
 import VentaDetailDialog from "./components/VentaDetailDialog";
 import { formatDate, formatDateTime, isToday } from "@/utils/formatters";
 import { usePermisos } from "@/utils/permisos_front";
@@ -489,7 +489,7 @@ const Ventas = () => {
             : undefined
         }
         headerActions={
-          <TextField
+          <SelectableTextField
             size="small"
             placeholder={isMobile ? "Buscar..." : "Buscar venta..."}
             value={searchTerm}

--- a/src/components/GestionInventario/dialogs/ChangeQtyDialog.tsx
+++ b/src/components/GestionInventario/dialogs/ChangeQtyDialog.tsx
@@ -10,7 +10,6 @@ import {
   DialogContent,
   DialogTitle,
   FormControl,
-  InputAdornment,
   InputLabel,
   MenuItem,
   Select,
@@ -22,6 +21,8 @@ import { ChangeQtyOptions } from "../hooks/useGestionInventario";
 import { formatNumber } from "@/utils/formatters";
 import { useAppContext } from "@/context/AppContext";
 import { convertToBase } from "@/lib/currency";
+import MoneyField from "@/components/MoneyField";
+import SelectableTextField from "@/components/SelectableTextField";
 
 interface Props {
   open: boolean;
@@ -120,7 +121,7 @@ export function ChangeQtyDialog({ open, producto, onClose, onSave }: Props) {
               size="small"
               sx={{ flex: 1 }}
             />
-            <TextField
+            <SelectableTextField
               label="Nueva cantidad"
               value={newQtyStr}
               onChange={(e) => setNewQtyStr(e.target.value)}
@@ -154,17 +155,11 @@ export function ChangeQtyDialog({ open, producto, onClose, onSave }: Props) {
           )}
 
           {mostrarCosto && (
-            <TextField
+            <MoneyField
               label={`Costo unitario${isExtraCurrency ? ` (${monedaCompra})` : ""}`}
               value={costoUnitario}
               onChange={(e) => setCostoUnitario(e.target.value)}
               size="small"
-              inputProps={{ inputMode: "decimal" }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">$</InputAdornment>
-                ),
-              }}
               helperText={
                 isExtraCurrency && costoUnitario
                   ? `≈ ${convertToBase(parseFloat(costoUnitario) || 0, monedaCompra, tasasVigentes, monedaBase).toFixed(2)} ${monedaBase}`

--- a/src/components/GestionInventario/dialogs/CreateMovimientoDialog.tsx
+++ b/src/components/GestionInventario/dialogs/CreateMovimientoDialog.tsx
@@ -11,7 +11,6 @@ import {
   DialogContent,
   DialogTitle,
   FormControl,
-  InputAdornment,
   InputLabel,
   MenuItem,
   Select,
@@ -36,6 +35,8 @@ import { formatAdvertenciasCaja, formatCurrency } from "@/utils/formatters";
 import { generateUUID } from "@/utils/uuid";
 import useConfirmDialog from "@/components/confirmDialog";
 import { FormaPagoCompraSelect } from "@/components/GestionInventario/FormaPagoCompraSelect";
+import MoneyField from "@/components/MoneyField";
+import SelectableTextField from "@/components/SelectableTextField";
 
 interface Props {
   open: boolean;
@@ -380,7 +381,7 @@ export function CreateMovimientoDialog({
               </FormControl>
             )}
 
-            <TextField
+            <SelectableTextField
               label="Cantidad"
               value={cantidad}
               onChange={(e) => setCantidad(e.target.value)}
@@ -390,17 +391,11 @@ export function CreateMovimientoDialog({
             />
 
             {mostrarCosto && (
-              <TextField
+              <MoneyField
                 label={`Costo unitario${isExtraCurrency ? ` (${monedaCompra})` : ""}`}
                 value={costoUnitario}
                 onChange={(e) => setCostoUnitario(e.target.value)}
                 size="small"
-                inputProps={{ inputMode: "decimal" }}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">$</InputAdornment>
-                  ),
-                }}
                 helperText={
                   isExtraCurrency && costoUnitario
                     ? `≈ ${convertToBase(parseFloat(costoUnitario) || 0, monedaCompra, tasasVigentes, monedaBase).toFixed(2)} ${monedaBase}`

--- a/src/components/GestionInventario/dialogs/CreateProductDialog.tsx
+++ b/src/components/GestionInventario/dialogs/CreateProductDialog.tsx
@@ -14,7 +14,6 @@ import {
   FormControl,
   FormControlLabel,
   IconButton,
-  InputAdornment,
   InputLabel,
   MenuItem,
   Select,
@@ -37,6 +36,8 @@ import MobileQrScanner from "@/components/ProductProcessorData/MobileQrScanner";
 import { useAppContext } from "@/context/AppContext";
 import { convertToBase, convertFromBase } from "@/lib/currency";
 import { usePermisos } from "@/utils/permisos_front";
+import MoneyField from "@/components/MoneyField";
+import SelectableTextField from "@/components/SelectableTextField";
 import {
   PRODUCTO_PRUEBA_SUGERENCIAS,
   selectIsOnboardingBlocking,
@@ -554,18 +555,12 @@ export function CreateProductDialog({
                 </Select>
               </FormControl>
             )}
-            <TextField
+            <MoneyField
               label={`Costo (${costoMonedaEfectiva})`}
               value={costo}
               onChange={(e) => setCosto(e.target.value)}
               size="small"
               disabled={!puedeEditarCosto}
-              inputProps={{ inputMode: "decimal" }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">$</InputAdornment>
-                ),
-              }}
               helperText={
                 costoEnBase !== null
                   ? `≈ ${costoEnBase.toFixed(2)} ${monedaBase}`
@@ -594,18 +589,12 @@ export function CreateProductDialog({
                 </Select>
               </FormControl>
             )}
-            <TextField
+            <MoneyField
               label={`Precio (${precioMonedaEfectiva})`}
               value={precio}
               onChange={(e) => setPrecio(e.target.value)}
               size="small"
               disabled={!puedeEditarPrecio}
-              inputProps={{ inputMode: "decimal" }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">$</InputAdornment>
-                ),
-              }}
               helperText={
                 precioEnBase !== null
                   ? `≈ ${precioEnBase.toFixed(2)} ${monedaBase}`
@@ -622,7 +611,7 @@ export function CreateProductDialog({
             </Alert>
           )}
 
-          <TextField
+          <SelectableTextField
             label="Cantidad inicial (opcional)"
             value={cantidadInicial}
             onChange={(e) => setCantidadInicial(e.target.value)}
@@ -697,7 +686,7 @@ export function CreateProductDialog({
                       ))}
                     </Select>
                   </FormControl>
-                  <TextField
+                  <SelectableTextField
                     label="Unidades por fracción"
                     value={fraccionValue ?? ""}
                     onChange={(e) =>

--- a/src/components/GestionInventario/dialogs/EditProductDialog.tsx
+++ b/src/components/GestionInventario/dialogs/EditProductDialog.tsx
@@ -14,7 +14,6 @@ import {
   FormControl,
   FormControlLabel,
   IconButton,
-  InputAdornment,
   InputLabel,
   MenuItem,
   Select,
@@ -36,6 +35,8 @@ import MobileQrScanner from "@/components/ProductProcessorData/MobileQrScanner";
 import { useAppContext } from "@/context/AppContext";
 import { convertToBase, convertFromBase } from "@/lib/currency";
 import { usePermisos } from "@/utils/permisos_front";
+import MoneyField from "@/components/MoneyField";
+import SelectableTextField from "@/components/SelectableTextField";
 
 interface Props {
   open: boolean;
@@ -335,18 +336,12 @@ export function EditProductDialog({
                 </Select>
               </FormControl>
             )}
-            <TextField
+            <MoneyField
               label={`Costo (${costoMonedaEfectiva})`}
               value={costo}
               onChange={(e) => setCosto(e.target.value)}
               size="small"
               disabled={!puedeEditarCosto}
-              inputProps={{ inputMode: "decimal" }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">$</InputAdornment>
-                ),
-              }}
               helperText={
                 costoEnBase !== null
                   ? `≈ ${costoEnBase.toFixed(2)} ${monedaBase}`
@@ -375,18 +370,12 @@ export function EditProductDialog({
                 </Select>
               </FormControl>
             )}
-            <TextField
+            <MoneyField
               label={`Precio (${precioMonedaEfectiva})`}
               value={precio}
               onChange={(e) => setPrecio(e.target.value)}
               size="small"
               disabled={!puedeEditarPrecio}
-              inputProps={{ inputMode: "decimal" }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">$</InputAdornment>
-                ),
-              }}
               helperText={
                 precioEnBase !== null
                   ? `≈ ${precioEnBase.toFixed(2)} ${monedaBase}`
@@ -456,7 +445,7 @@ export function EditProductDialog({
                   ))}
                 </Select>
               </FormControl>
-              <TextField
+              <SelectableTextField
                 label="Unidades por fracción"
                 value={fraccionValue ?? ""}
                 onChange={(e) =>

--- a/src/components/GestionInventario/dialogs/PrintLabelsModal.tsx
+++ b/src/components/GestionInventario/dialogs/PrintLabelsModal.tsx
@@ -14,7 +14,6 @@ import {
   ListItemText,
   ListItemSecondaryAction,
   Checkbox,
-  TextField,
   Alert,
   CircularProgress,
   Stack,
@@ -31,13 +30,14 @@ import {
   QrCode,
   QrCode2,
 } from "@mui/icons-material";
-import { formatCurrency } from '@/utils/formatters';
+import { formatCurrency } from "@/utils/formatters";
 import jsPDF from "jspdf";
 import bwipjs from "bwip-js";
 import QRCode from "qrcode";
-import generateEAN13 from '@/utils/generateProductCode';
+import generateEAN13 from "@/utils/generateProductCode";
 import { useMessageContext } from "@/context/MessageContext";
 import { generateProductsCode } from "@/services/productServise";
+import SelectableTextField from "@/components/SelectableTextField";
 
 interface ProductoConCodigos {
   id: string;
@@ -78,12 +78,14 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
   tiendaId,
 }) => {
   const [productos, setProductos] = useState<ProductoConCodigos[]>([]);
-  const [selectedProducts, setSelectedProducts] = useState<SelectedProduct[]>([]);
+  const [selectedProducts, setSelectedProducts] = useState<SelectedProduct[]>(
+    [],
+  );
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [generatingCodes, setGeneratingCodes] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const [codeType, setCodeType] = useState<'barcode' | 'qr'>('barcode');
+  const [codeType, setCodeType] = useState<"barcode" | "qr">("barcode");
   const { showMessage } = useMessageContext();
 
   // Cargar productos al abrir el modal
@@ -96,18 +98,26 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
   const loadProductos = async () => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/productos_tienda/${tiendaId}/with-codes`);
+      const response = await fetch(
+        `/api/productos_tienda/${tiendaId}/with-codes`,
+      );
       if (!response.ok) throw new Error("Error al cargar productos");
       const data = await response.json();
-      
-      const data2 = (data as ProductoConCodigos[])
-      .reduce((acum: ProductoConCodigos[], item) => {
-        const prod = acum.find(p => p.producto.nombre === item.producto.nombre && p.precio === item.precio);
-        if(!prod) {
-          acum.push(item);
-        }
-        return acum;
-      }, []);
+
+      const data2 = (data as ProductoConCodigos[]).reduce(
+        (acum: ProductoConCodigos[], item) => {
+          const prod = acum.find(
+            (p) =>
+              p.producto.nombre === item.producto.nombre &&
+              p.precio === item.precio,
+          );
+          if (!prod) {
+            acum.push(item);
+          }
+          return acum;
+        },
+        [],
+      );
       setProductos(data2);
     } catch (error) {
       console.error("Error al cargar productos:", error);
@@ -118,61 +128,73 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
 
   const filteredProducts = productos.filter(
     (product) =>
-      product.producto.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      product.categoria?.nombre?.toLowerCase()?.includes(searchTerm.toLowerCase())
+      product.producto.nombre
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase()) ||
+      product.categoria?.nombre
+        ?.toLowerCase()
+        ?.includes(searchTerm.toLowerCase()),
   );
 
-  const handleProductSelect = (product: ProductoConCodigos, selected: boolean) => {
+  const handleProductSelect = (
+    product: ProductoConCodigos,
+    selected: boolean,
+  ) => {
     if (selected) {
       const needsCode = product.producto.codigosProducto.length === 0;
-      setSelectedProducts(prev => [
+      setSelectedProducts((prev) => [
         ...prev,
-        { ...product, cantidad: 1, needsCode }
+        { ...product, cantidad: 1, needsCode },
       ]);
     } else {
-      setSelectedProducts(prev => 
-        prev.filter(p => p.id !== product.id)
-      );
+      setSelectedProducts((prev) => prev.filter((p) => p.id !== product.id));
     }
   };
 
   const handleQuantityChange = (productId: string, newQuantity: number) => {
     if (newQuantity < 1) return;
-    setSelectedProducts(prev =>
-      prev.map(p => p.id === productId ? { ...p, cantidad: newQuantity } : p)
+    setSelectedProducts((prev) =>
+      prev.map((p) =>
+        p.id === productId ? { ...p, cantidad: newQuantity } : p,
+      ),
     );
   };
 
   const handleSelectAllProducts = (checked: boolean) => {
     if (checked) {
-      setSelectedProducts(filteredProducts.map(p => ({
-        ...p,
-        cantidad: 1,
-        needsCode: p.producto.codigosProducto.length === 0
-      })));
+      setSelectedProducts(
+        filteredProducts.map((p) => ({
+          ...p,
+          cantidad: 1,
+          needsCode: p.producto.codigosProducto.length === 0,
+        })),
+      );
     } else {
       setSelectedProducts([]);
     }
   };
 
   const generateMissingCodes = async () => {
-    const productsNeedingCodes = selectedProducts.filter(p => p.needsCode);
+    const productsNeedingCodes = selectedProducts.filter((p) => p.needsCode);
     if (productsNeedingCodes.length === 0) return;
 
     setGeneratingCodes(true);
-    showMessage(`Generando códigos para ${productsNeedingCodes.length} producto(s)...`, 'info');
+    showMessage(
+      `Generando códigos para ${productsNeedingCodes.length} producto(s)...`,
+      "info",
+    );
 
     // Obtener códigos existentes para evitar duplicados
     const allCodes = productos
-      .flatMap(p => p.producto.codigosProducto.map(c => c.codigo))
-      .concat(selectedProducts.map(p => p.generatedCode).filter(Boolean));
-    
+      .flatMap((p) => p.producto.codigosProducto.map((c) => c.codigo))
+      .concat(selectedProducts.map((p) => p.generatedCode).filter(Boolean));
+
     const existingCodes = new Set(allCodes);
 
     try {
       // Generar códigos para cada producto que los necesite
-      const prodPayload:{ productoId: string, code: string}[] = [];
-      
+      const prodPayload: { productoId: string; code: string }[] = [];
+
       for (const product of productsNeedingCodes) {
         try {
           // Generar código
@@ -181,10 +203,13 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
 
           prodPayload.push({
             productoId: product.producto.id,
-            code: generatedCode
+            code: generatedCode,
           });
         } catch (error) {
-          console.error(`Error generando código para ${product.producto.nombre}:`, error);
+          console.error(
+            `Error generando código para ${product.producto.nombre}:`,
+            error,
+          );
         }
       }
 
@@ -192,7 +217,7 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
 
       // Procesar la respuesta del endpoint bulk
       const responseData = response.data;
-      
+
       // Crear un mapa de productos actualizados basado en la respuesta
       const successMap = new Map();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -201,7 +226,7 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
       });
 
       // Actualizar productos exitosos
-      const updatedProducts = selectedProducts.map(product => {
+      const updatedProducts = selectedProducts.map((product) => {
         if (product.needsCode && successMap.has(product.producto.id)) {
           const newCode = successMap.get(product.producto.id);
           return {
@@ -212,9 +237,9 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
               ...product.producto,
               codigosProducto: [
                 ...product.producto.codigosProducto,
-                { id: newCode.id, codigo: newCode.codigo }
-              ]
-            }
+                { id: newCode.id, codigo: newCode.codigo },
+              ],
+            },
           };
         }
         return product;
@@ -228,31 +253,45 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
       setSelectedProducts(updatedProducts);
 
       // También actualizar la lista principal de productos para reflejar los nuevos códigos
-      setProductos(prev => prev.map(product => {
-        const updated = updatedProducts.find(up => up.producto.id === product.producto.id);
-        return updated ? {
-          ...product,
-          producto: updated.producto
-        } : product;
-      }));
+      setProductos((prev) =>
+        prev.map((product) => {
+          const updated = updatedProducts.find(
+            (up) => up.producto.id === product.producto.id,
+          );
+          return updated
+            ? {
+                ...product,
+                producto: updated.producto,
+              }
+            : product;
+        }),
+      );
 
       // Mostrar mensaje de resultado
       if (successCount > 0 && errorCount === 0) {
-        showMessage(`Se generaron ${successCount} códigos exitosamente`, 'success');
+        showMessage(
+          `Se generaron ${successCount} códigos exitosamente`,
+          "success",
+        );
       } else if (successCount > 0 && errorCount > 0) {
-        showMessage(`Se generaron ${successCount} códigos. ${errorCount} fallaron.`, 'warning');
+        showMessage(
+          `Se generaron ${successCount} códigos. ${errorCount} fallaron.`,
+          "warning",
+        );
       } else if (errorCount > 0) {
-        showMessage(`Error generando códigos para ${errorCount} producto(s)`, 'error');
+        showMessage(
+          `Error generando códigos para ${errorCount} producto(s)`,
+          "error",
+        );
       }
 
       // Mostrar errores específicos si los hay
       if (errorCount > 0) {
-        console.error('Errores específicos:', responseData.errors);
+        console.error("Errores específicos:", responseData.errors);
       }
-
     } catch (error) {
-      console.error('Error generando códigos:', error);
-      showMessage('Error generando códigos de barras', 'error');
+      console.error("Error generando códigos:", error);
+      showMessage("Error generando códigos de barras", "error");
     } finally {
       setGeneratingCodes(false);
     }
@@ -263,19 +302,27 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
 
     setGenerating(true);
     try {
-      const doc = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'A4' });
+      const doc = new jsPDF({
+        orientation: "portrait",
+        unit: "pt",
+        format: "A4",
+      });
       const pageWidth = 595;
       const pageHeight = 842;
-      
+
       // Etiquetas más compactas
-      const labelWidth = 140;  // Reducido de 180 a 140
-      const labelHeight = 80;  // Reducido de 120 a 80
-      const margin = 10;       // Reducido de 15 a 10
-      const spacing = 2;       // Espaciado entre etiquetas
-      
-      const cols = Math.floor((pageWidth - 2 * margin) / (labelWidth + spacing));
-      const rows = Math.floor((pageHeight - 2 * margin) / (labelHeight + spacing));
-      
+      const labelWidth = 140; // Reducido de 180 a 140
+      const labelHeight = 80; // Reducido de 120 a 80
+      const margin = 10; // Reducido de 15 a 10
+      const spacing = 2; // Espaciado entre etiquetas
+
+      const cols = Math.floor(
+        (pageWidth - 2 * margin) / (labelWidth + spacing),
+      );
+      const rows = Math.floor(
+        (pageHeight - 2 * margin) / (labelHeight + spacing),
+      );
+
       // let currentPage = 1;
       let currentRow = 0;
       let currentCol = 0;
@@ -295,8 +342,9 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
           const y = margin + currentRow * (labelHeight + spacing);
 
           // Código de barras a usar
-          const codigoBarras = product.generatedCode || 
-            (product.producto.codigosProducto[0]?.codigo) || 
+          const codigoBarras =
+            product.generatedCode ||
+            product.producto.codigosProducto[0]?.codigo ||
             `NO-CODE-${product.id}`;
 
           // Dibujar borde de etiqueta más sutil
@@ -306,13 +354,16 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
 
           // Nombre del producto (letra más pequeña, arriba)
           doc.setFontSize(6);
-          doc.setFont('helvetica', 'normal');
-          const nombreWrapped = doc.splitTextToSize(product.producto.nombre, labelWidth - 8);
+          doc.setFont("helvetica", "normal");
+          const nombreWrapped = doc.splitTextToSize(
+            product.producto.nombre,
+            labelWidth - 8,
+          );
           doc.text(nombreWrapped.slice(0, 1), x + 4, y + 10); // Solo 1 línea para ser más compacto
 
           // Precio (letra grande pero proporcionalmente ajustada)
           doc.setFontSize(18); // Reducido de 24 a 18
-          doc.setFont('helvetica', 'bold');
+          doc.setFont("helvetica", "bold");
           const precioText = formatCurrency(product.precio);
           const precioWidth = doc.getTextWidth(precioText);
           doc.text(precioText, x + (labelWidth - precioWidth) / 2, y + 35); // Centrado verticalmente
@@ -320,46 +371,64 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
           // Generar código según el tipo seleccionado
           if (codigoBarras !== `NO-CODE-${product.id}`) {
             try {
-              if (codeType === 'barcode') {
+              if (codeType === "barcode") {
                 // Código de barras
-                const canvas = document.createElement('canvas');
+                const canvas = document.createElement("canvas");
                 bwipjs.toCanvas(canvas, {
-                  bcid: 'code128',
+                  bcid: "code128",
                   text: codigoBarras,
-                  scale: 0.8,  // Reducido de 1 a 0.8
-                  height: 12,  // Reducido de 20 a 12
+                  scale: 0.8, // Reducido de 1 a 0.8
+                  height: 12, // Reducido de 20 a 12
                   includetext: false,
-                  textxalign: 'center',
+                  textxalign: "center",
                 });
-                const barcodeDataUrl = canvas.toDataURL('image/png');
-                doc.addImage(barcodeDataUrl, 'PNG', x + 4, y + 45, labelWidth - 8, 16); // Más compacto
+                const barcodeDataUrl = canvas.toDataURL("image/png");
+                doc.addImage(
+                  barcodeDataUrl,
+                  "PNG",
+                  x + 4,
+                  y + 45,
+                  labelWidth - 8,
+                  16,
+                ); // Más compacto
               } else {
                 // Código QR
-                const qrDataUrl = await QRCode.toDataURL(codigoBarras, { 
-                  width: 48, 
+                const qrDataUrl = await QRCode.toDataURL(codigoBarras, {
+                  width: 48,
                   margin: 0,
-                  errorCorrectionLevel: 'M'
+                  errorCorrectionLevel: "M",
                 });
                 const qrSize = 16; // Tamaño compacto para QR
-                doc.addImage(qrDataUrl, 'PNG', x + (labelWidth - qrSize) / 2, y + 45, qrSize, qrSize);
+                doc.addImage(
+                  qrDataUrl,
+                  "PNG",
+                  x + (labelWidth - qrSize) / 2,
+                  y + 45,
+                  qrSize,
+                  qrSize,
+                );
               }
-              
+
               // Número del código (letra muy pequeña)
               doc.setFontSize(4); // Reducido de 6 a 4
-              doc.setFont('helvetica', 'normal');
+              doc.setFont("helvetica", "normal");
               const codigoWidth = doc.getTextWidth(codigoBarras);
-              doc.text(codigoBarras, x + (labelWidth - codigoWidth) / 2, y + 70);
+              doc.text(
+                codigoBarras,
+                x + (labelWidth - codigoWidth) / 2,
+                y + 70,
+              );
             } catch (error) {
               console.error("Error generando código:", error);
               // Fallback: mostrar solo el texto del código
               doc.setFontSize(5);
-              doc.setFont('helvetica', 'normal');
+              doc.setFont("helvetica", "normal");
               doc.text(`Código: ${codigoBarras}`, x + 4, y + 55);
             }
           } else {
             // Sin código de barras
             doc.setFontSize(5);
-            doc.setFont('helvetica', 'normal');
+            doc.setFont("helvetica", "normal");
             doc.text("Sin código", x + 4, y + 55);
           }
 
@@ -373,19 +442,24 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
         }
       }
 
-      const codeTypeText = codeType === 'barcode' ? 'barras' : 'QR';
+      const codeTypeText = codeType === "barcode" ? "barras" : "QR";
       doc.save(`etiquetas_precios_${codeTypeText}_${new Date().getTime()}.pdf`);
-      showMessage(`PDF generado con ${labelCount} etiquetas con códigos ${codeTypeText}`, 'success');
+      showMessage(
+        `PDF generado con ${labelCount} etiquetas con códigos ${codeTypeText}`,
+        "success",
+      );
     } catch (error) {
       console.error("Error generando PDF:", error);
-      showMessage('Error generando el PDF de etiquetas', 'error');
+      showMessage("Error generando el PDF de etiquetas", "error");
     } finally {
       setGenerating(false);
     }
   };
 
   const totalLabels = selectedProducts.reduce((sum, p) => sum + p.cantidad, 0);
-  const productsWithoutCodes = selectedProducts.filter(p => p.needsCode && !p.generatedCode);
+  const productsWithoutCodes = selectedProducts.filter(
+    (p) => p.needsCode && !p.generatedCode,
+  );
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
@@ -395,10 +469,15 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
           <Typography variant="h6">Imprimir Etiquetas de Precios</Typography>
         </Stack>
       </DialogTitle>
-      
+
       <DialogContent>
         {loading ? (
-          <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            minHeight="200px"
+          >
             <CircularProgress />
             <Typography variant="body2" sx={{ ml: 2 }}>
               Cargando productos...
@@ -407,7 +486,7 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
         ) : (
           <Stack spacing={2}>
             {/* Búsqueda */}
-            <TextField
+            <SelectableTextField
               fullWidth
               placeholder="Buscar productos..."
               value={searchTerm}
@@ -416,61 +495,88 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
             />
 
             {/* Selector de tipo de código */}
-            <Box sx={{ p: 2, bgcolor: 'background.paper', borderRadius: 1, border: 1, borderColor: 'divider' }}>
+            <Box
+              sx={{
+                p: 2,
+                bgcolor: "background.paper",
+                borderRadius: 1,
+                border: 1,
+                borderColor: "divider",
+              }}
+            >
               <Typography variant="subtitle2" gutterBottom>
                 Tipo de código a imprimir:
               </Typography>
               <Stack direction="row" spacing={2}>
                 <Button
-                  variant={codeType === 'barcode' ? 'contained' : 'outlined'}
+                  variant={codeType === "barcode" ? "contained" : "outlined"}
                   size="small"
-                  onClick={() => setCodeType('barcode')}
+                  onClick={() => setCodeType("barcode")}
                   startIcon={<QrCode />}
                 >
                   Código de Barras
                 </Button>
                 <Button
-                  variant={codeType === 'qr' ? 'contained' : 'outlined'}
+                  variant={codeType === "qr" ? "contained" : "outlined"}
                   size="small"
-                  onClick={() => setCodeType('qr')}
+                  onClick={() => setCodeType("qr")}
                   startIcon={<QrCode2 />}
                 >
                   Código QR
                 </Button>
               </Stack>
-              <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-                {codeType === 'barcode' 
-                  ? 'Los códigos de barras son ideales para escáneres tradicionales de tiendas'
-                  : 'Los códigos QR pueden escanearse con cualquier smartphone'
-                }
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ mt: 1, display: "block" }}
+              >
+                {codeType === "barcode"
+                  ? "Los códigos de barras son ideales para escáneres tradicionales de tiendas"
+                  : "Los códigos QR pueden escanearse con cualquier smartphone"}
               </Typography>
             </Box>
 
             {/* Productos sin códigos - advertencia */}
             {productsWithoutCodes.length > 0 && (
-              <Alert 
-                severity="warning" 
+              <Alert
+                severity="warning"
                 action={
-                  <Button 
-                    color="inherit" 
-                    size="small" 
+                  <Button
+                    color="inherit"
+                    size="small"
                     onClick={generateMissingCodes}
-                    startIcon={generatingCodes ? <CircularProgress size={16} /> : <QrCode />}
+                    startIcon={
+                      generatingCodes ? (
+                        <CircularProgress size={16} />
+                      ) : (
+                        <QrCode />
+                      )
+                    }
                     disabled={generatingCodes}
                   >
-                    {generatingCodes ? 'Generando...' : 'Auto-generar códigos'}
+                    {generatingCodes ? "Generando..." : "Auto-generar códigos"}
                   </Button>
                 }
               >
-                {productsWithoutCodes.length} producto(s) seleccionado(s) no tienen código de barras
+                {productsWithoutCodes.length} producto(s) seleccionado(s) no
+                tienen código de barras
               </Alert>
             )}
 
             {/* Resumen de selección */}
             {selectedProducts.length > 0 && (
-              <Box sx={{ p: 2, bgcolor: 'background.paper', borderRadius: 1, border: 1, borderColor: 'divider' }}>
+              <Box
+                sx={{
+                  p: 2,
+                  bgcolor: "background.paper",
+                  borderRadius: 1,
+                  border: 1,
+                  borderColor: "divider",
+                }}
+              >
                 <Typography variant="subtitle2" gutterBottom>
-                  Productos seleccionados: {selectedProducts.length} ({totalLabels} etiquetas)
+                  Productos seleccionados: {selectedProducts.length} (
+                  {totalLabels} etiquetas)
                 </Typography>
                 <Stack direction="row" spacing={1} flexWrap="wrap">
                   {selectedProducts.map((product) => (
@@ -488,35 +594,46 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
             <Divider />
 
             {/* Lista de productos */}
-            <Box sx={{ maxHeight: 400, overflow: 'auto' }}>
+            <Box sx={{ maxHeight: 400, overflow: "auto" }}>
               <List>
-
-              {/* Checkbox para seleccionar todos los productos */}
-              <ListItem>
-                <Checkbox
-                  checked={selectedProducts.length === filteredProducts.length}
-                  onChange={(e) => handleSelectAllProducts(e.target.checked)}
-                />
-                <ListItemText
-                  primary="Seleccionar todos"
-                  secondary={`${filteredProducts.length} productos disponibles`}
-                />
-              </ListItem>
+                {/* Checkbox para seleccionar todos los productos */}
+                <ListItem>
+                  <Checkbox
+                    checked={
+                      selectedProducts.length === filteredProducts.length
+                    }
+                    onChange={(e) => handleSelectAllProducts(e.target.checked)}
+                  />
+                  <ListItemText
+                    primary="Seleccionar todos"
+                    secondary={`${filteredProducts.length} productos disponibles`}
+                  />
+                </ListItem>
 
                 {filteredProducts.map((product) => {
-                  const isSelected = selectedProducts.some(p => p.id === product.id);
-                  const selectedProduct = selectedProducts.find(p => p.id === product.id);
+                  const isSelected = selectedProducts.some(
+                    (p) => p.id === product.id,
+                  );
+                  const selectedProduct = selectedProducts.find(
+                    (p) => p.id === product.id,
+                  );
                   const hasCode = product.producto.codigosProducto.length > 0;
 
                   return (
                     <ListItem key={product.id} dense>
                       <Checkbox
                         checked={isSelected}
-                        onChange={(e) => handleProductSelect(product, e.target.checked)}
+                        onChange={(e) =>
+                          handleProductSelect(product, e.target.checked)
+                        }
                       />
                       <ListItemText
                         primary={
-                          <Stack direction="row" alignItems="center" spacing={1}>
+                          <Stack
+                            direction="row"
+                            alignItems="center"
+                            spacing={1}
+                          >
                             <Typography variant="body2">
                               {product.producto.nombre}
                             </Typography>
@@ -539,8 +656,15 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
                           </Stack>
                         }
                         secondary={
-                          <Stack direction="row" alignItems="center" spacing={1}>
-                            <Typography variant="caption" color="text.secondary">
+                          <Stack
+                            direction="row"
+                            alignItems="center"
+                            spacing={1}
+                          >
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
                               {formatCurrency(product.precio)}
                             </Typography>
                             {product.categoria && (
@@ -549,9 +673,9 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
                                 size="small"
                                 sx={{
                                   bgcolor: product.categoria.color,
-                                  color: 'white',
-                                  fontSize: '0.65rem',
-                                  height: 16
+                                  color: "white",
+                                  fontSize: "0.65rem",
+                                  height: 16,
                                 }}
                               />
                             )}
@@ -560,20 +684,37 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
                       />
                       {isSelected && (
                         <ListItemSecondaryAction>
-                          <Stack direction="row" alignItems="center" spacing={0.5}>
+                          <Stack
+                            direction="row"
+                            alignItems="center"
+                            spacing={0.5}
+                          >
                             <IconButton
                               size="small"
-                              onClick={() => handleQuantityChange(product.id, selectedProduct.cantidad - 1)}
+                              onClick={() =>
+                                handleQuantityChange(
+                                  product.id,
+                                  selectedProduct.cantidad - 1,
+                                )
+                              }
                               disabled={selectedProduct.cantidad <= 1}
                             >
                               <Remove fontSize="small" />
                             </IconButton>
-                            <Typography variant="body2" sx={{ minWidth: 20, textAlign: 'center' }}>
+                            <Typography
+                              variant="body2"
+                              sx={{ minWidth: 20, textAlign: "center" }}
+                            >
                               {selectedProduct.cantidad}
                             </Typography>
                             <IconButton
                               size="small"
-                              onClick={() => handleQuantityChange(product.id, selectedProduct.cantidad + 1)}
+                              onClick={() =>
+                                handleQuantityChange(
+                                  product.id,
+                                  selectedProduct.cantidad + 1,
+                                )
+                              }
                             >
                               <Add fontSize="small" />
                             </IconButton>
@@ -590,18 +731,20 @@ export const PrintLabelsModal: React.FC<PrintLabelsModalProps> = ({
       </DialogContent>
 
       <DialogActions>
-        <Button onClick={onClose}>
-          Cancelar
-        </Button>
+        <Button onClick={onClose}>Cancelar</Button>
         <Button
           variant="contained"
           onClick={generatePriceLabelsPDF}
-          disabled={selectedProducts.length === 0 || generating || productsWithoutCodes.length > 0}
+          disabled={
+            selectedProducts.length === 0 ||
+            generating ||
+            productsWithoutCodes.length > 0
+          }
           startIcon={generating ? <CircularProgress size={16} /> : <Print />}
         >
-          {generating ? 'Generando...' : `Imprimir ${totalLabels} etiqueta(s)`}
+          {generating ? "Generando..." : `Imprimir ${totalLabels} etiqueta(s)`}
         </Button>
       </DialogActions>
     </Dialog>
   );
-}; 
+};

--- a/src/components/GestionInventario/filters/InventarioFiltersBar.tsx
+++ b/src/components/GestionInventario/filters/InventarioFiltersBar.tsx
@@ -33,6 +33,7 @@ import { useState, useRef, useMemo } from "react";
 import { ICategory } from "@/schemas/categoria";
 import { StockFilter, ExpiryFilter } from "../hooks/useGestionInventario";
 import { uniqueBy } from "@/utils/arrayUtils";
+import SelectableTextField from "@/components/SelectableTextField";
 
 interface InventarioFiltersBarProps {
   searchTerm: string;
@@ -139,12 +140,12 @@ export function InventarioFiltersBar({
           alignItems="center"
           sx={{ scrollMarginTop: "64px" }}
         >
-          <TextField
+          <SelectableTextField
             size="small"
             placeholder="Buscar..."
             value={searchTerm}
             onChange={(e) => onSearchChange(e.target.value)}
-            inputRef={searchInputRef}
+            ref={searchInputRef}
             onFocus={() =>
               searchRowRef.current?.scrollIntoView({
                 behavior: "smooth",
@@ -330,7 +331,7 @@ export function InventarioFiltersBar({
   return (
     <Box display="flex" flexDirection="column" gap={1.5}>
       <Box display="flex" gap={1} alignItems="center" flexWrap="wrap">
-        <TextField
+        <SelectableTextField
           size="small"
           placeholder="Buscar producto o categoría..."
           value={searchTerm}

--- a/src/components/GestionInventario/movimientos/DevolucionVentaDialog.tsx
+++ b/src/components/GestionInventario/movimientos/DevolucionVentaDialog.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/schemas/devolucionVenta";
 import { formatCurrency } from "@/utils/formatters";
 import useConfirmDialog from "@/components/confirmDialog";
+import SelectableTextField from "@/components/SelectableTextField";
 
 interface IProps {
   dialogOpen: boolean;
@@ -293,16 +294,11 @@ export const DevolucionVentaDialog: FC<IProps> = ({
                       direction={isMobile ? "column" : "row"}
                       spacing={1.5}
                     >
-                      <TextField
+                      <SelectableTextField
                         label="Cantidad"
-                        type="number"
                         value={cantidadDevolver}
                         onChange={(e) => setCantidadDevolver(e.target.value)}
-                        inputProps={{
-                          min: 0,
-                          max: returnTarget.producto.cantidadDisponible,
-                          step: "0.01",
-                        }}
+                        inputProps={{ inputMode: "decimal" }}
                         size="small"
                         fullWidth
                       />

--- a/src/components/GestionInventario/movimientos/DevolucionVentaDialog.tsx
+++ b/src/components/GestionInventario/movimientos/DevolucionVentaDialog.tsx
@@ -187,7 +187,7 @@ export const DevolucionVentaDialog: FC<IProps> = ({
             onChange={setFechaFin}
             slotProps={{ textField: { size: "small", fullWidth: true } }}
           />
-          <TextField
+          <SelectableTextField
             label="Producto"
             placeholder="Nombre del producto..."
             value={search}

--- a/src/components/GestionInventario/movimientos/MovimientosView.tsx
+++ b/src/components/GestionInventario/movimientos/MovimientosView.tsx
@@ -15,7 +15,6 @@ import {
   LinearProgress,
   Stack,
   Alert,
-  TextField,
   InputAdornment,
   Grid,
   Card,
@@ -64,6 +63,7 @@ import { isMovimientoBaja } from "@/utils/tipoMovimiento";
 import { ITipoMovimiento, MovimientoTipoEnum } from "@/schemas/movimiento";
 import { PageContainer } from "@/components/PageContainer";
 import { ContentCard } from "@/components/ContentCard";
+import SelectableTextField from "@/components/SelectableTextField";
 import { formatNumber, formatDateTime } from "@/utils/formatters";
 import ImportarExcelDialog from "./importExcelDialog";
 import {
@@ -671,7 +671,7 @@ export default function MovimientosView() {
         }
         headerActions={
           <Stack direction="row" spacing={1} alignItems="center">
-            <TextField
+            <SelectableTextField
               size="small"
               placeholder={isMobile ? "Buscar..." : "Buscar movimiento..."}
               value={searchInputValue}

--- a/src/components/MoneyField.tsx
+++ b/src/components/MoneyField.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import InputAdornment from "@mui/material/InputAdornment";
+import { TextFieldProps } from "@mui/material/TextField";
+import SelectableTextField from "./SelectableTextField";
+
+type MoneyFieldProps = TextFieldProps & {
+  currencySymbol?: React.ReactNode;
+};
+
+/**
+ * SelectableTextField preconfigured for money amounts: decimal keyboard on
+ * mobile via inputMode (not type="number", which browsers may not select()
+ * on) and a currency adornment, overridable per field (e.g. a symbol that
+ * depends on the selected currency).
+ */
+const MoneyField = React.forwardRef<HTMLInputElement, MoneyFieldProps>(
+  ({ currencySymbol = "$", InputProps, inputProps, ...other }, ref) => (
+    <SelectableTextField
+      {...other}
+      ref={ref}
+      inputProps={{ inputMode: "decimal", ...inputProps }}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">{currencySymbol}</InputAdornment>
+        ),
+        ...InputProps,
+      }}
+    />
+  ),
+);
+
+MoneyField.displayName = "MoneyField";
+
+export default MoneyField;

--- a/src/components/MultiCurrencyPayment/MultiCurrencyPayment.tsx
+++ b/src/components/MultiCurrencyPayment/MultiCurrencyPayment.tsx
@@ -1,16 +1,28 @@
 "use client";
 
 import {
-  Box, Button, Chip, Divider, FormControl, IconButton, InputAdornment,
-  InputLabel, MenuItem, Select, Stack, TextField, Tooltip, Typography,
-  useMediaQuery, useTheme,
-} from '@mui/material';
-import { Add, AttachMoney, CreditCard, Delete } from '@mui/icons-material';
-import { useMemo } from 'react';
-import { calcularVuelto, convertFromBase, convertToBase } from '@/lib/currency';
-import type { INegocioMoneda } from '@/schemas/moneda';
-import type { ITasaSnapshot } from '@/schemas/tasaCambio';
-import type { IPagoLinea, IVueltoLinea } from '@/schemas/pago';
+  Box,
+  Button,
+  Chip,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import { Add, AttachMoney, CreditCard, Delete } from "@mui/icons-material";
+import { useMemo } from "react";
+import { calcularVuelto, convertFromBase, convertToBase } from "@/lib/currency";
+import type { INegocioMoneda } from "@/schemas/moneda";
+import type { ITasaSnapshot } from "@/schemas/tasaCambio";
+import type { IPagoLinea, IVueltoLinea } from "@/schemas/pago";
+import MoneyField from "@/components/MoneyField";
 
 export interface MultiCurrencyPaymentProps {
   totalBase: number;
@@ -36,15 +48,27 @@ export function MultiCurrencyPayment({
   transferDestinations,
 }: MultiCurrencyPaymentProps) {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const totalPagadoBase = useMemo(
-    () => pagos.reduce((s, p) => s + convertToBase(p.monto, p.moneda, tasas, monedaBase), 0),
+    () =>
+      pagos.reduce(
+        (s, p) => s + convertToBase(p.monto, p.moneda, tasas, monedaBase),
+        0,
+      ),
     [pagos, tasas, monedaBase],
   );
 
   const vuelto: IVueltoLinea[] = useMemo(
-    () => calcularVuelto(totalBase, pagos, monedaCobro, monedaBase, tasas, denominaciones),
+    () =>
+      calcularVuelto(
+        totalBase,
+        pagos,
+        monedaCobro,
+        monedaBase,
+        tasas,
+        denominaciones,
+      ),
     [totalBase, pagos, monedaCobro, monedaBase, tasas, denominaciones],
   );
 
@@ -56,7 +80,16 @@ export function MultiCurrencyPayment({
   const falta = totalPagadoBase < totalBase;
 
   const todasMonedas = useMemo(() => {
-    const lista: INegocioMoneda[] = [{ monedaCode: monedaBase, admiteEfectivo: true, admiteTransferencia: true, activo: true, negocioId: '', id: '' }];
+    const lista: INegocioMoneda[] = [
+      {
+        monedaCode: monedaBase,
+        admiteEfectivo: true,
+        admiteTransferencia: true,
+        activo: true,
+        negocioId: "",
+        id: "",
+      },
+    ];
     for (const m of monedasDisponibles) {
       if (m.monedaCode !== monedaBase && m.activo) lista.push(m);
     }
@@ -66,18 +99,34 @@ export function MultiCurrencyPayment({
   const suggestMonto = (moneda: string, excludeIdx?: number): number => {
     const otherPaid = pagos
       .filter((_, i) => i !== excludeIdx)
-      .reduce((s, p) => s + convertToBase(p.monto, p.moneda, tasas, monedaBase), 0);
+      .reduce(
+        (s, p) => s + convertToBase(p.monto, p.moneda, tasas, monedaBase),
+        0,
+      );
     const rem = Math.max(0, totalBase - otherPaid);
     if (rem <= 0) return 0;
-    return parseFloat(convertFromBase(rem, moneda, tasas, monedaBase).toFixed(2));
+    return parseFloat(
+      convertFromBase(rem, moneda, tasas, monedaBase).toFixed(2),
+    );
   };
 
   const addPago = () => {
-    const primeraMoneda = todasMonedas.find((m) => m.admiteEfectivo) ?? todasMonedas[0];
+    const primeraMoneda =
+      todasMonedas.find((m) => m.admiteEfectivo) ?? todasMonedas[0];
     const monto = suggestMonto(primeraMoneda.monedaCode);
     onPagosChange([
       ...pagos,
-      { tipo: 'cash', moneda: primeraMoneda.monedaCode, monto, equivalenteBase: convertToBase(monto, primeraMoneda.monedaCode, tasas, monedaBase) },
+      {
+        tipo: "cash",
+        moneda: primeraMoneda.monedaCode,
+        monto,
+        equivalenteBase: convertToBase(
+          monto,
+          primeraMoneda.monedaCode,
+          tasas,
+          monedaBase,
+        ),
+      },
     ]);
   };
 
@@ -86,18 +135,25 @@ export function MultiCurrencyPayment({
       if (i !== idx) return p;
       const merged = { ...p, ...partial };
       // When only the currency changes, suggest the remaining amount in the new currency
-      if ('moneda' in partial && !('monto' in partial)) {
+      if ("moneda" in partial && !("monto" in partial)) {
         merged.monto = suggestMonto(merged.moneda, idx);
       }
-      merged.equivalenteBase = convertToBase(merged.monto, merged.moneda, tasas, monedaBase);
+      merged.equivalenteBase = convertToBase(
+        merged.monto,
+        merged.moneda,
+        tasas,
+        monedaBase,
+      );
       return merged;
     });
     onPagosChange(updated);
   };
 
-  const removePago = (idx: number) => onPagosChange(pagos.filter((_, i) => i !== idx));
+  const removePago = (idx: number) =>
+    onPagosChange(pagos.filter((_, i) => i !== idx));
 
-  const monedaInfo = (code: string) => todasMonedas.find((m) => m.monedaCode === code);
+  const monedaInfo = (code: string) =>
+    todasMonedas.find((m) => m.monedaCode === code);
 
   return (
     <Stack gap={1.5}>
@@ -106,7 +162,12 @@ export function MultiCurrencyPayment({
         Total:&nbsp;{totalEnMonedaCobro.toFixed(2)} {monedaCobro}
       </Typography>
       {monedaCobro !== monedaBase && (
-        <Typography variant="caption" color="text.secondary" display="block" mt={-0.5}>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          display="block"
+          mt={-0.5}
+        >
           = {totalBase.toFixed(2)} {monedaBase}
         </Typography>
       )}
@@ -114,40 +175,81 @@ export function MultiCurrencyPayment({
       <Divider />
 
       {/* Líneas de pago */}
-      <Typography variant="subtitle2" color="text.secondary">Pagos recibidos</Typography>
+      <Typography variant="subtitle2" color="text.secondary">
+        Pagos recibidos
+      </Typography>
 
       {pagos.map((p, idx) => {
         const info = monedaInfo(p.moneda);
-        const tipoOpts: { value: IPagoLinea['tipo']; label: string; icon: React.ReactNode }[] = [];
-        if (info?.admiteEfectivo) tipoOpts.push({ value: 'cash', label: 'Efectivo', icon: <AttachMoney fontSize="small" /> });
-        if (info?.admiteTransferencia) tipoOpts.push({ value: 'transfer', label: 'Transfer', icon: <CreditCard fontSize="small" /> });
+        const tipoOpts: {
+          value: IPagoLinea["tipo"];
+          label: string;
+          icon: React.ReactNode;
+        }[] = [];
+        if (info?.admiteEfectivo)
+          tipoOpts.push({
+            value: "cash",
+            label: "Efectivo",
+            icon: <AttachMoney fontSize="small" />,
+          });
+        if (info?.admiteTransferencia)
+          tipoOpts.push({
+            value: "transfer",
+            label: "Transfer",
+            icon: <CreditCard fontSize="small" />,
+          });
 
-        const eqBase = p.monto > 0 && p.moneda !== monedaBase
-          ? convertToBase(p.monto, p.moneda, tasas, monedaBase)
-          : null;
+        const eqBase =
+          p.monto > 0 && p.moneda !== monedaBase
+            ? convertToBase(p.monto, p.moneda, tasas, monedaBase)
+            : null;
 
         return isMobile ? (
           /* ── Mobile: stacked layout ── */
           <Box
             key={idx}
-            sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 1.5 }}
+            sx={{
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 1,
+              p: 1.5,
+            }}
           >
             {/* Row 1: moneda + tipo */}
             <Stack direction="row" gap={1} mb={1.5}>
               <FormControl size="small" sx={{ flex: 1 }}>
                 <InputLabel>Moneda</InputLabel>
-                <Select value={p.moneda} label="Moneda" onChange={(e) => updatePago(idx, { moneda: e.target.value, tipo: 'cash' })}>
+                <Select
+                  value={p.moneda}
+                  label="Moneda"
+                  onChange={(e) =>
+                    updatePago(idx, { moneda: e.target.value, tipo: "cash" })
+                  }
+                >
                   {todasMonedas.map((m) => (
-                    <MenuItem key={m.monedaCode} value={m.monedaCode}>{m.monedaCode}</MenuItem>
+                    <MenuItem key={m.monedaCode} value={m.monedaCode}>
+                      {m.monedaCode}
+                    </MenuItem>
                   ))}
                 </Select>
               </FormControl>
               <FormControl size="small" sx={{ flex: 1 }}>
                 <InputLabel>Tipo</InputLabel>
-                <Select value={p.tipo} label="Tipo" onChange={(e) => updatePago(idx, { tipo: e.target.value as IPagoLinea['tipo'] })}>
+                <Select
+                  value={p.tipo}
+                  label="Tipo"
+                  onChange={(e) =>
+                    updatePago(idx, {
+                      tipo: e.target.value as IPagoLinea["tipo"],
+                    })
+                  }
+                >
                   {tipoOpts.map((o) => (
                     <MenuItem key={o.value} value={o.value}>
-                      <Stack direction="row" alignItems="center" gap={0.5}>{o.icon}{o.label}</Stack>
+                      <Stack direction="row" alignItems="center" gap={0.5}>
+                        {o.icon}
+                        {o.label}
+                      </Stack>
                     </MenuItem>
                   ))}
                 </Select>
@@ -156,34 +258,41 @@ export function MultiCurrencyPayment({
 
             {/* Row 2: monto + equivalente */}
             <Stack direction="row" gap={1} alignItems="center" mb={1.5}>
-              <TextField
+              <MoneyField
                 size="small"
                 label={`Monto (${p.moneda})`}
-                type="number"
-                value={p.monto || ''}
-                onChange={(e) => updatePago(idx, { monto: parseFloat(e.target.value) || 0 })}
-                inputProps={{ min: 0, step: 0.01, inputMode: 'decimal' }}
-                InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                value={p.monto || ""}
+                onChange={(e) =>
+                  updatePago(idx, { monto: parseFloat(e.target.value) || 0 })
+                }
                 sx={{ flex: 1 }}
               />
               {eqBase !== null && (
-                <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ whiteSpace: "nowrap" }}
+                >
                   ≈ {eqBase.toFixed(2)} {monedaBase}
                 </Typography>
               )}
             </Stack>
 
             {/* Row 3: destination */}
-            {p.tipo === 'transfer' && transferDestinations.length > 0 && (
+            {p.tipo === "transfer" && transferDestinations.length > 0 && (
               <FormControl size="small" fullWidth sx={{ mb: 1.5 }}>
                 <InputLabel>Destino</InputLabel>
                 <Select
-                  value={p.transferDestinationId ?? ''}
+                  value={p.transferDestinationId ?? ""}
                   label="Destino"
-                  onChange={(e) => updatePago(idx, { transferDestinationId: e.target.value })}
+                  onChange={(e) =>
+                    updatePago(idx, { transferDestinationId: e.target.value })
+                  }
                 >
                   {transferDestinations.map((d) => (
-                    <MenuItem key={d.id} value={d.id}>{d.nombre}</MenuItem>
+                    <MenuItem key={d.id} value={d.id}>
+                      {d.nombre}
+                    </MenuItem>
                   ))}
                 </Select>
               </FormControl>
@@ -206,44 +315,67 @@ export function MultiCurrencyPayment({
           <Stack key={idx} direction="row" gap={1} alignItems="flex-start">
             <FormControl size="small" sx={{ minWidth: 90 }}>
               <InputLabel>Moneda</InputLabel>
-              <Select value={p.moneda} label="Moneda" onChange={(e) => updatePago(idx, { moneda: e.target.value, tipo: 'cash' })}>
+              <Select
+                value={p.moneda}
+                label="Moneda"
+                onChange={(e) =>
+                  updatePago(idx, { moneda: e.target.value, tipo: "cash" })
+                }
+              >
                 {todasMonedas.map((m) => (
-                  <MenuItem key={m.monedaCode} value={m.monedaCode}>{m.monedaCode}</MenuItem>
+                  <MenuItem key={m.monedaCode} value={m.monedaCode}>
+                    {m.monedaCode}
+                  </MenuItem>
                 ))}
               </Select>
             </FormControl>
 
             <FormControl size="small" sx={{ minWidth: 110 }}>
               <InputLabel>Tipo</InputLabel>
-              <Select value={p.tipo} label="Tipo" onChange={(e) => updatePago(idx, { tipo: e.target.value as IPagoLinea['tipo'] })}>
+              <Select
+                value={p.tipo}
+                label="Tipo"
+                onChange={(e) =>
+                  updatePago(idx, {
+                    tipo: e.target.value as IPagoLinea["tipo"],
+                  })
+                }
+              >
                 {tipoOpts.map((o) => (
                   <MenuItem key={o.value} value={o.value}>
-                    <Stack direction="row" alignItems="center" gap={0.5}>{o.icon}{o.label}</Stack>
+                    <Stack direction="row" alignItems="center" gap={0.5}>
+                      {o.icon}
+                      {o.label}
+                    </Stack>
                   </MenuItem>
                 ))}
               </Select>
             </FormControl>
 
-            <TextField
+            <MoneyField
               size="small"
               label={`Monto (${p.moneda})`}
-              type="number"
-              value={p.monto || ''}
-              onChange={(e) => updatePago(idx, { monto: parseFloat(e.target.value) || 0 })}
-              inputProps={{ min: 0, step: 0.01 }}
+              value={p.monto || ""}
+              onChange={(e) =>
+                updatePago(idx, { monto: parseFloat(e.target.value) || 0 })
+              }
               sx={{ flex: 1 }}
             />
 
-            {p.tipo === 'transfer' && transferDestinations.length > 0 && (
+            {p.tipo === "transfer" && transferDestinations.length > 0 && (
               <FormControl size="small" sx={{ minWidth: 130 }}>
                 <InputLabel>Destino</InputLabel>
                 <Select
-                  value={p.transferDestinationId ?? ''}
+                  value={p.transferDestinationId ?? ""}
                   label="Destino"
-                  onChange={(e) => updatePago(idx, { transferDestinationId: e.target.value })}
+                  onChange={(e) =>
+                    updatePago(idx, { transferDestinationId: e.target.value })
+                  }
                 >
                   {transferDestinations.map((d) => (
-                    <MenuItem key={d.id} value={d.id}>{d.nombre}</MenuItem>
+                    <MenuItem key={d.id} value={d.id}>
+                      {d.nombre}
+                    </MenuItem>
                   ))}
                 </Select>
               </FormControl>
@@ -251,18 +383,32 @@ export function MultiCurrencyPayment({
 
             {eqBase !== null && (
               <Tooltip title={`= ${eqBase.toFixed(2)} ${monedaBase}`}>
-                <Chip label={`≈${eqBase.toFixed(0)} ${monedaBase}`} size="small" sx={{ mt: 1 }} />
+                <Chip
+                  label={`≈${eqBase.toFixed(0)} ${monedaBase}`}
+                  size="small"
+                  sx={{ mt: 1 }}
+                />
               </Tooltip>
             )}
 
-            <IconButton size="small" color="error" onClick={() => removePago(idx)} sx={{ mt: 0.5 }}>
+            <IconButton
+              size="small"
+              color="error"
+              onClick={() => removePago(idx)}
+              sx={{ mt: 0.5 }}
+            >
               <Delete fontSize="small" />
             </IconButton>
           </Stack>
         );
       })}
 
-      <Button startIcon={<Add />} onClick={addPago} size="small" sx={{ alignSelf: 'flex-start' }}>
+      <Button
+        startIcon={<Add />}
+        onClick={addPago}
+        size="small"
+        sx={{ alignSelf: "flex-start" }}
+      >
         Agregar pago
       </Button>
 
@@ -272,25 +418,41 @@ export function MultiCurrencyPayment({
       <Stack spacing={0.5}>
         <Stack direction="row" justifyContent="space-between">
           <Typography variant="h6">Total recibido:</Typography>
-          <Typography variant="h6" fontWeight={600}>{totalPagadoBase.toFixed(2)} {monedaBase}</Typography>
+          <Typography variant="h6" fontWeight={600}>
+            {totalPagadoBase.toFixed(2)} {monedaBase}
+          </Typography>
         </Stack>
         {falta ? (
           <Stack direction="row" justifyContent="space-between">
-            <Typography variant="h6" color="error">Falta:</Typography>
-            <Typography variant="h6" color="error">{(totalBase - totalPagadoBase).toFixed(2)} {monedaBase}</Typography>
+            <Typography variant="h6" color="error">
+              Falta:
+            </Typography>
+            <Typography variant="h6" color="error">
+              {(totalBase - totalPagadoBase).toFixed(2)} {monedaBase}
+            </Typography>
           </Stack>
         ) : vuelto.length === 0 ? (
           <Stack direction="row" justifyContent="space-between">
-            <Typography variant="h6" color="success.main">Cambio:</Typography>
-            <Typography variant="h6" color="success.main">0.00</Typography>
+            <Typography variant="h6" color="success.main">
+              Cambio:
+            </Typography>
+            <Typography variant="h6" color="success.main">
+              0.00
+            </Typography>
           </Stack>
         ) : (
           vuelto.map((v) => (
-            <Stack key={v.moneda} direction="row" justifyContent="space-between">
+            <Stack
+              key={v.moneda}
+              direction="row"
+              justifyContent="space-between"
+            >
               <Typography variant="h6" color="success.main">
-                Cambio{vuelto.length > 1 ? ` (${v.moneda})` : ''}:
+                Cambio{vuelto.length > 1 ? ` (${v.moneda})` : ""}:
               </Typography>
-              <Typography variant="h6" color="success.main">{v.monto.toFixed(2)} {v.moneda}</Typography>
+              <Typography variant="h6" color="success.main">
+                {v.monto.toFixed(2)} {v.moneda}
+              </Typography>
             </Stack>
           ))
         )}

--- a/src/components/PercentageField.tsx
+++ b/src/components/PercentageField.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import InputAdornment from "@mui/material/InputAdornment";
+import { TextFieldProps } from "@mui/material/TextField";
+import SelectableTextField from "./SelectableTextField";
+
+/**
+ * SelectableTextField preconfigured for percentages: decimal keyboard on
+ * mobile via inputMode (not type="number", which browsers may not select()
+ * on) and a trailing "%" adornment.
+ */
+const PercentageField = React.forwardRef<HTMLInputElement, TextFieldProps>(
+  ({ InputProps, inputProps, ...other }, ref) => (
+    <SelectableTextField
+      {...other}
+      ref={ref}
+      inputProps={{ inputMode: "decimal", ...inputProps }}
+      InputProps={{
+        endAdornment: <InputAdornment position="end">%</InputAdornment>,
+        ...InputProps,
+      }}
+    />
+  ),
+);
+
+PercentageField.displayName = "PercentageField";
+
+export default PercentageField;

--- a/src/components/ProductcSelectionModal/tables/TableProductosDisponibles.tsx
+++ b/src/components/ProductcSelectionModal/tables/TableProductosDisponibles.tsx
@@ -18,7 +18,6 @@ import {
   Typography,
   Chip,
   Grid2 as Grid,
-  TextField,
   InputAdornment,
   FormControl,
   InputLabel,
@@ -36,6 +35,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import ProductCard from "@/components/ProductcSelectionModal/ProductCard";
 import ProductProcessorData from "@/components/ProductProcessorData/ProductProcessorData";
 import { IProcessedData } from "@/schemas/processedData";
+import SelectableTextField from "@/components/SelectableTextField";
 
 interface IProps {
   operacion: OperacionTipo;
@@ -226,7 +226,7 @@ const TableProductosDisponibles: React.FC<IProps> = ({
         <Grid container spacing={1} alignItems="center">
           <Grid size={{ xs: 12, sm: 4 }}>
             <Box display="flex" alignItems="center" gap={1}>
-              <TextField
+              <SelectableTextField
                 fullWidth
                 type="search"
                 size="small"

--- a/src/components/SelectableTextField.tsx
+++ b/src/components/SelectableTextField.tsx
@@ -14,7 +14,11 @@ const SelectableTextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     ) => {
       // Multiline fields are meant for partial edits, not full replacement.
       if (!multiline) {
-        event.target.select();
+        // Deferred: selecting synchronously on focus can be undone by the
+        // browser's own cursor placement on the mouseup that follows a click
+        // into an unfocused field. Running after that settles wins reliably.
+        const target = event.target;
+        setTimeout(() => target.select(), 0);
       }
       onFocus?.(event);
     };

--- a/src/components/SelectableTextField.tsx
+++ b/src/components/SelectableTextField.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import TextField, { TextFieldProps } from "@mui/material/TextField";
+
+/**
+ * Drop-in replacement for MUI's TextField that selects the whole value on focus,
+ * so the user can overwrite it immediately (mobile taps, desktop tabbing, etc).
+ * Opt in per field — use it only where "replace the whole value" is the expected
+ * interaction (quantities, prices, single-value fields), not for free text.
+ */
+const SelectableTextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
+  ({ onFocus, multiline, ...other }, ref) => {
+    const handleFocus = (
+      event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => {
+      // Multiline fields are meant for partial edits, not full replacement.
+      if (!multiline) {
+        event.target.select();
+      }
+      onFocus?.(event);
+    };
+
+    return (
+      <TextField
+        {...other}
+        multiline={multiline}
+        inputRef={ref}
+        onFocus={handleFocus}
+      />
+    );
+  },
+);
+
+SelectableTextField.displayName = "SelectableTextField";
+
+export default SelectableTextField;

--- a/src/constants/permisos/permisos.json
+++ b/src/constants/permisos/permisos.json
@@ -95,6 +95,9 @@
   "operaciones.cierre.gananciascostos": {
     "descripcion": "Permite ver las ganancias y costos en el resumen de cierre de caja"
   },
+  "operaciones.cierre.fondoinicial": {
+    "descripcion": "Permite registrar y modificar el fondo inicial de caja por moneda mientras el período sigue abierto"
+  },
   "operaciones.movimientos.acceder": {
     "descripcion": "Permite acceder a la interfaz de movimientos de stock"
   },

--- a/src/constants/permisos/permisos.templates.ts
+++ b/src/constants/permisos/permisos.templates.ts
@@ -55,6 +55,7 @@ export const permisosTemplates = {
     "operaciones.cierre.acceder",
     "operaciones.cierre.cerrar",
     "operaciones.cierre.gananciascostos",
+    "operaciones.cierre.fondoinicial",
     "operaciones.movimientos.acceder",
     "operaciones.movimientos.crear.compra",
     "operaciones.movimientos.crear.ajuste_entradas",

--- a/src/lib/movimiento/caja.ts
+++ b/src/lib/movimiento/caja.ts
@@ -200,42 +200,107 @@ export function buildResumenMonedas(
 }
 
 /**
- * Efectivo real disponible en caja, por moneda, para el período actualmente
- * abierto de una tienda: pagos en efectivo de las ventas del período, menos
- * vueltos, gastos y compras/devoluciones ya registrados. Usado para no
- * permitir que una COMPRA en efectivo deje la caja en negativo (ver
- * FormaPagoCompra.MIXTO).
+ * Fondo inicial vigente de un período, por moneda. `InitialCashFund` es
+ * append-only: cada edición inserta una fila con el snapshot completo de
+ * todas las monedas, y la más reciente por createdAt es la vigente. Sin
+ * ninguna fila, el fondo es 0 en todas las monedas (comportamiento por
+ * defecto al abrir un período, sin insertar nada).
  */
-export async function calcularEfectivoDisponiblePorMoneda(
-  tiendaId: string,
-  monedaBase: string,
+export async function getCurrentInitialCashFundAmounts(
+  cierrePeriodoId: string,
   client: PrismaLike = prisma,
 ): Promise<Record<string, number>> {
+  const latest = await client.initialCashFund.findFirst({
+    where: { cierrePeriodoId },
+    orderBy: { createdAt: "desc" },
+  });
+  return (latest?.amounts as Record<string, number>) ?? {};
+}
+
+/**
+ * Suma el fondo inicial de caja (por moneda) como término inicial positivo.
+ * No es una deducción — es el punto de partida del efectivo, igual que las
+ * ventas en efectivo del período. Debe aplicarse junto a (no después de)
+ * applyGastosToResumenMap/applyComprasYDevolucionesToResumenMap.
+ */
+export function applyInitialFundToResumenMap(
+  map: Record<string, ResumenEntry>,
+  amounts: Record<string, number>,
+  monedaBase: string,
+  tasas: ITasaSnapshot,
+): void {
+  for (const [monedaCode, amount] of Object.entries(amounts)) {
+    if (!amount) continue;
+    if (!map[monedaCode]) {
+      map[monedaCode] = {
+        totalEfectivo: 0,
+        totalTransfer: 0,
+        equivalenteBase: 0,
+      };
+    }
+    map[monedaCode].totalEfectivo += amount;
+    map[monedaCode].equivalenteBase += convertToBase(
+      amount,
+      monedaCode,
+      tasas,
+      monedaBase,
+    );
+  }
+}
+
+export type ResumenCajaMoneda = {
+  monedaCode: string;
+  fondoInicial: number;
+  // Ventas en efectivo, netas de vuelto — antes de mezclar el fondo inicial
+  // y las deducciones (gastos, compras/devoluciones en efectivo).
+  ventasEfectivo: number;
+  // fondoInicial + ventasEfectivo - gastos - compras/devoluciones en efectivo.
+  totalEsperado: number;
+  equivalenteBase: number;
+};
+
+/**
+ * Única fuente de verdad del desglose de caja del período actualmente abierto
+ * de una tienda, por moneda. `null` si no hay período abierto. Usada tanto
+ * por `calcularEfectivoDisponiblePorMoneda` (solo el total) como por
+ * `calcularResumenCajaPorMoneda` (desglose completo para el widget de caja).
+ */
+async function construirResumenCajaAbierta(
+  tiendaId: string,
+  monedaBase: string,
+  client: PrismaLike,
+): Promise<ResumenCajaMoneda[] | null> {
   const periodoAbierto = await client.cierrePeriodo.findFirst({
     where: { tiendaId, fechaFin: null },
     orderBy: { fechaInicio: "desc" },
   });
-  if (!periodoAbierto) return {};
+  if (!periodoAbierto) return null;
 
-  const [ventas, gastosCierre, movimientosPeriodo, tiendaConNegocio] =
-    await Promise.all([
-      client.venta.findMany({
-        where: { cierrePeriodoId: periodoAbierto.id },
-        select: { pagosDetalle: true, vueltoDetalle: true, tasaSnapshot: true },
-      }),
-      client.gastoCierre.findMany({ where: { cierreId: periodoAbierto.id } }),
-      client.movimientoStock.findMany({
-        where: {
-          tiendaId,
-          tipo: { in: ["COMPRA", "DEVOLUCION_VENTA"] },
-          fecha: { gte: periodoAbierto.fechaInicio },
-        },
-      }),
-      client.tienda.findUnique({
-        where: { id: tiendaId },
-        select: { negocio: { select: { id: true } } },
-      }),
-    ]);
+  const [
+    ventas,
+    gastosCierre,
+    movimientosPeriodo,
+    tiendaConNegocio,
+    initialFundAmounts,
+  ] = await Promise.all([
+    client.venta.findMany({
+      where: { cierrePeriodoId: periodoAbierto.id },
+      select: { pagosDetalle: true, vueltoDetalle: true, tasaSnapshot: true },
+    }),
+    client.gastoCierre.findMany({ where: { cierreId: periodoAbierto.id } }),
+    client.movimientoStock.findMany({
+      where: {
+        tiendaId,
+        tipo: { in: ["COMPRA", "DEVOLUCION_VENTA"] },
+        fecha: { gte: periodoAbierto.fechaInicio },
+      },
+    }),
+    client.tienda.findUnique({
+      where: { id: tiendaId },
+      select: { negocio: { select: { id: true } } },
+    }),
+    getCurrentInitialCashFundAmounts(periodoAbierto.id, client),
+  ]);
 
   const negocioId = tiendaConNegocio?.negocio?.id;
   const tasasCambio = negocioId
@@ -256,6 +321,20 @@ export async function calcularEfectivoDisponiblePorMoneda(
     return acc;
   }, {});
 
+  // Snapshot de ventas en efectivo (netas de vuelto) antes de mezclar el
+  // fondo inicial y las deducciones — es la línea "ventas reales" del
+  // desglose de caja.
+  const ventasEfectivoPorMoneda: Record<string, number> = {};
+  for (const [moneda, vals] of Object.entries(resumenMonedaMap)) {
+    ventasEfectivoPorMoneda[moneda] = vals.totalEfectivo;
+  }
+
+  applyInitialFundToResumenMap(
+    resumenMonedaMap,
+    initialFundAmounts,
+    monedaBase,
+    tasas,
+  );
   applyGastosToResumenMap(resumenMonedaMap, gastosCierre, monedaBase, tasas);
   applyComprasYDevolucionesToResumenMap(
     resumenMonedaMap,
@@ -264,9 +343,49 @@ export async function calcularEfectivoDisponiblePorMoneda(
     tasas,
   );
 
-  const disponible: Record<string, number> = {};
-  for (const [moneda, vals] of Object.entries(resumenMonedaMap)) {
-    disponible[moneda] = vals.totalEfectivo;
-  }
-  return disponible;
+  return Object.entries(resumenMonedaMap).map(([monedaCode, vals]) => ({
+    monedaCode,
+    fondoInicial: initialFundAmounts[monedaCode] ?? 0,
+    ventasEfectivo: ventasEfectivoPorMoneda[monedaCode] ?? 0,
+    totalEsperado: vals.totalEfectivo,
+    equivalenteBase: vals.equivalenteBase,
+  }));
+}
+
+/**
+ * Efectivo real disponible en caja, por moneda, para el período actualmente
+ * abierto de una tienda: pagos en efectivo de las ventas del período, menos
+ * vueltos, gastos y compras/devoluciones ya registrados. Usado para no
+ * permitir que una COMPRA en efectivo deje la caja en negativo (ver
+ * FormaPagoCompra.MIXTO).
+ */
+export async function calcularEfectivoDisponiblePorMoneda(
+  tiendaId: string,
+  monedaBase: string,
+  client: PrismaLike = prisma,
+): Promise<Record<string, number>> {
+  const resumen = await construirResumenCajaAbierta(
+    tiendaId,
+    monedaBase,
+    client,
+  );
+  if (!resumen) return {};
+  return Object.fromEntries(
+    resumen.map((r) => [r.monedaCode, r.totalEsperado]),
+  );
+}
+
+/**
+ * Desglose de caja del período abierto, por moneda, separando cuánto es
+ * fondo inicial y cuánto son ventas reales del total esperado en caja. Usado
+ * por el widget de caja del POS.
+ */
+export async function calcularResumenCajaPorMoneda(
+  tiendaId: string,
+  monedaBase: string,
+  client: PrismaLike = prisma,
+): Promise<ResumenCajaMoneda[]> {
+  return (
+    (await construirResumenCajaAbierta(tiendaId, monedaBase, client)) ?? []
+  );
 }

--- a/src/schemas/cierre.ts
+++ b/src/schemas/cierre.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { tiendaSchema } from "./tienda";
+import { initialCashFundEntrySchema } from "./initialCashFund";
 
 export const cierrePeriodoSchema = z.object({
   id: z.string().uuid(),
@@ -7,6 +8,7 @@ export const cierrePeriodoSchema = z.object({
   fechaFin: z.coerce.date().optional(),
   tiendaId: z.string().uuid(),
   tienda: tiendaSchema,
+  initialCashFund: initialCashFundEntrySchema.optional(),
   totalVentas: z.number(),
   totalGanancia: z.number(),
   totalInversion: z.number(),
@@ -44,6 +46,8 @@ const resumenMonedaCierreSchema = z.object({
   // Valores antes de restar gastos/compras/devoluciones (para mostrar bruto tachado -> final)
   totalEfectivoBruto: z.number().optional(),
   equivalenteBaseBruto: z.number().optional(),
+  // Fondo inicial de caja de esta moneda, ya incluido en totalEfectivo/equivalenteBase
+  initialFund: z.number().optional(),
 });
 
 export type IResumenMonedaCierre = z.infer<typeof resumenMonedaCierreSchema>;

--- a/src/schemas/initialCashFund.ts
+++ b/src/schemas/initialCashFund.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const initialCashFundInputSchema = z.object({
+  amounts: z.record(z.string(), z.coerce.number().min(0)),
+});
+
+export const initialCashFundEntrySchema = z.object({
+  id: z.string().uuid(),
+  cierrePeriodoId: z.string().uuid(),
+  amounts: z.record(z.string(), z.number()),
+  createdById: z.string().uuid(),
+  createdByName: z.string().optional(),
+  createdAt: z.coerce.date(),
+});
+
+export type IInitialCashFundInput = z.infer<typeof initialCashFundInputSchema>;
+export type IInitialCashFundEntry = z.infer<typeof initialCashFundEntrySchema>;

--- a/src/schemas/resumenCaja.ts
+++ b/src/schemas/resumenCaja.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const resumenCajaMonedaSchema = z.object({
+  monedaCode: z.string(),
+  fondoInicial: z.number(),
+  ventasEfectivo: z.number(),
+  totalEsperado: z.number(),
+  equivalenteBase: z.number(),
+});
+
+export const resumenCajaResponseSchema = z.object({
+  monedaBase: z.string(),
+  resumen: z.array(resumenCajaMonedaSchema),
+});
+
+export type IResumenCajaMoneda = z.infer<typeof resumenCajaMonedaSchema>;
+export type IResumenCajaResponse = z.infer<typeof resumenCajaResponseSchema>;

--- a/src/services/cierrePeriodService.ts
+++ b/src/services/cierrePeriodService.ts
@@ -2,32 +2,49 @@ import { ICierreData } from "@/schemas/cierre";
 import { ICierrePeriodo } from "@/schemas/cierre";
 import { IBillCount, ICashBreakdownCierre } from "@/schemas/billBreakdown";
 import type { ITasaSnapshot } from "@/schemas/tasaCambio";
+import type { IInitialCashFundEntry } from "@/schemas/initialCashFund";
 import axios from "@/lib/axiosClient";
 
 const API_URL = (tiendaId) => `/api/cierre/${tiendaId}`; // Ruta base del backend
 
-export const fetchLastPeriod = async (tiendaId): Promise<ICierrePeriodo|undefined> => {
+export const fetchLastPeriod = async (
+  tiendaId,
+): Promise<ICierrePeriodo | undefined> => {
   const response = await axios.get<ICierrePeriodo>(`${API_URL(tiendaId)}/last`);
   return response.data;
 };
 
-export const openPeriod = async (tiendaId): Promise<ICierrePeriodo|undefined> => {
+export const openPeriod = async (
+  tiendaId,
+): Promise<ICierrePeriodo | undefined> => {
   const response = await axios.put<ICierrePeriodo>(`${API_URL(tiendaId)}/open`);
-  return response.data;
-}
-
-export const fetchCierreData = async (tiendaId: string, cierreId: string) => {
-  const response = await axios.get<ICierreData>(`${API_URL(tiendaId)}/${cierreId}`);
   return response.data;
 };
 
-export const closePeriod = async (tiendaId: string, cierreId: string): Promise<ICierrePeriodo|undefined> => {
-  const response = await axios.put<ICierrePeriodo>(`${API_URL(tiendaId)}/${cierreId}/close`);
+export const fetchCierreData = async (tiendaId: string, cierreId: string) => {
+  const response = await axios.get<ICierreData>(
+    `${API_URL(tiendaId)}/${cierreId}`,
+  );
   return response.data;
-}
+};
 
-export const fetchCashBreakdown = async (tiendaId: string, cierreId: string): Promise<ICashBreakdownCierre | null> => {
-  const response = await axios.get<ICashBreakdownCierre | null>(`${API_URL(tiendaId)}/${cierreId}/cash-breakdown`);
+export const closePeriod = async (
+  tiendaId: string,
+  cierreId: string,
+): Promise<ICierrePeriodo | undefined> => {
+  const response = await axios.put<ICierrePeriodo>(
+    `${API_URL(tiendaId)}/${cierreId}/close`,
+  );
+  return response.data;
+};
+
+export const fetchCashBreakdown = async (
+  tiendaId: string,
+  cierreId: string,
+): Promise<ICashBreakdownCierre | null> => {
+  const response = await axios.get<ICashBreakdownCierre | null>(
+    `${API_URL(tiendaId)}/${cierreId}/cash-breakdown`,
+  );
   return response.data;
 };
 
@@ -38,11 +55,14 @@ export const saveCashBreakdown = async (
   items: IBillCount[],
   total: number,
 ): Promise<ICashBreakdownCierre> => {
-  const response = await axios.put<ICashBreakdownCierre>(`${API_URL(tiendaId)}/${cierreId}/cash-breakdown`, {
-    currency,
-    items,
-    total,
-  });
+  const response = await axios.put<ICashBreakdownCierre>(
+    `${API_URL(tiendaId)}/${cierreId}/cash-breakdown`,
+    {
+      currency,
+      items,
+      total,
+    },
+  );
   return response.data;
 };
 
@@ -51,9 +71,10 @@ export const fetchMonedaBreakdown = async (
   cierreId: string,
   monedaCode: string,
 ): Promise<{ items: IBillCount[]; total: number } | null> => {
-  const response = await axios.get<{ items: IBillCount[]; total: number } | null>(
-    `${API_URL(tiendaId)}/${cierreId}/moneda-breakdown/${monedaCode}`,
-  );
+  const response = await axios.get<{
+    items: IBillCount[];
+    total: number;
+  } | null>(`${API_URL(tiendaId)}/${cierreId}/moneda-breakdown/${monedaCode}`);
   return response.data;
 };
 
@@ -61,7 +82,9 @@ export const fetchTasasAtClose = async (
   tiendaId: string,
   cierreId: string,
 ): Promise<ITasaSnapshot> => {
-  const response = await axios.get<ITasaSnapshot>(`${API_URL(tiendaId)}/${cierreId}/tasas-at-close`);
+  const response = await axios.get<ITasaSnapshot>(
+    `${API_URL(tiendaId)}/${cierreId}/tasas-at-close`,
+  );
   return response.data;
 };
 
@@ -72,5 +95,30 @@ export const saveMonedaBreakdown = async (
   items: IBillCount[],
   total: number,
 ): Promise<void> => {
-  await axios.put(`${API_URL(tiendaId)}/${cierreId}/moneda-breakdown/${monedaCode}`, { items, total });
+  await axios.put(
+    `${API_URL(tiendaId)}/${cierreId}/moneda-breakdown/${monedaCode}`,
+    { items, total },
+  );
+};
+
+export const fetchInitialCashFundHistory = async (
+  tiendaId: string,
+  cierreId: string,
+): Promise<IInitialCashFundEntry[]> => {
+  const response = await axios.get<IInitialCashFundEntry[]>(
+    `${API_URL(tiendaId)}/${cierreId}/initial-cash-fund`,
+  );
+  return response.data;
+};
+
+export const saveInitialCashFund = async (
+  tiendaId: string,
+  cierreId: string,
+  amounts: Record<string, number>,
+): Promise<IInitialCashFundEntry> => {
+  const response = await axios.put<IInitialCashFundEntry>(
+    `${API_URL(tiendaId)}/${cierreId}/initial-cash-fund`,
+    { amounts },
+  );
+  return response.data;
 };

--- a/src/services/movimientoService.ts
+++ b/src/services/movimientoService.ts
@@ -12,6 +12,7 @@ import type {
   IProdTiendaQueryParams,
   IProdTiendaResponse,
 } from "@/schemas/producto";
+import type { IResumenCajaResponse } from "@/schemas/resumenCaja";
 
 const API_URL = `/api/movimiento`;
 
@@ -49,6 +50,15 @@ export const getEfectivoDisponibleCaja = async (
 ): Promise<Record<string, number>> => {
   const res = await axiosClient.get(`${API_URL}/${tiendaId}/caja-disponible`);
   return res.data.disponible;
+};
+
+export const getResumenCaja = async (
+  tiendaId: string,
+): Promise<IResumenCajaResponse> => {
+  const res = await axiosClient.get<IResumenCajaResponse>(
+    `${API_URL}/${tiendaId}/caja-resumen`,
+  );
+  return res.data;
 };
 
 export const findMovimientos = async (


### PR DESCRIPTION
### Summary

This pull request introduces functionality for managing initial cash fund allocations across different periods.

### Changes

- **API Enhancements**:  
  - Added routes for creating and retrieving initial cash fund entries under `/initial-cash-fund`.
  - Integrated initial cash fund data into period cash summaries and calculations, supporting snapshots for multiple currencies.
  - Added a database migration to support the `InitialCashFund` table for record storage.

- **User Interface Updates**:  
  - Added a dedicated dialogue for managing initial cash fund inputs, ensuring changes are reflected in related period breakdowns.
  - Improved input components by introducing:
    - `SelectableTextField` for auto-selection of values on focus.
    - `MoneyField` for better formatting and usability in financial inputs.
  
- **Code Refactoring**:  
  - Replaced standard `TextField` components with `SelectableTextField` and `MoneyField` where suitable.
  - Optimized and cleaned up props in affected components.

### Notes

- These updates ensure accurate and user-friendly management of initial cash funds while streamlining related workflows. 
- Future iterations may include additional validations or support for extended functionalities.