### PR TITLE
Improve rounding precision for coarse base currencies

### DIFF
--- a/src/__tests__/changeMath.test.ts
+++ b/src/__tests__/changeMath.test.ts
@@ -310,6 +310,25 @@ describe("changeOptions", () => {
     );
     expect(other[0].id).not.toBe(first[0].id);
   });
+
+  // Regression: USD-based business, 1 USD = 670 CUP, 500-CUP sale paid with
+  // 1 USD. The true change is 170 CUP; when the amount due was quantized to
+  // base cents upstream (0.75 USD) this produced 168 CUP instead.
+  it("gives exact CUP change for a coarse-base overpayment", () => {
+    const usdRates: ITasaSnapshot = { USD: 670 };
+    const due = 500 / 670;
+    const changeAmountBase = 1 - due; // paid 1 USD
+    const options = changeOptions(
+      [cash("USD", 1)],
+      changeAmountBase,
+      usdRates,
+      "USD",
+      CURRENCIES,
+      STANDARD,
+    );
+    // 0.2537 USD is below the smallest USD bill, so all change lands in CUP.
+    expect(splits(options)).toEqual([{ CUP: 170 }]);
+  });
 });
 
 describe("customChangeSplit", () => {

--- a/src/__tests__/currency.test.ts
+++ b/src/__tests__/currency.test.ts
@@ -4,6 +4,8 @@ import {
   convertToBase,
   convertFromBase,
   buildTasaSnapshot,
+  roundBaseToAnchorCents,
+  anchorCents,
 } from "@/lib/currency";
 import type { IPagoLinea, IVueltoLinea } from "@/schemas/pago";
 import type { ITasaSnapshot } from "@/schemas/tasaCambio";
@@ -1060,5 +1062,28 @@ describe("calcularVuelto - floating point noise regression", () => {
 
     // denomMin for CUP is 0.01, genuine remainder must still round up
     expect(result).toEqual([{ moneda: "CUP", monto: 20.01 }]);
+  });
+});
+
+describe("roundBaseToAnchorCents / anchorCents", () => {
+  const rates: ITasaSnapshot = { USD: 670 };
+
+  it("is a plain round-to-cents when the base is the anchor", () => {
+    expect(roundBaseToAnchorCents(1.006, {}, "CUP")).toBeCloseTo(1.01, 10);
+    expect(anchorCents(12.34, {}, "CUP")).toBe(1234);
+  });
+
+  it("keeps CUP-cent precision for a coarse USD base", () => {
+    // 500 CUP in a USD base: rounding to base cents would give 0.75 USD
+    // (502.5 CUP); anchor-cent rounding preserves the exact 500.
+    const due = roundBaseToAnchorCents(500 / 670, rates, "USD");
+    expect(convertFromBase(due, "CUP", rates, "USD")).toBeCloseTo(500, 6);
+  });
+
+  it("compares in anchor cents, catching sub-base-cent differences", () => {
+    // 3 CUP apart — under half a USD cent, invisible to base-cent compares.
+    expect(anchorCents(497 / 670, rates, "USD")).toBeLessThan(
+      anchorCents(500 / 670, rates, "USD"),
+    );
   });
 });

--- a/src/__tests__/paymentMath.test.ts
+++ b/src/__tests__/paymentMath.test.ts
@@ -8,6 +8,7 @@ import {
   toPagoLineas,
   type PaymentLine,
 } from "@/app/pos/utils/paymentMath";
+import { convertFromBase } from "@/lib/currency";
 import type { ITasaSnapshot } from "@/schemas/tasaCambio";
 
 // 1 USD = 350 CUP; base is CUP.
@@ -81,25 +82,67 @@ describe("pendingInCurrency", () => {
 
 describe("isMissing", () => {
   it("is true when the paid amount falls short", () => {
-    expect(isMissing(1000, 1250)).toBe(true);
+    expect(isMissing(1000, 1250, RATES, BASE)).toBe(true);
   });
 
   it("is false on an exact payment", () => {
-    expect(isMissing(1250, 1250)).toBe(false);
+    expect(isMissing(1250, 1250, RATES, BASE)).toBe(false);
   });
 
   it("ignores sub-cent float noise", () => {
-    expect(isMissing(0.1 + 0.2, 0.3)).toBe(false);
+    expect(isMissing(0.1 + 0.2, 0.3, RATES, BASE)).toBe(false);
   });
 });
 
 describe("changeBase", () => {
   it("returns the overshoot", () => {
-    expect(changeBase(1500, 1250)).toBe(250);
+    expect(changeBase(1500, 1250, RATES, BASE)).toBe(250);
   });
 
   it("returns zero when the payment falls short", () => {
-    expect(changeBase(1000, 1250)).toBe(0);
+    expect(changeBase(1000, 1250, RATES, BASE)).toBe(0);
+  });
+});
+
+// Regression: business based in a coarse currency (USD) selling CUP-priced
+// products. 1 USD = 670 CUP, two 250-CUP items → 500 CUP = 0.746268… USD.
+// Quantizing that total to base cents (0.75 USD) used to corrupt everything
+// derived from it: it asked 503 CUP when paying in CUP and returned 168 CUP
+// of change on a 1-USD payment instead of 170.
+describe("coarse base currency (USD business, CUP prices)", () => {
+  const USD_RATES: ITasaSnapshot = { USD: 670 };
+  const USD_BASE = "USD";
+  /** 500 CUP expressed in the USD base, exactly as useCartTotal computes it. */
+  const DUE = 500 / 670;
+
+  it("asks exactly 500 CUP when paying in CUP", () => {
+    expect(pendingInCurrency([], DUE, "CUP", USD_RATES, USD_BASE)).toBe(500);
+  });
+
+  it("suggests 0.75 USD (cent-ceiled) when paying in USD", () => {
+    expect(pendingInCurrency([], DUE, "USD", USD_RATES, USD_BASE)).toBe(0.75);
+  });
+
+  it("returns 170 CUP of change on a 1 USD payment", () => {
+    const paid = paidBase([cash("USD", 1)], USD_RATES, USD_BASE);
+    const change = changeBase(paid, DUE, USD_RATES, USD_BASE);
+    expect(convertFromBase(change, "CUP", USD_RATES, USD_BASE)).toBeCloseTo(
+      170,
+      6,
+    );
+  });
+
+  it("considers an exact 500 CUP payment complete", () => {
+    const paid = paidBase([cash("CUP", 500)], USD_RATES, USD_BASE);
+    expect(isMissing(paid, DUE, USD_RATES, USD_BASE)).toBe(false);
+    expect(changeBase(paid, DUE, USD_RATES, USD_BASE)).toBe(0);
+  });
+
+  it("flags a payment short by real CUP even below a base cent", () => {
+    // 497 CUP short of 500: 3 CUP ≈ 0.0045 USD — under half a base cent,
+    // which the old base-cents comparison silently accepted.
+    const paid = paidBase([cash("CUP", 497)], USD_RATES, USD_BASE);
+    expect(isMissing(paid, DUE, USD_RATES, USD_BASE)).toBe(true);
   });
 });
 

--- a/src/__tests__/tipMath.test.ts
+++ b/src/__tests__/tipMath.test.ts
@@ -49,7 +49,7 @@ describe("tipLinesFromChange", () => {
       { tipo: "cash", moneda: "CUP", monto: 150, equivalenteBase: 150 },
       { tipo: "cash", moneda: "USD", monto: 2, equivalenteBase: 700 },
     ]);
-    expect(tipTotalBase(lines)).toBe(850);
+    expect(tipTotalBase(lines, RATES, BASE)).toBe(850);
   });
 
   it("drops currencies with no amount", () => {
@@ -88,7 +88,7 @@ describe("tipLinesFromAmounts", () => {
       { tipo: "cash", moneda: "CUP", monto: 300, equivalenteBase: 300 },
       { tipo: "cash", moneda: "USD", monto: 2, equivalenteBase: 700 },
     ]);
-    expect(tipTotalBase(lines)).toBe(1000);
+    expect(tipTotalBase(lines, RATES, BASE)).toBe(1000);
   });
 
   it("rides the transfer when that currency was only paid by transfer", () => {
@@ -168,6 +168,6 @@ describe("tipTotalFromAmounts", () => {
 
 describe("tipTotalBase", () => {
   it("returns zero for an empty breakdown", () => {
-    expect(tipTotalBase([])).toBe(0);
+    expect(tipTotalBase([], RATES, BASE)).toBe(0);
   });
 });

--- a/src/app/pos/components/checkout/CheckoutView.tsx
+++ b/src/app/pos/components/checkout/CheckoutView.tsx
@@ -42,7 +42,11 @@ import {
   tipTotalFromAmounts,
   type TipAmounts,
 } from "@/app/pos/utils/tipMath";
-import { convertFromBase, convertToBase } from "@/lib/currency";
+import {
+  convertFromBase,
+  convertToBase,
+  roundBaseToAnchorCents,
+} from "@/lib/currency";
 import { DENOMINACIONES } from "@/constants/billDenominations";
 import type { IMultimonedaExtras, IPagoLinea } from "@/schemas/pago";
 import type { ITransferDestination } from "@/schemas/transferDestination";
@@ -108,13 +112,20 @@ export function CheckoutView({
   const [explicitTip, setExplicitTip] = useState<TipAmounts>({});
 
   const tipTotal = tipFromChange
-    ? tipTotalBase(tipFromChange.detail)
+    ? tipTotalBase(tipFromChange.detail, tasasVigentes, monedaBase)
     : tipTotalFromAmounts(explicitTip, tasasVigentes, monedaBase);
 
   // What the customer actually has to cover. Everything downstream — the
   // preloaded line, "falta", the change — is measured against this, never
-  // against finalTotal, which is the business's share alone.
-  const amountDue = Math.round((finalTotal + tipTotal) * 100) / 100;
+  // against finalTotal, which is the business's share alone. Quantized on the
+  // anchor's cents, NOT the base's: with a USD base a base cent is worth
+  // several CUP, and rounding a 500-CUP sale to 0.75 USD would corrupt every
+  // pending/change figure derived from it (503 CUP asked, 168 CUP change).
+  const amountDue = roundBaseToAnchorCents(
+    finalTotal + tipTotal,
+    tasasVigentes,
+    monedaBase,
+  );
 
   const monedasActivas = useMemo(
     () => monedasNegocio.filter((m) => m.activo),
@@ -215,8 +226,11 @@ export function CheckoutView({
   }, [lines]);
 
   const paid = paidBase(lines, tasasVigentes, monedaBase);
-  const missing = amountDue === 0 ? false : isMissing(paid, amountDue);
-  const change = changeBase(paid, amountDue);
+  const missing =
+    amountDue === 0
+      ? false
+      : isMissing(paid, amountDue, tasasVigentes, monedaBase);
+  const change = changeBase(paid, amountDue, tasasVigentes, monedaBase);
 
   /** The payment state a committed tip was captured against. */
   const linesSignature = useMemo(

--- a/src/app/pos/utils/changeMath.ts
+++ b/src/app/pos/utils/changeMath.ts
@@ -1,4 +1,8 @@
-import { convertToBase, convertFromBase } from "@/lib/currency";
+import {
+  convertToBase,
+  convertFromBase,
+  roundBaseToAnchorCents,
+} from "@/lib/currency";
 import { ceilToStep } from "@/app/pos/utils/suggestedAmounts";
 import type { PaymentLine } from "@/app/pos/utils/paymentMath";
 import type { IVueltoLinea } from "@/schemas/pago";
@@ -318,7 +322,13 @@ export function customChangeSplit(
     typedBase += convertToBase(amount, currency, rates, base);
   }
 
-  const remainderBase = round2(changeAmountBase - typedBase);
+  // Anchor-cent grid, not base cents: with a USD base, round2 here would
+  // erase a remainder worth several CUP (0.0037 USD ≈ 2.5 CUP → 0).
+  const remainderBase = roundBaseToAnchorCents(
+    changeAmountBase - typedBase,
+    rates,
+    base,
+  );
   if (remainderBase > EPS) {
     distribution[remainderCurrency] = ceilToStep(
       convertFromBase(remainderBase, remainderCurrency, rates, base),
@@ -329,7 +339,7 @@ export function customChangeSplit(
   return {
     distribution,
     remainderCurrency,
-    overshootBase: remainderBase < -EPS ? round2(-remainderBase) : 0,
+    overshootBase: remainderBase < -EPS ? -remainderBase : 0,
   };
 }
 

--- a/src/app/pos/utils/paymentMath.ts
+++ b/src/app/pos/utils/paymentMath.ts
@@ -1,4 +1,9 @@
-import { convertToBase, convertFromBase } from "@/lib/currency";
+import {
+  convertToBase,
+  convertFromBase,
+  roundBaseToAnchorCents,
+  anchorCents,
+} from "@/lib/currency";
 import type { IPagoLinea } from "@/schemas/pago";
 import type { ITasaSnapshot } from "@/schemas/tasaCambio";
 
@@ -17,26 +22,21 @@ export interface PaymentLine {
   transferDestinationId?: string;
 }
 
-function round2(value: number): number {
-  return Math.round(value * 100) / 100;
-}
-
-/** Compares money in cents so float noise never decides a sale. */
-function cents(value: number): number {
-  return Math.round(value * 100);
-}
-
 export function paidBase(
   lines: PaymentLine[],
   rates: ITasaSnapshot,
   base: string,
 ): number {
-  return round2(
+  // Anchor-cent grid, not base cents: quantizing a coarse base (USD) to its
+  // own cents shifts the sum by several CUP (see roundBaseToAnchorCents).
+  return roundBaseToAnchorCents(
     lines.reduce(
       (sum, line) =>
         sum + convertToBase(line.amount, line.currency, rates, base),
       0,
     ),
+    rates,
+    base,
   );
 }
 
@@ -68,15 +68,32 @@ export function pendingInCurrency(
   );
   const remaining = Math.max(0, finalTotal - covered);
   if (remaining === 0) return 0;
-  return round2(convertFromBase(remaining, currency, rates, base));
+  const raw = convertFromBase(remaining, currency, rates, base);
+  // Ceiled to the target currency's cent, never nearest-rounded: paying the
+  // stated amount must always clear the debt. Rounding 0.7463 USD down to
+  // 0.74 would leave the sale short by real CUP after the customer paid
+  // exactly what was asked. The epsilon keeps float noise (500.0000000006)
+  // from ceiling an exact amount up a cent.
+  return Math.ceil(raw * 100 - 1e-6) / 100;
 }
 
-export function isMissing(paid: number, finalTotal: number): boolean {
-  return cents(paid) < cents(finalTotal);
+/** Compares money in anchor (CUP) cents so float noise never decides a sale. */
+export function isMissing(
+  paid: number,
+  finalTotal: number,
+  rates: ITasaSnapshot,
+  base: string,
+): boolean {
+  return anchorCents(paid, rates, base) < anchorCents(finalTotal, rates, base);
 }
 
-export function changeBase(paid: number, finalTotal: number): number {
-  return Math.max(0, round2(paid - finalTotal));
+export function changeBase(
+  paid: number,
+  finalTotal: number,
+  rates: ITasaSnapshot,
+  base: string,
+): number {
+  return Math.max(0, roundBaseToAnchorCents(paid - finalTotal, rates, base));
 }
 
 export function hasMissingTransferDestination(lines: PaymentLine[]): boolean {

--- a/src/app/pos/utils/tipMath.ts
+++ b/src/app/pos/utils/tipMath.ts
@@ -13,7 +13,7 @@
  * and handed out later.
  */
 
-import { convertToBase } from "@/lib/currency";
+import { convertToBase, roundBaseToAnchorCents } from "@/lib/currency";
 import type { PaymentLine } from "./paymentMath";
 import type { ChangeDistribution } from "./changeMath";
 import type { IPagoLinea } from "@/schemas/pago";
@@ -42,7 +42,13 @@ export function tipLinesFromChange(
       tipo: "cash" as const,
       moneda,
       monto: round2(monto),
-      equivalenteBase: round2(convertToBase(monto, moneda, rates, base)),
+      // Anchor-cent grid: base cents are too coarse when the base is USD
+      // (see roundBaseToAnchorCents) and would shift the tip by real CUP.
+      equivalenteBase: roundBaseToAnchorCents(
+        convertToBase(monto, moneda, rates, base),
+        rates,
+        base,
+      ),
     }));
 }
 
@@ -87,7 +93,11 @@ export function tipLinesFromAmounts(
         tipo: asTransfer ? ("transfer" as const) : ("cash" as const),
         moneda,
         monto: round2(monto),
-        equivalenteBase: round2(convertToBase(monto, moneda, rates, base)),
+        equivalenteBase: roundBaseToAnchorCents(
+          convertToBase(monto, moneda, rates, base),
+          rates,
+          base,
+        ),
         ...(asTransfer && transferLine?.transferDestinationId
           ? { transferDestinationId: transferLine.transferDestinationId }
           : {}),
@@ -101,16 +111,26 @@ export function tipTotalFromAmounts(
   rates: ITasaSnapshot,
   base: string,
 ): number {
-  return round2(
+  return roundBaseToAnchorCents(
     Object.entries(amounts).reduce(
       (sum, [moneda, monto]) =>
         monto > 0 ? sum + convertToBase(monto, moneda, rates, base) : sum,
       0,
     ),
+    rates,
+    base,
   );
 }
 
 /** Total of a tip breakdown in base currency. */
-export function tipTotalBase(tipDetail: IPagoLinea[]): number {
-  return round2(tipDetail.reduce((sum, line) => sum + line.equivalenteBase, 0));
+export function tipTotalBase(
+  tipDetail: IPagoLinea[],
+  rates: ITasaSnapshot,
+  base: string,
+): number {
+  return roundBaseToAnchorCents(
+    tipDetail.reduce((sum, line) => sum + line.equivalenteBase, 0),
+    rates,
+    base,
+  );
 }

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -103,6 +103,38 @@ export function convertFromBase(
 }
 
 /**
+ * Rounds an amount expressed in `monedaBase` to the anchor's (CUP) cent grid.
+ *
+ * Base-currency arithmetic must never be quantized to the base's own cents:
+ * with a coarse base (1 USD = 670 CUP) one base cent is worth 6.7 CUP, so
+ * rounding a 500-CUP sale to 0.75 USD invents 2.5 CUP out of thin air — and
+ * every derived number (pending, change, suggestions) inherits the error.
+ * Quantizing on the anchor keeps full precision for any base: when the base
+ * IS the anchor this is a plain round-to-cents.
+ */
+export function roundBaseToAnchorCents(
+  monto: number,
+  tasas: ITasaSnapshot,
+  monedaBase = "CUP",
+): number {
+  const rate = cupTasa(monedaBase, tasas);
+  if (rate === 0) return monto;
+  return Math.round(monto * rate * 100) / 100 / rate;
+}
+
+/**
+ * A base-currency amount in whole anchor (CUP) cents, for float-safe money
+ * comparisons at the finest granularity the business handles.
+ */
+export function anchorCents(
+  monto: number,
+  tasas: ITasaSnapshot,
+  monedaBase = "CUP",
+): number {
+  return Math.round(monto * cupTasa(monedaBase, tasas) * 100);
+}
+
+/**
  * Calculates change distribution across currencies.
  * All arithmetic routes through CUP anchor.
  */


### PR DESCRIPTION
---

### Description

This pull request improves payment rounding precision when working with coarse base currencies. Key updates include:

- Introduced utilities `roundBaseToAnchorCents` and `anchorCents` to ensure accurate rounding on CUP-cent grids.
- Refined payment, change, and tip calculations to address rounding inaccuracies in cases like USD (e.g., 1 USD = 670 CUP).
- Refactored associated logic across `paymentMath`, `tipMath`, `changeMath`, and `CheckoutView`.
- Expanded test coverage to verify edge cases and prevent regressions in currency conversion.

### Checklist

- [ ] Tests added or updated as necessary  
- [ ] Documentation updated if applicable  
- [ ] Code complies with project guidelines  
- [ ] Changes reviewed by at least one other contributor  

